### PR TITLE
feat: enrich WorkspacePackage with dependency query APIs and root inclusion

### DIFF
--- a/.changeset/dark-eagle-513.md
+++ b/.changeset/dark-eagle-513.md
@@ -1,0 +1,40 @@
+---
+"workspaces-effect": minor
+---
+
+## Features
+
+### WorkspacePackage Enrichment
+
+New schema fields, getters, instance methods, and dual-API static methods for
+dependency querying and package introspection.
+
+**New schema fields:** `peerDependencies`, `optionalDependencies` on
+`WorkspacePackage`.
+
+**New getters:** `isRootWorkspace`, `packageJsonPath`, `isPublic`, `scope`,
+`unscopedName`, `allDependencies`.
+
+**New dual-API methods (instance + static + pipeable):**
+
+- `hasDependency`, `hasDevDependency`, `hasPeerDependency`,
+  `hasOptionalDependency`, `hasAnyDependencyOn` — per-type and cross-type
+  dependency checks
+- `dependencyVersion` — look up version specifier across all dep types
+- `matchesDependency` — minimatch glob pattern matching against dep names
+- `dependencyDiff` — compare two package snapshots, returns added/removed/changed
+- `readPackageJson` — read and parse package.json from disk
+
+### WorkspaceDiscovery.importerMap()
+
+Returns a `ReadonlyMap<string, WorkspacePackage>` keyed by workspace-relative
+directory path, useful for mapping lockfile importer keys to workspace packages.
+
+## Breaking Changes
+
+`listPackages()` now always includes the root workspace package as the first
+entry, identifiable via the `isRootWorkspace` getter. `getPackage()` also
+resolves the root package by name. Consumers that assumed only glob-matched
+packages were returned should filter with `pkg.isRootWorkspace` if needed.
+
+Closes #12.

--- a/.claude/design/architecture.md
+++ b/.claude/design/architecture.md
@@ -5,8 +5,8 @@ category: architecture
 status: current
 completeness: 100
 created: 2026-03-12
-updated: 2026-03-14
-last-synced: 2026-03-14
+updated: 2026-03-25
+last-synced: 2026-03-25
 related:
   - phase2-dependency-graph.md
   - phase3-change-detection.md
@@ -42,7 +42,7 @@ platform layers (Node.js or Bun) at the edge.
 
 ## Current State
 
-All phases complete. 174 tests passing, all typechecking. Full observability
+All phases complete. 206 tests passing, all typechecking. Full observability
 (spans + structured logging) across all services.
 
 - **Phase 1 (Discovery)**: WorkspaceRootLive, PackageManagerDetectorLive,
@@ -51,6 +51,15 @@ All phases complete. 174 tests passing, all typechecking. Full observability
 - **Phase 3 (Change Detection)**: PackageResolverLive, ChangeDetectorLive
 - **Phase 4 (Configuration & Lockfiles)**: LockfileReaderLive,
   PublishabilityDetectorLive, integrity checker, parsers for pnpm/npm/yarn/bun
+- **WorkspacePackage Enrichment** (Issue #12): `peerDependencies` and
+  `optionalDependencies` fields, computed getters (`isRootWorkspace`,
+  `packageJsonPath`, `isPublic`, `scope`, `unscopedName`, `allDependencies`),
+  instance methods (`hasDependency`, `hasDevDependency`, `hasPeerDependency`,
+  `hasOptionalDependency`, `hasAnyDependencyOn`, `dependencyVersion`,
+  `matchesDependency`, `dependencyDiff`), `DependencyDiff` interface, static
+  dual-API functions in `src/utils/workspace-package.ts`, `readPackageJson`
+  utility, `WorkspaceDiscovery.importerMap()`, root package inclusion in
+  `listPackages()` (breaking change)
 - **Composite layers**: WorkspacesLive (no git), WorkspacesFullLive (with git)
 - **Internal patterns**: Request/RequestResolver with per-layer caching for
   DependencyGraph and LockfileReader lookups
@@ -81,7 +90,18 @@ The library provides 9 services organized into four groups:
 | --- | --- | --- |
 | `WorkspaceRoot` | Find monorepo root from cwd | FileSystem, Path |
 | `PackageManagerDetector` | Detect PM type and version | FileSystem, Path |
-| `WorkspaceDiscovery` | List workspace packages | FileSystem, Path, WorkspaceRoot |
+| `WorkspaceDiscovery` | List workspace packages, importer map | FileSystem, Path, WorkspaceRoot |
+
+WorkspaceDiscovery methods:
+
+- `listPackages()` -- returns all workspace packages **including the root
+  workspace package** as the first entry (breaking change from Issue #12).
+  The root package has `relativePath: "."`. Consumers can filter using
+  `isRootWorkspace` getter if they need only non-root packages.
+- `getPackage(name)` -- resolves any package by name (including root).
+- `importerMap()` -- returns `ReadonlyMap<string, WorkspacePackage>` keyed by
+  `relativePath`. Built from `listPackages()` and inherits its caching.
+  Supports lockfile importer-to-package mapping use cases.
 
 ### Group 2: Package Analysis
 
@@ -139,6 +159,81 @@ Key principles:
 - Service methods have `R = never` (dependencies resolved at layer construction)
 - Tag identifiers use `workspaces-effect/ServiceName` namespace
 - `_base` symbols from Context.Tag are correctly inlined by api-extractor DTS bundling
+
+## WorkspacePackage Data Model
+
+`WorkspacePackage` is a `Schema.Class` in `src/schemas/core.ts` representing a
+workspace package with its metadata and dependencies.
+
+### Schema Fields
+
+| Field | Type | Default |
+| --- | --- | --- |
+| `name` | `string` | (required) |
+| `version` | `string` | (required) |
+| `path` | `string` | (required) |
+| `relativePath` | `string` | (required) |
+| `private` | `boolean` | `true` |
+| `dependencies` | `Record<string, string>` | `{}` |
+| `devDependencies` | `Record<string, string>` | `{}` |
+| `peerDependencies` | `Record<string, string>` | `{}` |
+| `optionalDependencies` | `Record<string, string>` | `{}` |
+
+### Computed Getters
+
+| Getter | Returns | Derivation |
+| --- | --- | --- |
+| `isRootWorkspace` | `boolean` | `this.relativePath === "."` |
+| `packageJsonPath` | `string` | `` `${this.path}/package.json` `` |
+| `isPublic` | `boolean` | `!this.private` |
+| `scope` | `Option<string>` | Extract `@scope` from name, or `Option.none()` |
+| `unscopedName` | `string` | Strip `@scope/` prefix if present |
+| `allDependencies` | `Record<string, string>` | Merged map of all 4 dep types |
+
+### Instance Methods
+
+| Method | Signature | Description |
+| --- | --- | --- |
+| `hasDependency` | `(name: string) => boolean` | Checks `dependencies` |
+| `hasDevDependency` | `(name: string) => boolean` | Checks `devDependencies` |
+| `hasPeerDependency` | `(name: string) => boolean` | Checks `peerDependencies` |
+| `hasOptionalDependency` | `(name: string) => boolean` | Checks `optionalDependencies` |
+| `hasAnyDependencyOn` | `(name: string) => boolean` | Checks all 4 dep types |
+| `dependencyVersion` | `(name: string) => Option<string>` | Version across all dep types |
+| `matchesDependency` | `(pattern: string) => boolean` | Glob match on dep names |
+| `dependencyDiff` | `(other: WorkspacePackage) => DependencyDiff` | Compare dep snapshots |
+
+### Static Dual-API Functions
+
+Each instance method also exists as a standalone `Function.dual()` function in
+`src/utils/workspace-package.ts` for pipeable/curried use. These are wired as
+static methods on the `WorkspacePackage` class in `src/index.ts`, following
+the pattern from `semver-effect`:
+
+```typescript
+// Instance
+pkg.hasDependency("effect")
+// Static data-first
+WorkspacePackage.hasDependency(pkg, "effect")
+// Static data-last (pipeable)
+pipe(pkg, WorkspacePackage.hasDependency("effect"))
+```
+
+Additionally, `readPackageJson` is a standalone effectful utility (not dual)
+that reads and decodes a package's `package.json` via `@effect/platform`
+FileSystem. Also wired as a static method.
+
+### DependencyDiff Interface
+
+```typescript
+interface DependencyDiff {
+  readonly added: Record<string, string>
+  readonly removed: Record<string, string>
+  readonly changed: Record<string, { readonly from: string; readonly to: string }>
+}
+```
+
+Compares all 4 dep types combined. Located in `src/schemas/core.ts`.
 
 ## Error Hierarchy
 
@@ -248,3 +343,10 @@ details. Key decisions:
 - **PublishabilityDetector** as separate composable service (not embedded in LockfileReader)
 - **Unified LockfileReader** (merged WorkspaceConfigReader)
 - **GlobResolver** deferred (WorkspaceDiscoveryLive handles workspace patterns)
+- **Static method wiring** in `src/index.ts` following `semver-effect` pattern
+  (avoids circular imports between schema classes and utility functions)
+- **`src/utils/` directory** for standalone dual-API functions that wrap
+  instance methods; keeps `Schema.Class` definitions clean
+- **Root package in listPackages()** (Issue #12 breaking change) -- root
+  workspace always included as first entry; `isRootWorkspace` getter for
+  filtering

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -5,6 +5,8 @@
 	},
 	"enableAllProjectMcpServers": true,
 	"enabledPlugins": {
-		"workflow@savvy-web-claude-tools": true
+		"workflow@savvy-web-claude-tools": true,
+		"changesets@savvy-web-systems": true,
+		"design-docs@spencerbeggs": true
 	}
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,10 +5,16 @@ tooling. Supports npm, pnpm, yarn Berry, and Bun workspaces.
 
 ## Status
 
-All phases complete. 174 tests passing. Full observability (spans + structured
-logging) across all services. Request/RequestResolver with per-layer caching
-for DependencyGraph and LockfileReader lookups. Composite layers:
-WorkspacesLive (no git), WorkspacesFullLive (with git).
+All phases complete plus WorkspacePackage enrichment (Issue #12). 206 tests
+passing. Full observability (spans + structured logging) across all services.
+Request/RequestResolver with per-layer caching for DependencyGraph and
+LockfileReader lookups. Composite layers: WorkspacesLive (no git),
+WorkspacesFullLive (with git). WorkspacePackage has peerDependencies,
+optionalDependencies, computed getters (isRootWorkspace, packageJsonPath,
+isPublic, scope, unscopedName, allDependencies), instance methods + static
+dual-API functions, DependencyDiff, readPackageJson utility.
+WorkspaceDiscovery.importerMap() added. listPackages() now includes root
+workspace (breaking change).
 
 ## Design Documents
 
@@ -37,6 +43,8 @@ Load these when working on the corresponding area:
 - Request/RequestResolver with per-layer `Request.makeCache` for deduplication
 - `Schema.transformOrFail` + `Schema.compose` for parsing pipelines
 - Test fixtures in `src/test-fixtures/` (lockfiles for all 4 PMs)
+- Static dual-API wiring in `src/index.ts` (semver-effect pattern)
+- Standalone utility functions in `src/utils/` directory
 
 ## Commands
 

--- a/README.md
+++ b/README.md
@@ -4,15 +4,22 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![TypeScript](https://img.shields.io/badge/TypeScript-5.9-blue.svg)](https://www.typescriptlang.org/)
 
-An Effect-TS library for monorepo workspace tooling. Discover workspaces, analyze dependency graphs, detect changes, parse lockfiles, and check publishability across npm, pnpm, yarn Berry, and Bun through composable Effect services with typed errors and platform independence.
+An Effect-TS library for monorepo workspace tooling. Discover workspaces,
+analyze dependency graphs, detect changes, parse lockfiles, and check
+publishability across npm, pnpm, yarn Berry, and Bun through composable
+Effect services with typed errors and platform independence.
 
 ## Features
 
-- Workspace discovery across all four major package managers with automatic detection
+- Workspace discovery across all four major package managers with automatic
+  detection
+- Rich package metadata with computed getters, dependency queries, and a
+  dual-API pattern (instance, static data-first, and pipeable)
 - Dependency graph analysis with topological sorting for correct build ordering
 - Git-based change detection to find affected packages from file changes
 - Lockfile parsing for pnpm, npm, yarn, and bun with integrity verification
-- Platform independent -- runs on Node.js or Bun via `@effect/platform` abstractions
+- Platform independent -- runs on Node.js or Bun via `@effect/platform`
+  abstractions
 
 ## Installation
 
@@ -30,14 +37,34 @@ bun add workspaces-effect effect @effect/platform @effect/platform-bun
 ## Quick Start
 
 ```typescript
-import { Effect } from "effect";
+import { Effect, Option, pipe } from "effect";
 import { NodeContext } from "@effect/platform-node";
-import { DependencyGraph, WorkspacesLive } from "workspaces-effect";
+import {
+  WorkspaceDiscovery,
+  WorkspacePackage,
+  WorkspacesLive,
+} from "workspaces-effect";
 
 const program = Effect.gen(function* () {
-  const graph = yield* DependencyGraph;
-  const deps = yield* graph.dependenciesOf("my-package");
-  console.log("Dependencies:", deps);
+  const discovery = yield* WorkspaceDiscovery;
+  const packages = yield* discovery.listPackages();
+
+  for (const pkg of packages) {
+    // Computed getters
+    if (pkg.isRootWorkspace) continue; // skip the root package
+    console.log(pkg.unscopedName, pkg.isPublic ? "(public)" : "(private)");
+
+    // Instance method
+    if (pkg.hasAnyDependencyOn("effect")) {
+      const version = pkg.dependencyVersion("effect");
+      console.log("  effect:", Option.getOrElse(version, () => "n/a"));
+    }
+  }
+
+  // Static data-last (pipeable) style
+  const usesReact = packages.filter(
+    pipe(WorkspacePackage.hasAnyDependencyOn("react")),
+  );
 });
 
 Effect.runPromise(
@@ -50,12 +77,15 @@ Effect.runPromise(
 
 Two composite layers cover most use cases:
 
-- **`WorkspacesLive`** -- all services except git-dependent ones (requires `FileSystem` + `Path`)
-- **`WorkspacesFullLive`** -- all services including change detection (additionally requires `CommandExecutor`)
+- **`WorkspacesLive`** -- all services except git-dependent ones (requires
+  `FileSystem` + `Path`)
+- **`WorkspacesFullLive`** -- all services including change detection
+  (additionally requires `CommandExecutor`)
 
 ## Documentation
 
-For architecture details, API reference, and advanced usage, see [docs](./docs/).
+For architecture details, API reference, and advanced usage, see
+[docs/](./docs/).
 
 ## License
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -18,6 +18,8 @@ Comprehensive documentation for `workspaces-effect`.
 
 ### Guides
 
+- [WorkspacePackage API](./guides/workspace-package.md) -- Getters, dependency
+  queries, dual-API pattern, diffs, and readPackageJson
 - [Dependency Analysis](./guides/dependency-analysis.md) -- Building dependency
   graphs and topological sorting
 - [Change Detection](./guides/change-detection.md) -- Git-based change detection

--- a/docs/architecture/services.md
+++ b/docs/architecture/services.md
@@ -82,10 +82,18 @@ Get a specific workspace package by name.
 
 - Returns: `Effect<WorkspacePackage, PackageNotFoundError | WorkspaceDiscoveryError>`
 
+#### `importerMap()`
+
+Get a map of workspace-relative directory paths to packages. Useful for mapping
+lockfile importer keys to their workspace packages.
+
+- Returns: `Effect<ReadonlyMap<string, WorkspacePackage>, WorkspaceDiscoveryError>`
+
 ```typescript
 const discovery = yield* WorkspaceDiscovery;
 const packages = yield* discovery.listPackages();
 const core = yield* discovery.getPackage("@myorg/core");
+const importers = yield* discovery.importerMap();
 ```
 
 ## DependencyGraph

--- a/docs/guides/dependency-analysis.md
+++ b/docs/guides/dependency-analysis.md
@@ -17,8 +17,7 @@ The `DependencyGraph` service constructs a directed graph at layer creation
 time from all workspace package.json files. Only edges between workspace
 packages are included -- external npm dependencies are excluded.
 
-Edges are derived from `dependencies`, `devDependencies`, and
-`peerDependencies`.
+Edges are derived from `dependencies` and `devDependencies`.
 
 ```typescript
 import { Effect } from "effect";

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -48,6 +48,7 @@ const program = Effect.gen(function* () {
   const packages = yield* discovery.listPackages();
 
   for (const pkg of packages) {
+    if (pkg.isRootWorkspace) continue; // skip root workspace
     console.log(`${pkg.name} @ ${pkg.path}`);
   }
 });
@@ -62,6 +63,10 @@ Effect.runPromise(
 
 Run this from anywhere inside your monorepo. The library automatically finds
 the workspace root by walking up the directory tree.
+
+Note that `listPackages()` includes the root workspace package (with
+`relativePath: "."`) as the first entry. Use the `isRootWorkspace` getter to
+filter it out when you only want child packages.
 
 ## Understanding Layers
 
@@ -127,6 +132,8 @@ Effect.runPromise(
 
 ## Next Steps
 
+- [WorkspacePackage API](./workspace-package.md) -- Getters, dependency queries,
+  dual-API pattern, diffs, and readPackageJson
 - [Dependency Analysis](./dependency-analysis.md) -- Build dependency graphs
   and sort packages
 - [Change Detection](./change-detection.md) -- Find affected packages from git

--- a/docs/guides/publishability.md
+++ b/docs/guides/publishability.md
@@ -32,7 +32,7 @@ const program = Effect.gen(function* () {
   const publishability = yield* PublishabilityDetector;
   const packages = yield* discovery.listPackages();
 
-  for (const pkg of packages) {
+  for (const pkg of packages.filter((p) => !p.isRootWorkspace)) {
     const targets = yield* publishability.detect(pkg, "/path/to/monorepo");
     if (targets.length > 0) {
       console.log(`${pkg.name} publishes to:`);

--- a/docs/guides/workspace-package.md
+++ b/docs/guides/workspace-package.md
@@ -1,0 +1,259 @@
+# WorkspacePackage API
+
+`WorkspacePackage` is the core data model representing a workspace package. It
+provides computed getters for common metadata, dependency query methods, diff
+comparison, and a dual-API pattern for both OOP and functional usage.
+
+## Table of Contents
+
+- [Computed Getters](#computed-getters)
+- [Dependency Query Methods](#dependency-query-methods)
+- [Dual-API Pattern](#dual-api-pattern)
+- [Dependency Diff](#dependency-diff)
+- [Reading package.json](#reading-packagejson)
+- [Importer Map](#importer-map)
+- [Root Package in listPackages](#root-package-in-listpackages)
+
+## Computed Getters
+
+Every `WorkspacePackage` instance exposes these computed properties:
+
+| Getter | Returns | Description |
+| --- | --- | --- |
+| `isRootWorkspace` | `boolean` | `true` when `relativePath === "."` |
+| `packageJsonPath` | `string` | Absolute path to `package.json` |
+| `isPublic` | `boolean` | `true` when `private` is `false` |
+| `scope` | `Option<string>` | The `@scope` portion, or `Option.none()` |
+| `unscopedName` | `string` | Package name without the `@scope/` prefix |
+| `allDependencies` | `Record<string, string>` | Merged map of all 4 dependency types |
+
+```typescript
+import { Option } from "effect";
+import { WorkspaceDiscovery, WorkspacesLive } from "workspaces-effect";
+
+const program = Effect.gen(function* () {
+  const discovery = yield* WorkspaceDiscovery;
+  const pkg = yield* discovery.getPackage("@myorg/utils");
+
+  console.log(pkg.isRootWorkspace);   // false
+  console.log(pkg.packageJsonPath);   // "/workspace/packages/utils/package.json"
+  console.log(pkg.isPublic);          // true
+  console.log(pkg.unscopedName);      // "utils"
+
+  if (Option.isSome(pkg.scope)) {
+    console.log(pkg.scope.value);     // "@myorg"
+  }
+
+  // allDependencies merges dependencies + devDependencies +
+  // peerDependencies + optionalDependencies
+  console.log(Object.keys(pkg.allDependencies));
+});
+```
+
+## Dependency Query Methods
+
+Query whether a package depends on something, across all four dependency types:
+
+```typescript
+const program = Effect.gen(function* () {
+  const discovery = yield* WorkspaceDiscovery;
+  const pkg = yield* discovery.getPackage("@myorg/app");
+
+  // Check specific dependency types
+  pkg.hasDependency("react");          // checks dependencies only
+  pkg.hasDevDependency("vitest");      // checks devDependencies only
+  pkg.hasPeerDependency("effect");     // checks peerDependencies only
+  pkg.hasOptionalDependency("fsevents"); // checks optionalDependencies only
+
+  // Check across ALL dependency types at once
+  pkg.hasAnyDependencyOn("effect");    // true if in any of the 4 maps
+
+  // Get the version string (searches all 4 types)
+  const version = pkg.dependencyVersion("effect");
+  // Option.some("^3.19.0") or Option.none()
+
+  // Glob pattern matching on dependency names
+  pkg.matchesDependency("@myorg/*");   // true if any dep matches the glob
+  pkg.matchesDependency("react*");     // matches react, react-dom, etc.
+});
+```
+
+## Dual-API Pattern
+
+Every instance method is also available as a static dual function on
+`WorkspacePackage`. This supports three calling styles -- instance, static
+data-first, and static data-last (pipeable):
+
+```typescript
+import { pipe } from "effect";
+import { WorkspacePackage } from "workspaces-effect";
+
+// 1. Instance method
+pkg.hasDependency("effect");
+
+// 2. Static data-first
+WorkspacePackage.hasDependency(pkg, "effect");
+
+// 3. Static data-last (pipeable)
+pipe(pkg, WorkspacePackage.hasDependency("effect"));
+```
+
+The pipeable form is useful for filtering and transforming arrays of packages:
+
+```typescript
+const program = Effect.gen(function* () {
+  const discovery = yield* WorkspaceDiscovery;
+  const packages = yield* discovery.listPackages();
+
+  // Filter to packages that use react
+  const reactPackages = packages.filter(
+    WorkspacePackage.hasAnyDependencyOn("react"),
+  );
+
+  // Filter to packages matching a dependency glob
+  const orgPackages = packages.filter(
+    WorkspacePackage.matchesDependency("@myorg/*"),
+  );
+
+  // Get effect version from each package that has it
+  const effectVersions = packages
+    .map((p) => [p.name, WorkspacePackage.dependencyVersion(p, "effect")] as const)
+    .filter(([, v]) => Option.isSome(v));
+});
+```
+
+All dual-API functions:
+
+| Function | Signature |
+| --- | --- |
+| `hasDependency` | `(name) => (pkg) => boolean` or `(pkg, name) => boolean` |
+| `hasDevDependency` | `(name) => (pkg) => boolean` or `(pkg, name) => boolean` |
+| `hasPeerDependency` | `(name) => (pkg) => boolean` or `(pkg, name) => boolean` |
+| `hasOptionalDependency` | `(name) => (pkg) => boolean` or `(pkg, name) => boolean` |
+| `hasAnyDependencyOn` | `(name) => (pkg) => boolean` or `(pkg, name) => boolean` |
+| `dependencyVersion` | `(name) => (pkg) => Option<string>` or `(pkg, name) => Option<string>` |
+| `matchesDependency` | `(pattern) => (pkg) => boolean` or `(pkg, pattern) => boolean` |
+| `dependencyDiff` | `(other) => (pkg) => DependencyDiff` or `(pkg, other) => DependencyDiff` |
+
+## Dependency Diff
+
+Compare the dependency snapshots of two `WorkspacePackage` instances to find
+what was added, removed, or changed. This compares across all four dependency
+types combined:
+
+```typescript
+import { WorkspacePackage } from "workspaces-effect";
+
+const program = Effect.gen(function* () {
+  const discovery = yield* WorkspaceDiscovery;
+
+  // Compare two different packages
+  const app = yield* discovery.getPackage("@myorg/app");
+  const api = yield* discovery.getPackage("@myorg/api");
+
+  const diff = app.dependencyDiff(api);
+
+  // { added: { "react": "^19.0.0" },
+  //   removed: { "express": "^4.18.0" },
+  //   changed: { "effect": { from: "^3.18.0", to: "^3.19.0" } } }
+
+  console.log("Added:", Object.keys(diff.added));
+  console.log("Removed:", Object.keys(diff.removed));
+  for (const [name, { from, to }] of Object.entries(diff.changed)) {
+    console.log(`${name}: ${from} -> ${to}`);
+  }
+});
+```
+
+The `DependencyDiff` interface:
+
+```typescript
+interface DependencyDiff {
+  readonly added: Record<string, string>;    // in self but not other
+  readonly removed: Record<string, string>;  // in other but not self
+  readonly changed: Record<string, { readonly from: string; readonly to: string }>;
+}
+```
+
+The diff also works with the static dual-API:
+
+```typescript
+// Static data-first
+WorkspacePackage.dependencyDiff(app, api);
+
+// Static data-last (pipeable)
+pipe(app, WorkspacePackage.dependencyDiff(api));
+```
+
+## Reading package.json
+
+The `readPackageJson` utility reads and parses a package's `package.json` from
+disk using `@effect/platform` FileSystem. It returns the minimal
+`PackageJsonType` schema fields:
+
+```typescript
+import { WorkspacePackage, readPackageJson } from "workspaces-effect";
+
+const program = Effect.gen(function* () {
+  const discovery = yield* WorkspaceDiscovery;
+  const pkg = yield* discovery.getPackage("@myorg/utils");
+
+  // As a standalone function
+  const json = yield* readPackageJson(pkg);
+  console.log(json.name, json.version, json.workspaces);
+
+  // Or as a static method
+  const json2 = yield* WorkspacePackage.readPackageJson(pkg);
+});
+```
+
+This requires `FileSystem` in the Effect context, which is already provided by
+`NodeContext.layer` or `BunContext.layer`.
+
+## Importer Map
+
+`WorkspaceDiscovery.importerMap()` returns a `ReadonlyMap<string, WorkspacePackage>`
+keyed by `relativePath`. This is useful for mapping lockfile importer keys (which
+use relative paths like `packages/utils`) back to their workspace packages:
+
+```typescript
+const program = Effect.gen(function* () {
+  const discovery = yield* WorkspaceDiscovery;
+  const importers = yield* discovery.importerMap();
+
+  // Look up a package by its relative path
+  const utils = importers.get("packages/utils");
+  if (utils) {
+    console.log(utils.name); // "@myorg/utils"
+  }
+
+  // The root package is keyed by "."
+  const root = importers.get(".");
+  if (root) {
+    console.log("Root:", root.name);
+  }
+});
+```
+
+The importer map is built from `listPackages()` and inherits its caching, so
+repeated calls are free.
+
+## Root Package in listPackages
+
+`WorkspaceDiscovery.listPackages()` includes the root workspace package as the
+first entry in the returned array. The root package has `relativePath: "."`.
+
+Use the `isRootWorkspace` getter to filter it out when you only want child
+packages:
+
+```typescript
+const program = Effect.gen(function* () {
+  const discovery = yield* WorkspaceDiscovery;
+  const all = yield* discovery.listPackages();
+
+  // all[0].isRootWorkspace === true
+
+  // Filter to non-root packages only
+  const childPackages = all.filter((pkg) => !pkg.isRootWorkspace);
+});
+```

--- a/docs/superpowers/plans/2026-03-25-workspace-package-enrichment.md
+++ b/docs/superpowers/plans/2026-03-25-workspace-package-enrichment.md
@@ -1,0 +1,1255 @@
+# WorkspacePackage Enrichment Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Enrich `WorkspacePackage` with dependency query methods, getters, root package inclusion, and `importerMap()` on `WorkspaceDiscovery` to replace `workspace-tools` in `pnpm-config-dependency-action`.
+
+**Architecture:** Add new schema fields (`peerDependencies`, `optionalDependencies`) and getters/methods to `WorkspacePackage` as a `Schema.Class`. Standalone `Function.dual()` functions in `src/utils/workspace-package.ts` provide pipeable APIs, wired as static methods in `src/index.ts`. `WorkspaceDiscoveryLive` is modified to include the root package and implement `importerMap()`.
+
+**Tech Stack:** Effect (`Schema.Class`, `Function.dual`, `Option`), Vitest, minimatch (for glob matching)
+
+**Spec:** `docs/superpowers/specs/2026-03-25-workspace-package-enrichment-design.md`
+
+---
+
+## File Structure
+
+| File | Responsibility |
+| ---- | -------------- |
+| `src/schemas/core.ts` | `WorkspacePackage` schema fields, getters, instance methods; `DependencyDiff` interface; `PackageJsonSchema` update |
+| `src/utils/workspace-package.ts` | **New** — standalone `Function.dual()` functions + `readPackageJson` utility |
+| `src/services/WorkspaceDiscovery.ts` | Add `importerMap()` to service interface |
+| `src/layers/WorkspaceDiscoveryLive.ts` | Root package inclusion, wire new fields, implement `importerMap()` |
+| `src/index.ts` | Export utils, wire static methods, export `DependencyDiff` |
+| `src/schemas/core.test.ts` | **New** — unit tests for `WorkspacePackage` getters and instance methods |
+| `src/utils/workspace-package.test.ts` | **New** — unit tests for standalone dual functions and `readPackageJson` |
+| `src/layers/WorkspaceDiscoveryLive.test.ts` | Update for root inclusion, add `importerMap()` tests |
+
+---
+
+### Task 1: Add `peerDependencies` and `optionalDependencies` to schemas
+
+**Files:**
+
+- Modify: `src/schemas/core.ts:195-261`
+
+- [ ] **Step 1: Add `optionalDependencies` to `PackageJsonSchema`**
+
+In `src/schemas/core.ts`, add after the `peerDependencies` line (line 202):
+
+```typescript
+optionalDependencies: Schema.optional(Schema.Record({ key: Schema.String, value: Schema.String })),
+```
+
+- [ ] **Step 2: Add `peerDependencies` and `optionalDependencies` to `WorkspacePackage`**
+
+In the `WorkspacePackage` class definition, add after the `devDependencies` field (line 259):
+
+```typescript
+peerDependencies: Schema.optionalWith(Schema.Record({ key: Schema.String, value: Schema.String }), {
+    default: () => ({}),
+}),
+optionalDependencies: Schema.optionalWith(Schema.Record({ key: Schema.String, value: Schema.String }), {
+    default: () => ({}),
+}),
+```
+
+- [ ] **Step 3: Run typecheck to verify schema changes compile**
+
+Run: `pnpm run typecheck`
+Expected: PASS (no new type errors from schema additions)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/schemas/core.ts
+git commit -m "feat: add peerDependencies and optionalDependencies to WorkspacePackage schema
+
+Signed-off-by: C. Spencer Beggs <spencer@beggs.codes>"
+```
+
+---
+
+### Task 2: Add getters to `WorkspacePackage`
+
+**Files:**
+
+- Modify: `src/schemas/core.ts:248-261`
+- Create: `src/schemas/core.test.ts`
+
+- [ ] **Step 1: Write failing tests for getters**
+
+Create `src/schemas/core.test.ts`:
+
+```typescript
+import { Option } from "effect";
+import { describe, expect, it } from "vitest";
+import { WorkspacePackage } from "./core.js";
+
+const rootPkg = new WorkspacePackage({
+    name: "my-monorepo",
+    version: "1.0.0",
+    path: "/workspace",
+    relativePath: ".",
+});
+
+const scopedPkg = new WorkspacePackage({
+    name: "@scope/utils",
+    version: "2.0.0",
+    path: "/workspace/packages/utils",
+    relativePath: "packages/utils",
+    private: false,
+    dependencies: { effect: "^3.0.0" },
+    devDependencies: { vitest: "^3.0.0" },
+    peerDependencies: { react: "^18.0.0" },
+    optionalDependencies: { fsevents: "^2.3.0" },
+});
+
+const unscopedPkg = new WorkspacePackage({
+    name: "my-lib",
+    version: "1.0.0",
+    path: "/workspace/packages/my-lib",
+    relativePath: "packages/my-lib",
+    private: true,
+});
+
+describe("WorkspacePackage getters", () => {
+    it("isRootWorkspace returns true for root", () => {
+        expect(rootPkg.isRootWorkspace).toBe(true);
+        expect(scopedPkg.isRootWorkspace).toBe(false);
+    });
+
+    it("packageJsonPath appends package.json", () => {
+        expect(rootPkg.packageJsonPath).toBe("/workspace/package.json");
+        expect(scopedPkg.packageJsonPath).toBe("/workspace/packages/utils/package.json");
+    });
+
+    it("isPublic is inverse of private", () => {
+        expect(scopedPkg.isPublic).toBe(true);
+        expect(unscopedPkg.isPublic).toBe(false);
+    });
+
+    it("scope extracts @scope from scoped name", () => {
+        expect(scopedPkg.scope).toEqual(Option.some("@scope"));
+        expect(unscopedPkg.scope).toEqual(Option.none());
+    });
+
+    it("unscopedName strips scope prefix", () => {
+        expect(scopedPkg.unscopedName).toBe("utils");
+        expect(unscopedPkg.unscopedName).toBe("my-lib");
+    });
+
+    it("allDependencies merges all 4 dep types", () => {
+        expect(scopedPkg.allDependencies).toEqual({
+            effect: "^3.0.0",
+            vitest: "^3.0.0",
+            react: "^18.0.0",
+            fsevents: "^2.3.0",
+        });
+    });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm vitest run src/schemas/core.test.ts`
+Expected: FAIL (getters not defined)
+
+- [ ] **Step 3: Implement getters on `WorkspacePackage`**
+
+Add inside the `WorkspacePackage` class body (after the closing `})` of the schema fields, before the final `{}`:
+
+```typescript
+export class WorkspacePackage extends Schema.Class<WorkspacePackage>("WorkspacePackage")({
+    // ... existing fields ...
+}) {
+    get isRootWorkspace(): boolean {
+        return this.relativePath === ".";
+    }
+
+    get packageJsonPath(): string {
+        return `${this.path}/package.json`;
+    }
+
+    get isPublic(): boolean {
+        return !this.private;
+    }
+
+    get scope(): Option.Option<string> {
+        const match = this.name.match(/^(@[^/]+)\//);
+        return match ? Option.some(match[1]) : Option.none();
+    }
+
+    get unscopedName(): string {
+        const slashIndex = this.name.indexOf("/");
+        return this.name.startsWith("@") && slashIndex !== -1
+            ? this.name.slice(slashIndex + 1)
+            : this.name;
+    }
+
+    get allDependencies(): Record<string, string> {
+        return {
+            ...this.dependencies,
+            ...this.devDependencies,
+            ...this.peerDependencies,
+            ...this.optionalDependencies,
+        };
+    }
+}
+```
+
+Add `import { Option } from "effect";` at the top of `core.ts` (extend the existing `import { Schema } from "effect";`).
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm vitest run src/schemas/core.test.ts`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/schemas/core.ts src/schemas/core.test.ts
+git commit -m "feat: add getters to WorkspacePackage (isRootWorkspace, packageJsonPath, scope, etc.)
+
+Signed-off-by: C. Spencer Beggs <spencer@beggs.codes>"
+```
+
+---
+
+### Task 3: Add instance methods to `WorkspacePackage`
+
+**Files:**
+
+- Modify: `src/schemas/core.ts`
+- Modify: `src/schemas/core.test.ts`
+
+- [ ] **Step 1: Write failing tests for instance methods**
+
+Append to `src/schemas/core.test.ts`:
+
+```typescript
+describe("WorkspacePackage instance methods", () => {
+    it("hasDependency checks dependencies only", () => {
+        expect(scopedPkg.hasDependency("effect")).toBe(true);
+        expect(scopedPkg.hasDependency("vitest")).toBe(false);
+    });
+
+    it("hasDevDependency checks devDependencies only", () => {
+        expect(scopedPkg.hasDevDependency("vitest")).toBe(true);
+        expect(scopedPkg.hasDevDependency("effect")).toBe(false);
+    });
+
+    it("hasPeerDependency checks peerDependencies only", () => {
+        expect(scopedPkg.hasPeerDependency("react")).toBe(true);
+        expect(scopedPkg.hasPeerDependency("effect")).toBe(false);
+    });
+
+    it("hasOptionalDependency checks optionalDependencies only", () => {
+        expect(scopedPkg.hasOptionalDependency("fsevents")).toBe(true);
+        expect(scopedPkg.hasOptionalDependency("effect")).toBe(false);
+    });
+
+    it("hasAnyDependencyOn checks all 4 dep types", () => {
+        expect(scopedPkg.hasAnyDependencyOn("effect")).toBe(true);
+        expect(scopedPkg.hasAnyDependencyOn("vitest")).toBe(true);
+        expect(scopedPkg.hasAnyDependencyOn("react")).toBe(true);
+        expect(scopedPkg.hasAnyDependencyOn("fsevents")).toBe(true);
+        expect(scopedPkg.hasAnyDependencyOn("nonexistent")).toBe(false);
+    });
+
+    it("dependencyVersion returns version from any dep type", () => {
+        expect(scopedPkg.dependencyVersion("effect")).toEqual(Option.some("^3.0.0"));
+        expect(scopedPkg.dependencyVersion("react")).toEqual(Option.some("^18.0.0"));
+        expect(scopedPkg.dependencyVersion("nonexistent")).toEqual(Option.none());
+    });
+
+    it("matchesDependency matches glob patterns against dep names", () => {
+        expect(scopedPkg.matchesDependency("effect")).toBe(true);
+        expect(scopedPkg.matchesDependency("*test*")).toBe(true);  // matches "vitest"
+        expect(scopedPkg.matchesDependency("@scope/*")).toBe(false);
+    });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm vitest run src/schemas/core.test.ts`
+Expected: FAIL (methods not defined)
+
+- [ ] **Step 3: Install minimatch**
+
+Run: `pnpm add minimatch`
+
+Check if `@types/minimatch` is needed or if minimatch ships its own types.
+
+- [ ] **Step 4: Implement instance methods on `WorkspacePackage`**
+
+Add inside the `WorkspacePackage` class body, after the getters:
+
+```typescript
+hasDependency(name: string): boolean {
+    return name in this.dependencies;
+}
+
+hasDevDependency(name: string): boolean {
+    return name in this.devDependencies;
+}
+
+hasPeerDependency(name: string): boolean {
+    return name in this.peerDependencies;
+}
+
+hasOptionalDependency(name: string): boolean {
+    return name in this.optionalDependencies;
+}
+
+hasAnyDependencyOn(name: string): boolean {
+    return this.hasDependency(name)
+        || this.hasDevDependency(name)
+        || this.hasPeerDependency(name)
+        || this.hasOptionalDependency(name);
+}
+
+dependencyVersion(name: string): Option.Option<string> {
+    const version = this.dependencies[name]
+        ?? this.devDependencies[name]
+        ?? this.peerDependencies[name]
+        ?? this.optionalDependencies[name];
+    return version !== undefined ? Option.some(version) : Option.none();
+}
+
+matchesDependency(pattern: string): boolean {
+    return Object.keys(this.allDependencies).some((name) => minimatch(name, pattern));
+}
+```
+
+Add `import { minimatch } from "minimatch";` at the top of `core.ts`.
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `pnpm vitest run src/schemas/core.test.ts`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/schemas/core.ts src/schemas/core.test.ts package.json pnpm-lock.yaml
+git commit -m "feat: add dependency query instance methods to WorkspacePackage
+
+Signed-off-by: C. Spencer Beggs <spencer@beggs.codes>"
+```
+
+---
+
+### Task 4: Add `DependencyDiff` and `dependencyDiff` method
+
+**Files:**
+
+- Modify: `src/schemas/core.ts`
+- Modify: `src/schemas/core.test.ts`
+
+- [ ] **Step 1: Write failing tests for dependencyDiff**
+
+Append to `src/schemas/core.test.ts`:
+
+```typescript
+describe("WorkspacePackage.dependencyDiff", () => {
+    it("detects added dependencies", () => {
+        const before = new WorkspacePackage({
+            name: "pkg",
+            version: "1.0.0",
+            path: "/workspace/pkg",
+            relativePath: "pkg",
+            dependencies: { a: "1.0.0" },
+        });
+        const after = new WorkspacePackage({
+            name: "pkg",
+            version: "1.0.0",
+            path: "/workspace/pkg",
+            relativePath: "pkg",
+            dependencies: { a: "1.0.0", b: "2.0.0" },
+        });
+        const diff = after.dependencyDiff(before);
+        expect(diff.added).toEqual({ b: "2.0.0" });
+        expect(diff.removed).toEqual({});
+        expect(diff.changed).toEqual({});
+    });
+
+    it("detects removed dependencies", () => {
+        const before = new WorkspacePackage({
+            name: "pkg",
+            version: "1.0.0",
+            path: "/workspace/pkg",
+            relativePath: "pkg",
+            dependencies: { a: "1.0.0", b: "2.0.0" },
+        });
+        const after = new WorkspacePackage({
+            name: "pkg",
+            version: "1.0.0",
+            path: "/workspace/pkg",
+            relativePath: "pkg",
+            dependencies: { a: "1.0.0" },
+        });
+        const diff = after.dependencyDiff(before);
+        expect(diff.added).toEqual({});
+        expect(diff.removed).toEqual({ b: "2.0.0" });
+        expect(diff.changed).toEqual({});
+    });
+
+    it("detects changed versions", () => {
+        const before = new WorkspacePackage({
+            name: "pkg",
+            version: "1.0.0",
+            path: "/workspace/pkg",
+            relativePath: "pkg",
+            dependencies: { a: "1.0.0" },
+        });
+        const after = new WorkspacePackage({
+            name: "pkg",
+            version: "1.0.0",
+            path: "/workspace/pkg",
+            relativePath: "pkg",
+            dependencies: { a: "2.0.0" },
+        });
+        const diff = after.dependencyDiff(before);
+        expect(diff.added).toEqual({});
+        expect(diff.removed).toEqual({});
+        expect(diff.changed).toEqual({ a: { from: "1.0.0", to: "2.0.0" } });
+    });
+
+    it("compares across all dep types", () => {
+        const before = new WorkspacePackage({
+            name: "pkg",
+            version: "1.0.0",
+            path: "/workspace/pkg",
+            relativePath: "pkg",
+            peerDependencies: { react: "^17.0.0" },
+        });
+        const after = new WorkspacePackage({
+            name: "pkg",
+            version: "1.0.0",
+            path: "/workspace/pkg",
+            relativePath: "pkg",
+            peerDependencies: { react: "^18.0.0" },
+        });
+        const diff = after.dependencyDiff(before);
+        expect(diff.changed).toEqual({ react: { from: "^17.0.0", to: "^18.0.0" } });
+    });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm vitest run src/schemas/core.test.ts`
+Expected: FAIL (dependencyDiff not defined)
+
+- [ ] **Step 3: Implement `DependencyDiff` interface and `dependencyDiff` method**
+
+Add the `DependencyDiff` interface in `src/schemas/core.ts` before the `WorkspacePackage` class:
+
+```typescript
+/**
+ * Result of comparing two WorkspacePackage dependency snapshots.
+ *
+ * @public
+ */
+export interface DependencyDiff {
+    readonly added: Record<string, string>;
+    readonly removed: Record<string, string>;
+    readonly changed: Record<string, { readonly from: string; readonly to: string }>;
+}
+```
+
+Add the instance method to `WorkspacePackage`:
+
+```typescript
+dependencyDiff(other: WorkspacePackage): DependencyDiff {
+    const selfDeps = this.allDependencies;
+    const otherDeps = other.allDependencies;
+    const added: Record<string, string> = {};
+    const removed: Record<string, string> = {};
+    const changed: Record<string, { from: string; to: string }> = {};
+
+    for (const [name, version] of Object.entries(selfDeps)) {
+        if (!(name in otherDeps)) {
+            added[name] = version;
+        } else if (otherDeps[name] !== version) {
+            changed[name] = { from: otherDeps[name], to: version };
+        }
+    }
+    for (const [name, version] of Object.entries(otherDeps)) {
+        if (!(name in selfDeps)) {
+            removed[name] = version;
+        }
+    }
+
+    return { added, removed, changed };
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm vitest run src/schemas/core.test.ts`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/schemas/core.ts src/schemas/core.test.ts
+git commit -m "feat: add DependencyDiff and dependencyDiff method to WorkspacePackage
+
+Signed-off-by: C. Spencer Beggs <spencer@beggs.codes>"
+```
+
+---
+
+### Task 5: Create standalone `Function.dual()` functions
+
+**Files:**
+
+- Create: `src/utils/workspace-package.ts`
+- Create: `src/utils/workspace-package.test.ts`
+
+- [ ] **Step 1: Write failing tests for standalone dual functions**
+
+Create `src/utils/workspace-package.test.ts`:
+
+```typescript
+import { FileSystem, Path } from "@effect/platform";
+import { Effect, Option, pipe } from "effect";
+import { describe, expect, it } from "vitest";
+import { WorkspacePackage } from "../schemas/core.js";
+import {
+    dependencyDiff,
+    dependencyVersion,
+    hasAnyDependencyOn,
+    hasDependency,
+    hasDevDependency,
+    hasOptionalDependency,
+    hasPeerDependency,
+    matchesDependency,
+    readPackageJson,
+} from "./workspace-package.js";
+
+const pkg = new WorkspacePackage({
+    name: "@scope/utils",
+    version: "1.0.0",
+    path: "/workspace/packages/utils",
+    relativePath: "packages/utils",
+    dependencies: { effect: "^3.0.0" },
+    devDependencies: { vitest: "^3.0.0" },
+    peerDependencies: { react: "^18.0.0" },
+    optionalDependencies: { fsevents: "^2.3.0" },
+});
+
+describe("standalone dual functions", () => {
+    describe("data-first calling style", () => {
+        it("hasDependency", () => {
+            expect(hasDependency(pkg, "effect")).toBe(true);
+            expect(hasDependency(pkg, "vitest")).toBe(false);
+        });
+
+        it("hasDevDependency", () => {
+            expect(hasDevDependency(pkg, "vitest")).toBe(true);
+        });
+
+        it("hasPeerDependency", () => {
+            expect(hasPeerDependency(pkg, "react")).toBe(true);
+        });
+
+        it("hasOptionalDependency", () => {
+            expect(hasOptionalDependency(pkg, "fsevents")).toBe(true);
+        });
+
+        it("hasAnyDependencyOn", () => {
+            expect(hasAnyDependencyOn(pkg, "effect")).toBe(true);
+            expect(hasAnyDependencyOn(pkg, "nonexistent")).toBe(false);
+        });
+
+        it("dependencyVersion", () => {
+            expect(dependencyVersion(pkg, "effect")).toEqual(Option.some("^3.0.0"));
+            expect(dependencyVersion(pkg, "nonexistent")).toEqual(Option.none());
+        });
+
+        it("matchesDependency", () => {
+            expect(matchesDependency(pkg, "*test*")).toBe(true);
+        });
+    });
+
+    describe("data-last (pipeable) calling style", () => {
+        it("hasDependency", () => {
+            expect(pipe(pkg, hasDependency("effect"))).toBe(true);
+        });
+
+        it("dependencyVersion", () => {
+            expect(pipe(pkg, dependencyVersion("effect"))).toEqual(Option.some("^3.0.0"));
+        });
+
+        it("matchesDependency", () => {
+            expect(pipe(pkg, matchesDependency("*test*"))).toBe(true);
+        });
+    });
+
+    describe("dependencyDiff standalone", () => {
+        it("data-first", () => {
+            const before = new WorkspacePackage({
+                name: "pkg",
+                version: "1.0.0",
+                path: "/workspace/pkg",
+                relativePath: "pkg",
+                dependencies: { a: "1.0.0" },
+            });
+            const after = new WorkspacePackage({
+                name: "pkg",
+                version: "1.0.0",
+                path: "/workspace/pkg",
+                relativePath: "pkg",
+                dependencies: { a: "2.0.0", b: "1.0.0" },
+            });
+            const diff = dependencyDiff(after, before);
+            expect(diff.added).toEqual({ b: "1.0.0" });
+            expect(diff.changed).toEqual({ a: { from: "1.0.0", to: "2.0.0" } });
+        });
+
+        it("data-last (pipeable)", () => {
+            const before = new WorkspacePackage({
+                name: "pkg",
+                version: "1.0.0",
+                path: "/workspace/pkg",
+                relativePath: "pkg",
+                dependencies: { a: "1.0.0" },
+            });
+            const after = new WorkspacePackage({
+                name: "pkg",
+                version: "1.0.0",
+                path: "/workspace/pkg",
+                relativePath: "pkg",
+                dependencies: { b: "1.0.0" },
+            });
+            const diff = pipe(after, dependencyDiff(before));
+            expect(diff.added).toEqual({ b: "1.0.0" });
+            expect(diff.removed).toEqual({ a: "1.0.0" });
+        });
+    });
+});
+
+describe("readPackageJson", () => {
+    it("reads and parses a package.json from the filesystem", async () => {
+        const testPkg = new WorkspacePackage({
+            name: "test-pkg",
+            version: "1.0.0",
+            path: "/workspace/packages/test",
+            relativePath: "packages/test",
+        });
+
+        const mockFsLayer = FileSystem.layerNoop({
+            readFileString: (path) => {
+                if (path === "/workspace/packages/test/package.json") {
+                    return Effect.succeed(
+                        JSON.stringify({
+                            name: "test-pkg",
+                            version: "1.0.0",
+                            dependencies: { effect: "^3.0.0" },
+                        }),
+                    );
+                }
+                return Effect.die(new Error(`ENOENT: ${path}`));
+            },
+        });
+
+        const result = await Effect.runPromise(
+            readPackageJson(testPkg).pipe(Effect.provide(mockFsLayer)),
+        );
+
+        expect(result.name).toBe("test-pkg");
+        expect(result.dependencies).toEqual({ effect: "^3.0.0" });
+    });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm vitest run src/utils/workspace-package.test.ts`
+Expected: FAIL (module does not exist)
+
+- [ ] **Step 3: Implement standalone dual functions**
+
+Create `src/utils/workspace-package.ts`:
+
+```typescript
+/**
+ * Standalone dual-API functions for WorkspacePackage.
+ *
+ * Each function supports both data-first and data-last (pipeable) calling styles
+ * via `Function.dual()`.
+ *
+ * @packageDocumentation
+ */
+
+import { FileSystem } from "@effect/platform";
+import { Effect, Function as Fn, Option, Schema } from "effect";
+import { minimatch } from "minimatch";
+import { PackageJsonParseError } from "../errors/PackageJsonParseError.js";
+import { type DependencyDiff, PackageJsonSchema, WorkspacePackage } from "../schemas/core.js";
+
+/** Check if a package has a production dependency. Dual API. */
+export const hasDependency: {
+    (name: string): (self: WorkspacePackage) => boolean;
+    (self: WorkspacePackage, name: string): boolean;
+} = Fn.dual(2, (self: WorkspacePackage, name: string): boolean => self.hasDependency(name));
+
+/** Check if a package has a dev dependency. Dual API. */
+export const hasDevDependency: {
+    (name: string): (self: WorkspacePackage) => boolean;
+    (self: WorkspacePackage, name: string): boolean;
+} = Fn.dual(2, (self: WorkspacePackage, name: string): boolean => self.hasDevDependency(name));
+
+/** Check if a package has a peer dependency. Dual API. */
+export const hasPeerDependency: {
+    (name: string): (self: WorkspacePackage) => boolean;
+    (self: WorkspacePackage, name: string): boolean;
+} = Fn.dual(2, (self: WorkspacePackage, name: string): boolean => self.hasPeerDependency(name));
+
+/** Check if a package has an optional dependency. Dual API. */
+export const hasOptionalDependency: {
+    (name: string): (self: WorkspacePackage) => boolean;
+    (self: WorkspacePackage, name: string): boolean;
+} = Fn.dual(2, (self: WorkspacePackage, name: string): boolean => self.hasOptionalDependency(name));
+
+/** Check if a package depends on a name in any dep type. Dual API. */
+export const hasAnyDependencyOn: {
+    (name: string): (self: WorkspacePackage) => boolean;
+    (self: WorkspacePackage, name: string): boolean;
+} = Fn.dual(2, (self: WorkspacePackage, name: string): boolean => self.hasAnyDependencyOn(name));
+
+/** Look up version across all dep types. Dual API. */
+export const dependencyVersion: {
+    (name: string): (self: WorkspacePackage) => Option.Option<string>;
+    (self: WorkspacePackage, name: string): Option.Option<string>;
+} = Fn.dual(2, (self: WorkspacePackage, name: string): Option.Option<string> => self.dependencyVersion(name));
+
+/** Check if any dep name matches a glob pattern. Dual API. */
+export const matchesDependency: {
+    (pattern: string): (self: WorkspacePackage) => boolean;
+    (self: WorkspacePackage, pattern: string): boolean;
+} = Fn.dual(2, (self: WorkspacePackage, pattern: string): boolean => self.matchesDependency(pattern));
+
+/** Compare two WorkspacePackage dependency snapshots. Dual API. */
+export const dependencyDiff: {
+    (other: WorkspacePackage): (self: WorkspacePackage) => DependencyDiff;
+    (self: WorkspacePackage, other: WorkspacePackage): DependencyDiff;
+} = Fn.dual(2, (self: WorkspacePackage, other: WorkspacePackage): DependencyDiff => self.dependencyDiff(other));
+
+/**
+ * Read and parse a package's package.json from disk.
+ *
+ * Returns the minimal `PackageJsonType` schema fields. For full raw
+ * package.json access, read `pkg.packageJsonPath` directly.
+ *
+ * Not a dual function — takes a single `WorkspacePackage` argument.
+ * Pipeable via `pipe(pkg, readPackageJson)`.
+ */
+export const readPackageJson = (
+    self: WorkspacePackage,
+): Effect.Effect<Schema.Schema.Type<typeof PackageJsonSchema>, PackageJsonParseError, FileSystem.FileSystem> =>
+    Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const content = yield* fs.readFileString(self.packageJsonPath).pipe(
+            Effect.mapError(
+                () => new PackageJsonParseError({ filePath: self.packageJsonPath, cause: "failed to read file" }),
+            ),
+        );
+        const raw = yield* Effect.try({
+            try: () => JSON.parse(content) as Record<string, unknown>,
+            catch: () =>
+                new PackageJsonParseError({ filePath: self.packageJsonPath, cause: "invalid JSON" }),
+        });
+        return yield* Schema.decodeUnknown(PackageJsonSchema)(raw).pipe(
+            Effect.mapError(
+                () => new PackageJsonParseError({ filePath: self.packageJsonPath, cause: "schema decode failed" }),
+            ),
+        );
+    });
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm vitest run src/utils/workspace-package.test.ts`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/utils/workspace-package.ts src/utils/workspace-package.test.ts
+git commit -m "feat: add standalone dual-API functions for WorkspacePackage
+
+Signed-off-by: C. Spencer Beggs <spencer@beggs.codes>"
+```
+
+---
+
+### Task 6: Wire static methods and update exports in `src/index.ts`
+
+**Files:**
+
+- Modify: `src/index.ts`
+
+- [ ] **Step 1: Add exports for new utils and DependencyDiff**
+
+Add to the Schemas section of `src/index.ts`:
+
+```typescript
+export type { DependencyDiff } from "./schemas/core.js";
+```
+
+Add a new Utils section:
+
+```typescript
+// ── Utils ────────────────────────────────────────────────────────────
+export {
+    dependencyDiff,
+    dependencyVersion,
+    hasAnyDependencyOn,
+    hasDependency,
+    hasDevDependency,
+    hasOptionalDependency,
+    hasPeerDependency,
+    matchesDependency,
+    readPackageJson,
+} from "./utils/workspace-package.js";
+```
+
+- [ ] **Step 2: Wire static methods at module load**
+
+Add at the bottom of `src/index.ts`, following the semver-effect pattern:
+
+```typescript
+// ── Wire cross-cutting static methods (avoids circular imports) ─────────
+
+import { WorkspacePackage as _WP } from "./schemas/core.js";
+import {
+    dependencyDiff as _dependencyDiff,
+    dependencyVersion as _dependencyVersion,
+    hasAnyDependencyOn as _hasAnyDependencyOn,
+    hasDependency as _hasDependency,
+    hasDevDependency as _hasDevDependency,
+    hasOptionalDependency as _hasOptionalDependency,
+    hasPeerDependency as _hasPeerDependency,
+    matchesDependency as _matchesDependency,
+    readPackageJson as _readPackageJson,
+} from "./utils/workspace-package.js";
+
+// WorkspacePackage statics
+_WP.hasDependency = _hasDependency;
+_WP.hasDevDependency = _hasDevDependency;
+_WP.hasPeerDependency = _hasPeerDependency;
+_WP.hasOptionalDependency = _hasOptionalDependency;
+_WP.hasAnyDependencyOn = _hasAnyDependencyOn;
+_WP.dependencyVersion = _dependencyVersion;
+_WP.matchesDependency = _matchesDependency;
+_WP.dependencyDiff = _dependencyDiff;
+_WP.readPackageJson = _readPackageJson;
+```
+
+- [ ] **Step 3: Add static method type declarations to `WorkspacePackage` class**
+
+In `src/schemas/core.ts`, add static declarations inside the `WorkspacePackage` class body (similar to how `SemVer` declares them in `src/schemas/SemVer.ts:46-62` of semver-effect):
+
+```typescript
+// ── Cross-cutting statics (wired in index.ts) ───────────────────────
+// Use `declare` to avoid "not definitely assigned" errors —
+// these are assigned at module load time in src/index.ts.
+static declare hasDependency: {
+    (name: string): (self: WorkspacePackage) => boolean;
+    (self: WorkspacePackage, name: string): boolean;
+};
+static declare hasDevDependency: {
+    (name: string): (self: WorkspacePackage) => boolean;
+    (self: WorkspacePackage, name: string): boolean;
+};
+static declare hasPeerDependency: {
+    (name: string): (self: WorkspacePackage) => boolean;
+    (self: WorkspacePackage, name: string): boolean;
+};
+static declare hasOptionalDependency: {
+    (name: string): (self: WorkspacePackage) => boolean;
+    (self: WorkspacePackage, name: string): boolean;
+};
+static declare hasAnyDependencyOn: {
+    (name: string): (self: WorkspacePackage) => boolean;
+    (self: WorkspacePackage, name: string): boolean;
+};
+static declare dependencyVersion: {
+    (name: string): (self: WorkspacePackage) => Option.Option<string>;
+    (self: WorkspacePackage, name: string): Option.Option<string>;
+};
+static declare matchesDependency: {
+    (pattern: string): (self: WorkspacePackage) => boolean;
+    (self: WorkspacePackage, pattern: string): boolean;
+};
+static declare dependencyDiff: {
+    (other: WorkspacePackage): (self: WorkspacePackage) => DependencyDiff;
+    (self: WorkspacePackage, other: WorkspacePackage): DependencyDiff;
+};
+static declare readPackageJson: (
+    self: WorkspacePackage,
+) => Effect.Effect<PackageJsonType, PackageJsonParseError, FileSystem.FileSystem>;
+```
+
+This requires adding imports for `Effect` and `FileSystem` types at the top of `core.ts`:
+
+```typescript
+import type { FileSystem } from "@effect/platform";
+import type { Effect } from "effect";
+import type { PackageJsonParseError } from "../errors/PackageJsonParseError.js";
+```
+
+- [ ] **Step 4: Run typecheck**
+
+Run: `pnpm run typecheck`
+Expected: PASS
+
+- [ ] **Step 5: Run all tests to verify nothing is broken**
+
+Run: `pnpm run test`
+Expected: All tests PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/index.ts src/schemas/core.ts
+git commit -m "feat: wire WorkspacePackage static methods and export utils
+
+Signed-off-by: C. Spencer Beggs <spencer@beggs.codes>"
+```
+
+---
+
+### Task 7: Include root package in `listPackages()` and wire new fields
+
+**Files:**
+
+- Modify: `src/layers/WorkspaceDiscoveryLive.ts:208-267,336-352`
+- Modify: `src/layers/WorkspaceDiscoveryLive.test.ts`
+
+- [ ] **Step 1: Write failing test for root package inclusion**
+
+Add to `src/layers/WorkspaceDiscoveryLive.test.ts`, inside the `describe("listPackages")` block:
+
+```typescript
+it("includes root workspace package as first entry", async () => {
+    const root = "/projects/monorepo";
+    const layer = testLayer(
+        root,
+        {
+            [`${root}/pnpm-workspace.yaml`]: "packages:\n  - 'packages/*'",
+            [`${root}/package.json`]: JSON.stringify({
+                name: "my-monorepo",
+                version: "0.0.0",
+                private: true,
+                dependencies: { typescript: "^5.0.0" },
+            }),
+            [`${root}/packages/pkg-a/package.json`]: JSON.stringify({
+                name: "@scope/pkg-a",
+                version: "1.0.0",
+            }),
+        },
+        {
+            [`${root}/packages`]: ["pkg-a"],
+        },
+    );
+
+    const result = await Effect.runPromise(
+        Effect.gen(function* () {
+            const discovery = yield* WorkspaceDiscovery;
+            return yield* discovery.listPackages();
+        }).pipe(Effect.provide(layer)),
+    );
+
+    expect(result).toHaveLength(2);
+    // Root is first
+    expect(result[0].name).toBe("my-monorepo");
+    expect(result[0].relativePath).toBe(".");
+    expect(result[0].path).toBe(root);
+    expect(result[0].isRootWorkspace).toBe(true);
+    expect(result[0].dependencies).toEqual({ typescript: "^5.0.0" });
+    // Workspace package follows
+    expect(result[1].name).toBe("@scope/pkg-a");
+    expect(result[1].isRootWorkspace).toBe(false);
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm vitest run src/layers/WorkspaceDiscoveryLive.test.ts`
+Expected: FAIL (root package not included, length is 1)
+
+- [ ] **Step 3: Wire `peerDependencies` and `optionalDependencies` in `readWorkspacePackage`**
+
+In `src/layers/WorkspaceDiscoveryLive.ts`, update the `WorkspacePackage` constructor call in `readWorkspacePackage` (around line 257-266):
+
+```typescript
+return new WorkspacePackage({
+    name,
+    version: decoded.version ?? "0.0.0",
+    path: pkgDir,
+    relativePath,
+    private: decoded.private ?? false,
+    dependencies: (decoded.dependencies as Record<string, string>) ?? {},
+    devDependencies: (decoded.devDependencies as Record<string, string>) ?? {},
+    peerDependencies: (decoded.peerDependencies as Record<string, string>) ?? {},
+    optionalDependencies: (decoded.optionalDependencies as Record<string, string>) ?? {},
+    publishConfig: decoded.publishConfig,
+});
+```
+
+- [ ] **Step 4: Add root package to `discoverPackages`**
+
+In the `discoverPackages` function (around line 336-352), add root package construction before returning:
+
+```typescript
+const discoverPackages = (): Effect.Effect<ReadonlyArray<WorkspacePackage>, WorkspaceDiscoveryError> =>
+    Effect.gen(function* () {
+        if (cachedPackages) return cachedPackages;
+
+        const patterns = yield* readWorkspacePatterns(fs, path, resolvedRoot);
+        const dirs = yield* resolvePatterns(fs, path, resolvedRoot, patterns);
+
+        const workspacePackages = yield* Effect.forEach(
+            dirs,
+            (dir) => readWorkspacePackage(fs, path, resolvedRoot, dir),
+            { concurrency: 10 },
+        );
+
+        // Read root package.json and prepend as first entry.
+        // The root may not have a `name` field, so read it manually
+        // with a fallback to the directory basename.
+        const rootPkgJsonPath = path.join(resolvedRoot, "package.json");
+        const rootContent = yield* fs.readFileString(rootPkgJsonPath).pipe(
+            Effect.mapError(() =>
+                new WorkspaceDiscoveryError({
+                    root: resolvedRoot,
+                    reason: `failed to read root ${rootPkgJsonPath}`,
+                }),
+            ),
+        );
+        const rootRaw = yield* Effect.try({
+            try: () => JSON.parse(rootContent) as Record<string, unknown>,
+            catch: () =>
+                new WorkspaceDiscoveryError({
+                    root: resolvedRoot,
+                    reason: `invalid JSON in root ${rootPkgJsonPath}`,
+                }),
+        });
+        const rootDecoded = yield* Schema.decodeUnknown(PackageJsonSchema)(rootRaw).pipe(
+            Effect.mapError(() =>
+                new WorkspaceDiscoveryError({
+                    root: resolvedRoot,
+                    reason: `failed to parse root ${rootPkgJsonPath}`,
+                }),
+            ),
+        );
+
+        const rootPkg = new WorkspacePackage({
+            name: rootDecoded.name ?? path.basename(resolvedRoot),
+            version: rootDecoded.version ?? "0.0.0",
+            path: resolvedRoot,
+            relativePath: ".",
+            private: rootDecoded.private ?? false,
+            dependencies: (rootDecoded.dependencies as Record<string, string>) ?? {},
+            devDependencies: (rootDecoded.devDependencies as Record<string, string>) ?? {},
+            peerDependencies: (rootDecoded.peerDependencies as Record<string, string>) ?? {},
+            optionalDependencies: (rootDecoded.optionalDependencies as Record<string, string>) ?? {},
+            publishConfig: rootDecoded.publishConfig,
+        });
+
+        const packages = [rootPkg, ...workspacePackages];
+        cachedPackages = packages;
+        yield* Effect.logInfo("Workspace packages discovered").pipe(
+            Effect.annotateLogs("workspace.packages.count", packages.length),
+        );
+        return packages;
+    }).pipe(Effect.withSpan("WorkspaceDiscovery.listPackages"));
+
+- [ ] **Step 5: Update existing tests for new length expectations**
+
+Existing tests that assert `toHaveLength(N)` need to be updated to `N+1` to account for the root package. Each test's mock filesystem needs a root `package.json` added. Review each test case and update accordingly.
+
+For example, the first test "discovers packages from pnpm-workspace.yaml" currently expects length 2. With root included, add a root `package.json` to the mock and expect length 3.
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `pnpm vitest run src/layers/WorkspaceDiscoveryLive.test.ts`
+Expected: All tests PASS
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/layers/WorkspaceDiscoveryLive.ts src/layers/WorkspaceDiscoveryLive.test.ts
+git commit -m "feat: include root workspace package in listPackages() (breaking change)
+
+Signed-off-by: C. Spencer Beggs <spencer@beggs.codes>"
+```
+
+---
+
+### Task 8: Add `importerMap()` to `WorkspaceDiscovery`
+
+**Files:**
+
+- Modify: `src/services/WorkspaceDiscovery.ts`
+- Modify: `src/layers/WorkspaceDiscoveryLive.ts`
+- Modify: `src/layers/WorkspaceDiscoveryLive.test.ts`
+
+- [ ] **Step 1: Write failing test for `importerMap()`**
+
+Add to `src/layers/WorkspaceDiscoveryLive.test.ts`:
+
+```typescript
+describe("importerMap", () => {
+    it("returns map keyed by relativePath", async () => {
+        const root = "/projects/monorepo";
+        const layer = testLayer(
+            root,
+            {
+                [`${root}/pnpm-workspace.yaml`]: "packages:\n  - 'packages/*'",
+                [`${root}/package.json`]: JSON.stringify({
+                    name: "my-monorepo",
+                    version: "0.0.0",
+                }),
+                [`${root}/packages/core/package.json`]: JSON.stringify({
+                    name: "@scope/core",
+                    version: "1.0.0",
+                }),
+                [`${root}/packages/utils/package.json`]: JSON.stringify({
+                    name: "@scope/utils",
+                    version: "1.0.0",
+                }),
+            },
+            {
+                [`${root}/packages`]: ["core", "utils"],
+            },
+        );
+
+        const result = await Effect.runPromise(
+            Effect.gen(function* () {
+                const discovery = yield* WorkspaceDiscovery;
+                return yield* discovery.importerMap();
+            }).pipe(Effect.provide(layer)),
+        );
+
+        expect(result.size).toBe(3);
+        expect(result.get(".")?.name).toBe("my-monorepo");
+        expect(result.get("packages/core")?.name).toBe("@scope/core");
+        expect(result.get("packages/utils")?.name).toBe("@scope/utils");
+    });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm vitest run src/layers/WorkspaceDiscoveryLive.test.ts`
+Expected: FAIL (importerMap not defined on service)
+
+- [ ] **Step 3: Add `importerMap()` to service interface**
+
+In `src/services/WorkspaceDiscovery.ts`, add to the service shape:
+
+```typescript
+/**
+ * Get a map of workspace-relative directory paths to packages.
+ *
+ * Useful for mapping lockfile importer keys to their workspace packages.
+ * Built from `listPackages()` output and inherits its caching.
+ *
+ * @returns An Effect that succeeds with a ReadonlyMap keyed by relativePath.
+ */
+readonly importerMap: () => Effect.Effect<
+    ReadonlyMap<string, WorkspacePackage>,
+    WorkspaceDiscoveryError
+>;
+```
+
+Add the `WorkspacePackage` import at the top of the file.
+
+- [ ] **Step 4: Implement `importerMap()` in `WorkspaceDiscoveryLive`**
+
+In `src/layers/WorkspaceDiscoveryLive.ts`, add to the returned service object (inside the `return { ... }` block, after `getPackage`):
+
+```typescript
+importerMap: () =>
+    Effect.gen(function* () {
+        const packages = yield* discoverPackages();
+        return new Map(packages.map((p) => [p.relativePath, p])) as ReadonlyMap<string, WorkspacePackage>;
+    }).pipe(Effect.withSpan("WorkspaceDiscovery.importerMap")),
+```
+
+- [ ] **Step 5: Update mock discovery in other test files**
+
+Any test file that creates a mock `WorkspaceDiscovery` (e.g. `DependencyGraphLive.test.ts`) needs to add `importerMap` to the mock. Check all test files that mock `WorkspaceDiscovery`:
+
+```typescript
+const mockDiscovery = (packages: WorkspacePackage[]) =>
+    Layer.succeed(WorkspaceDiscovery, {
+        listPackages: () => Effect.succeed(packages),
+        getPackage: (name: string) => { /* existing */ },
+        importerMap: () => Effect.succeed(
+            new Map(packages.map((p) => [p.relativePath, p])) as ReadonlyMap<string, WorkspacePackage>,
+        ),
+    });
+```
+
+Files that mock `WorkspaceDiscovery` and need `importerMap` added:
+`DependencyGraphLive.test.ts`, `TopologicalSorterLive.test.ts`, `PackageResolverLive.test.ts`, `index.test.ts`.
+
+Files that use the real `WorkspaceDiscoveryLive` with mock filesystems — these need root `package.json` fixtures with `name` fields added:
+`WorkspacesLive.test.ts`, `integration.test.ts`.
+
+- [ ] **Step 6: Run all tests**
+
+Run: `pnpm run test`
+Expected: All tests PASS
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/services/WorkspaceDiscovery.ts src/layers/WorkspaceDiscoveryLive.ts src/layers/WorkspaceDiscoveryLive.test.ts src/layers/DependencyGraphLive.test.ts src/layers/TopologicalSorterLive.test.ts src/layers/PackageResolverLive.test.ts src/index.test.ts src/layers/WorkspacesLive.test.ts src/layers/integration.test.ts
+git commit -m "feat: add importerMap() to WorkspaceDiscovery service
+
+Signed-off-by: C. Spencer Beggs <spencer@beggs.codes>"
+```
+
+---
+
+### Task 9: Final verification and lint
+
+**Files:** All modified files
+
+- [ ] **Step 1: Run full typecheck**
+
+Run: `pnpm run typecheck`
+Expected: PASS
+
+- [ ] **Step 2: Run full test suite**
+
+Run: `pnpm run test`
+Expected: All 174+ tests PASS (existing + new)
+
+- [ ] **Step 3: Run linter and fix**
+
+Run: `pnpm run lint:fix`
+Expected: PASS or auto-fixed
+
+- [ ] **Step 4: Run markdown lint**
+
+Run: `pnpm run lint:md:fix`
+Expected: PASS
+
+- [ ] **Step 5: Commit any lint fixes**
+
+```bash
+git add -A
+git commit -m "chore: lint fixes
+
+Signed-off-by: C. Spencer Beggs <spencer@beggs.codes>"
+```

--- a/docs/superpowers/specs/2026-03-25-workspace-package-enrichment-design.md
+++ b/docs/superpowers/specs/2026-03-25-workspace-package-enrichment-design.md
@@ -1,0 +1,203 @@
+# WorkspacePackage Enrichment & API Surface for GitHub Action Integration
+
+**Issue:** [#12 — APIs needed to replace workspace-tools in GitHub Action](https://github.com/spencerbeggs/workspaces-effect/issues/12)
+**Date:** 2026-03-25
+**Status:** Draft
+
+## Motivation
+
+`pnpm-config-dependency-action` depends on `workspace-tools` (Microsoft) for
+workspace package discovery. That dependency pulls in `jju` which uses dynamic
+`require()`, producing bundler warnings. The action needs only two things from
+it: a list of workspace packages with paths, and a mapping from relative
+directory paths to package names (for lockfile importer keys).
+
+`workspaces-effect` already provides most of this data through
+`WorkspaceDiscovery.listPackages()` and the `WorkspacePackage` schema. This
+spec covers the gaps and enrichments needed to make `workspaces-effect` a
+complete drop-in replacement.
+
+## Changes Overview
+
+### 1. WorkspacePackage Schema Enrichment
+
+**New schema fields** on `WorkspacePackage` (`src/schemas/core.ts`):
+
+| Field | Type | Default |
+| ----- | ---- | ------- |
+| `peerDependencies` | `Record<string, string>` | `{}` |
+| `optionalDependencies` | `Record<string, string>` | `{}` |
+
+Both are entirely new to `WorkspacePackage`. While `PackageJsonSchema` already
+parses `peerDependencies`, the value is currently dropped when constructing
+`WorkspacePackage` instances in `WorkspaceDiscoveryLive`. Both fields must be
+added to the schema class and wired through from `readWorkspacePackage`.
+`optionalDependencies` must also be added to `PackageJsonSchema`.
+
+**New getters** (derived, no stored state):
+
+| Getter | Returns | Derivation |
+| ------ | ------- | ---------- |
+| `isRootWorkspace` | `boolean` | `this.relativePath === "."` |
+| `packageJsonPath` | `string` | `` `${this.path}/package.json` `` |
+| `isPublic` | `boolean` | `!this.private` |
+| `scope` | `Option<string>` | Extract `@scope` from `@scope/name`, or `Option.none()` |
+| `unscopedName` | `string` | `core` from `@scope/core`, or full name if unscoped |
+| `allDependencies` | `Record<string, string>` | Merged map of all 4 dependency types |
+
+**New instance methods:**
+
+| Method | Signature | Description |
+| ------ | --------- | ----------- |
+| `hasDependency` | `(name: string) => boolean` | Checks `dependencies` |
+| `hasDevDependency` | `(name: string) => boolean` | Checks `devDependencies` |
+| `hasPeerDependency` | `(name: string) => boolean` | Checks `peerDependencies` |
+| `hasOptionalDependency` | `(name: string) => boolean` | Checks `optionalDependencies` |
+| `hasAnyDependencyOn` | `(name: string) => boolean` | Checks all 4 dependency types |
+| `dependencyVersion` | `(name: string) => Option<string>` | Looks up version across all dep types |
+| `dependencyDiff` | `(other: WorkspacePackage) => DependencyDiff` | Compare two snapshots; returns added/removed/changed deps |
+| `matchesDependency` | `(pattern: string) => boolean` | Check if any dep name matches a glob pattern (minimatch semantics) |
+
+**Dual static + instance API** (following the `semver-effect` pattern):
+
+Each instance method also exists as a standalone `Function.dual()` function
+(from `effect/Function`) for pipeable/curried use. Static methods are wired to
+the class in the barrel file:
+
+```typescript
+// Instance use
+pkg.hasDependency("effect")
+
+// Static data-first use
+WorkspacePackage.hasDependency(pkg, "effect")
+
+// Static data-last (pipeable) use
+pipe(pkg, WorkspacePackage.hasDependency("effect"))
+```
+
+The standalone functions live in a new `src/utils/workspace-package.ts` module
+(new directory). Static wiring happens in `src/index.ts`.
+
+### 2. readPackageJson Utility
+
+`readPackageJson` is a standalone utility function in
+`src/utils/workspace-package.ts`, not an instance method on `WorkspacePackage`.
+This keeps `WorkspacePackage` as a pure data type, consistent with the
+codebase's separation of data and effects. It is also wired as a static method
+on the class.
+
+```typescript
+// Standalone use
+readPackageJson(pkg) // Effect<PackageJsonType, PackageJsonParseError, FileSystem>
+
+// Static use
+WorkspacePackage.readPackageJson(pkg)
+
+// Pipeable use
+pipe(pkg, WorkspacePackage.readPackageJson)
+```
+
+Note: `PackageJsonType` is the minimal schema subset. If callers need the full
+raw `package.json` (scripts, exports, bin, etc.), they can read the file at
+`pkg.packageJsonPath` directly. The utility is for the common case of accessing
+the fields the library already models.
+
+### 3. DependencyDiff Type
+
+A new interface for the return value of `dependencyDiff`. Uses `Record` for
+consistency with the existing dependency map types throughout the codebase:
+
+```typescript
+interface DependencyDiff {
+  readonly added: Record<string, string>       // name → new version
+  readonly removed: Record<string, string>     // name → old version
+  readonly changed: Record<string, { readonly from: string; readonly to: string }>
+}
+```
+
+Compares across all 4 dep types combined. Located in `src/schemas/core.ts`
+alongside `WorkspacePackage`.
+
+### 4. Root Package Inclusion
+
+`WorkspaceDiscoveryLive.listPackages()` will **always include the root
+workspace package** as the first entry in the returned array. The root package
+is constructed from the root `package.json` with:
+
+- `relativePath: "."`
+- `path`: the workspace root absolute path
+- All dependency fields populated from root `package.json`
+
+Consumers can identify the root via the `isRootWorkspace` getter and filter it
+out if needed:
+
+```typescript
+const nonRootPackages = packages.filter(p => !p.isRootWorkspace)
+```
+
+This is a **breaking change** to `listPackages()` behavior. The root package
+was previously excluded. This also means `getPackage(name)` will now resolve
+the root workspace package by name, since it searches the `listPackages()`
+result.
+
+### 5. WorkspaceDiscovery.importerMap()
+
+New method on the `WorkspaceDiscovery` service interface:
+
+```typescript
+readonly importerMap: () => Effect.Effect<
+  ReadonlyMap<string, WorkspacePackage>,
+  WorkspaceDiscoveryError
+>
+```
+
+Returns a `ReadonlyMap` keyed by `relativePath` (e.g. `"packages/core"`, `"."`)
+with `WorkspacePackage` values. Built from `listPackages()` output and
+therefore inherits its caching — no separate cache needed. This directly
+supports the lockfile importer-to-package mapping use case.
+
+### 6. PackageJsonSchema Update
+
+Add `optionalDependencies` to `PackageJsonSchema`:
+
+```typescript
+optionalDependencies: Schema.optional(
+  Schema.Record({ key: Schema.String, value: Schema.String })
+)
+```
+
+`peerDependencies` is already present in the schema.
+
+## Files to Modify
+
+| File | Change |
+| ---- | ------ |
+| `src/schemas/core.ts` | Add `peerDependencies`/`optionalDependencies` fields, getters, instance methods to `WorkspacePackage`; add `DependencyDiff`; add `optionalDependencies` to `PackageJsonSchema` |
+| `src/utils/workspace-package.ts` | **New file** (new `src/utils/` directory) — standalone `Function.dual()` functions including `readPackageJson` |
+| `src/services/WorkspaceDiscovery.ts` | Add `importerMap()` to service interface |
+| `src/layers/WorkspaceDiscoveryLive.ts` | Include root package in `listPackages()`; wire `peerDependencies`/`optionalDependencies` from decoded `PackageJsonSchema` into `WorkspacePackage` constructor; implement `importerMap()` |
+| `src/index.ts` | Wire static methods; export new utils and `DependencyDiff` |
+| Tests | Update existing tests for root inclusion; update test fixtures to include `peerDependencies`/`optionalDependencies` where needed; add tests for all new methods/getters |
+
+## Files NOT Modified
+
+| File | Reason |
+| ---- | ------ |
+| `src/services/PackageResolver.ts` | Already handles path → package mapping for absolute paths |
+| `src/services/TopologicalSorter.ts` | Untouched; consumes DependencyGraph, not WorkspacePackage directly |
+| `src/services/PublishabilityDetector.ts` | Remains a separate overridable service |
+| `src/services/DependencyGraph.ts` | May benefit from `peerDependencies` later; out of scope here |
+| `src/layers/WorkspacesLive.ts` | Composite layer unchanged; already provides WorkspaceDiscovery |
+
+## Breaking Changes
+
+1. **`listPackages()` now includes the root package.** Consumers that assumed
+   only workspace glob-matched packages were returned must filter using
+   `isRootWorkspace` if they need the old behavior.
+2. **`getPackage(name)` now resolves the root package.** Since it searches
+   `listPackages()`, the root is now findable by name.
+
+## Open Questions
+
+1. Should `DependencyGraph` be updated to consider `peerDependencies` in the
+   graph edges? Deferred — out of scope for this issue.

--- a/package.json
+++ b/package.json
@@ -65,22 +65,22 @@
 	},
 	"dependencies": {
 		"jsonc-effect": "^0.2.0",
-		"semver-effect": "^0.1.0",
-		"yaml-effect": "^0.1.0"
+		"semver-effect": "^0.2.0",
+		"yaml-effect": "^0.2.2"
 	},
 	"devDependencies": {
-		"@effect/platform": "^0.94.5",
-		"@effect/platform-node": "^0.104.1",
-		"@savvy-web/changesets": "^0.5.1",
+		"@effect/platform": "catalog:silk",
+		"@effect/platform-node": "catalog:silk",
+		"@savvy-web/changesets": "^0.6.0",
 		"@savvy-web/commitlint": "^0.4.1",
-		"@savvy-web/lint-staged": "^0.5.2",
-		"@savvy-web/rslib-builder": "^0.18.1",
-		"@savvy-web/vitest": "^0.2.1",
-		"effect": "^3.19.19"
+		"@savvy-web/lint-staged": "^0.6.2",
+		"@savvy-web/rslib-builder": "^0.19.0",
+		"@savvy-web/vitest": "^1.0.0",
+		"effect": "catalog:silk"
 	},
 	"peerDependencies": {
-		"@effect/platform": "^0.94.0",
-		"effect": "^3.19.0"
+		"@effect/platform": "catalog:silkPeers",
+		"effect": "catalog:silkPeers"
 	},
 	"packageManager": "pnpm@10.32.1+sha512.a706938f0e89ac1456b6563eab4edf1d1faf3368d1191fc5c59790e96dc918e4456ab2e67d613de1043d2e8c81f87303e6b40d4ffeca9df15ef1ad567348f2be",
 	"devEngines": {

--- a/package.json
+++ b/package.json
@@ -64,8 +64,9 @@
 		"types:check": "tsgo --noEmit"
 	},
 	"dependencies": {
-		"jsonc-effect": "^0.2.0",
-		"semver-effect": "^0.2.0",
+		"jsonc-effect": "^0.2.1",
+		"minimatch": ">=10.2.3",
+		"semver-effect": "^0.2.1",
 		"yaml-effect": "^0.2.2"
 	},
 	"devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,11 +30,14 @@ importers:
   .:
     dependencies:
       jsonc-effect:
-        specifier: ^0.2.0
-        version: 0.2.0
+        specifier: ^0.2.1
+        version: 0.2.1(effect@3.21.0)
+      minimatch:
+        specifier: '>=10.2.3'
+        version: 10.2.4
       semver-effect:
-        specifier: ^0.2.0
-        version: 0.2.0(effect@3.21.0)
+        specifier: ^0.2.1
+        version: 0.2.1(effect@3.21.0)
       yaml-effect:
         specifier: ^0.2.2
         version: 0.2.2(effect@3.21.0)
@@ -2346,8 +2349,10 @@ packages:
     engines: {node: '>=6'}
     hasBin: true
 
-  jsonc-effect@0.2.0:
-    resolution: {integrity: sha512-tMDWhm8efXWz4k0zvgLu4dXLrlyjHrErJ4S2l28lyW5RFl3+Pg8XMRyl+PlMK4x9eIbOGs/TyKrW67eU7hqgZw==}
+  jsonc-effect@0.2.1:
+    resolution: {integrity: sha512-gqxLlEStGJwmrRJZ3VyJbeb3m3yL+zptGGJrL30x0pxu2XgaWHbwM+YyruJtx4e3qXctWG79Fqyx8+VE/zNOUg==}
+    peerDependencies:
+      effect: '>=3.21.0'
 
   jsonc-parser@3.3.1:
     resolution: {integrity: sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==}
@@ -3126,10 +3131,10 @@ packages:
   secure-keys@1.0.0:
     resolution: {integrity: sha512-nZi59hW3Sl5P3+wOO89eHBAAGwmCPd2aE1+dLZV5MO+ItQctIvAqihzaAXIQhvtH4KJPxM080HsnqltR2y8cWg==}
 
-  semver-effect@0.2.0:
-    resolution: {integrity: sha512-N2ieg9JiBQ3DZDzklqyUHF/1Lx4nOxHeKkAb0YYOkwj8sz4PyqPFEXzPHotLKdgCchIVUpvJpO/+ekPgH2T+6w==}
+  semver-effect@0.2.1:
+    resolution: {integrity: sha512-W4JwQ4Ot6Yl/Fr8OT5OJnxc9SSuLKqslCb9fbbIFwm0198usbn2KoDKhWrCntDUT935UM85ljflwJIFe2YQ6LA==}
     peerDependencies:
-      effect: ^3.19.0
+      effect: '>=3.21.0'
 
   semver@7.5.4:
     resolution: {integrity: sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==}
@@ -4782,7 +4787,7 @@ snapshots:
       eslint: 10.1.0(jiti@2.6.1)
       eslint-plugin-tsdoc: 0.5.2(eslint@10.1.0(jiti@2.6.1))(typescript@5.9.3)
       husky: 9.1.7
-      jsonc-effect: 0.2.0
+      jsonc-effect: 0.2.1(effect@3.21.0)
       lint-staged: 16.4.0
       markdownlint-cli2: 0.22.0
       markdownlint-cli2-formatter-codequality: 0.0.7(markdownlint-cli2@0.22.0)
@@ -6121,7 +6126,7 @@ snapshots:
 
   json5@2.2.3: {}
 
-  jsonc-effect@0.2.0:
+  jsonc-effect@0.2.1(effect@3.21.0):
     dependencies:
       effect: 3.21.0
 
@@ -7096,7 +7101,7 @@ snapshots:
 
   secure-keys@1.0.0: {}
 
-  semver-effect@0.2.0(effect@3.21.0):
+  semver-effect@0.2.1(effect@3.21.0):
     dependencies:
       effect: 3.21.0
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,18 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+catalogs:
+  silk:
+    '@effect/platform':
+      specifier: ^0.96.0
+      version: 0.96.0
+    '@effect/platform-node':
+      specifier: ^0.106.0
+      version: 0.106.0
+    effect:
+      specifier: ^3.21.0
+      version: 3.21.0
+
 overrides:
   '@isaacs/brace-expansion': ^5.0.1
   lodash: ^4.17.23
@@ -11,7 +23,7 @@ overrides:
   minimatch: '>=10.2.3'
   tmp: ^0.2.4
 
-pnpmfileChecksum: sha256-frAR5HNgVgtGTprdTnIzKdO1A6kY+c7Wz5F9JqOsjN8=
+pnpmfileChecksum: sha256-OVggNoUSjNrBglprlO4g7FXDflfm7pzLSJffre8Kj8Q=
 
 importers:
 
@@ -21,36 +33,36 @@ importers:
         specifier: ^0.2.0
         version: 0.2.0
       semver-effect:
-        specifier: ^0.1.0
-        version: 0.1.0(effect@3.19.19)
+        specifier: ^0.2.0
+        version: 0.2.0(effect@3.21.0)
       yaml-effect:
-        specifier: ^0.1.0
-        version: 0.1.0(effect@3.19.19)
+        specifier: ^0.2.2
+        version: 0.2.2(effect@3.21.0)
     devDependencies:
       '@effect/platform':
-        specifier: ^0.94.5
-        version: 0.94.5(effect@3.19.19)
+        specifier: catalog:silk
+        version: 0.96.0(effect@3.21.0)
       '@effect/platform-node':
-        specifier: ^0.104.1
-        version: 0.104.1(@effect/cluster@0.56.4(@effect/platform@0.94.5(effect@3.19.19))(@effect/rpc@0.73.2(@effect/platform@0.94.5(effect@3.19.19))(effect@3.19.19))(@effect/sql@0.49.0(@effect/experimental@0.58.0(@effect/platform@0.94.5(effect@3.19.19))(effect@3.19.19))(@effect/platform@0.94.5(effect@3.19.19))(effect@3.19.19))(@effect/workflow@0.16.0(@effect/experimental@0.58.0(@effect/platform@0.94.5(effect@3.19.19))(effect@3.19.19))(@effect/platform@0.94.5(effect@3.19.19))(@effect/rpc@0.73.2(@effect/platform@0.94.5(effect@3.19.19))(effect@3.19.19))(effect@3.19.19))(effect@3.19.19))(@effect/platform@0.94.5(effect@3.19.19))(@effect/rpc@0.73.2(@effect/platform@0.94.5(effect@3.19.19))(effect@3.19.19))(@effect/sql@0.49.0(@effect/experimental@0.58.0(@effect/platform@0.94.5(effect@3.19.19))(effect@3.19.19))(@effect/platform@0.94.5(effect@3.19.19))(effect@3.19.19))(effect@3.19.19)
+        specifier: catalog:silk
+        version: 0.106.0(@effect/cluster@0.58.0(@effect/platform@0.96.0(effect@3.21.0))(@effect/rpc@0.75.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/sql@0.51.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/workflow@0.18.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/platform@0.96.0(effect@3.21.0))(@effect/rpc@0.75.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(effect@3.21.0))(effect@3.21.0))(@effect/platform@0.96.0(effect@3.21.0))(@effect/rpc@0.75.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/sql@0.51.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(effect@3.21.0)
       '@savvy-web/changesets':
-        specifier: ^0.5.1
-        version: 0.5.1(0c118329066b697e68e825dd8709de22)
+        specifier: ^0.6.0
+        version: 0.6.0(@changesets/cli@2.30.0(@types/node@25.5.0))(@effect/cluster@0.58.0(@effect/platform@0.96.0(effect@3.21.0))(@effect/rpc@0.75.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/sql@0.51.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/workflow@0.18.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/platform@0.96.0(effect@3.21.0))(@effect/rpc@0.75.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(effect@3.21.0))(effect@3.21.0))(@effect/printer-ansi@0.49.0(@effect/typeclass@0.40.0(effect@3.21.0))(effect@3.21.0))(@effect/printer@0.49.0(@effect/typeclass@0.40.0(effect@3.21.0))(effect@3.21.0))(@effect/rpc@0.75.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/sql@0.51.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))
       '@savvy-web/commitlint':
         specifier: ^0.4.1
-        version: 0.4.1(7ad55c769ef6e03468ea280af116902e)
+        version: 0.4.3(@commitlint/cli@20.5.0(@types/node@25.5.0)(conventional-commits-parser@6.3.0)(typescript@5.9.3))(@commitlint/config-conventional@20.5.0)(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/typeclass@0.40.0(effect@3.21.0))(@effect/workflow@0.18.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/platform@0.96.0(effect@3.21.0))(@effect/rpc@0.75.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(effect@3.21.0))(husky@9.1.7)
       '@savvy-web/lint-staged':
-        specifier: ^0.5.2
-        version: 0.5.2(03929e76edcf99ee8580c27fcc711de5)
+        specifier: ^0.6.2
+        version: 0.6.2(4b8140fb90d3444252315ca2c86c4be4)
       '@savvy-web/rslib-builder':
-        specifier: ^0.18.1
-        version: 0.18.1(@microsoft/api-extractor@7.57.7(@types/node@25.4.0))(@pnpm/logger@1001.0.1)(@rslib/core@0.19.6(@microsoft/api-extractor@7.57.7(@types/node@25.4.0))(@typescript/native-preview@7.0.0-dev.20260311.1)(typescript@5.9.3))(@types/node@25.4.0)(@typescript/native-preview@7.0.0-dev.20260311.1)(jiti@2.6.1)(typescript@5.9.3)
+        specifier: ^0.19.0
+        version: 0.19.0(@microsoft/api-extractor@7.57.7(@types/node@25.5.0))(@pnpm/logger@1001.0.1)(@rslib/core@0.20.0(@microsoft/api-extractor@7.57.7(@types/node@25.5.0))(@typescript/native-preview@7.0.0-dev.20260324.1)(typescript@5.9.3))(@types/node@25.5.0)(@typescript/native-preview@7.0.0-dev.20260324.1)(jiti@2.6.1)(typescript@5.9.3)
       '@savvy-web/vitest':
-        specifier: ^0.2.1
-        version: 0.2.1(@types/node@25.4.0)(@typescript/native-preview@7.0.0-dev.20260311.1)(@vitest/coverage-v8@4.0.18(vitest@4.0.18(@types/node@25.4.0)(jiti@2.6.1)(yaml@2.8.2)))(typescript@5.9.3)(vitest@4.0.18(@types/node@25.4.0)(jiti@2.6.1)(yaml@2.8.2))
+        specifier: ^1.0.0
+        version: 1.0.0(f6bd36e22e00e000fe24ba2dfdd2d131)
       effect:
-        specifier: ^3.19.19
-        version: 3.19.19
+        specifier: catalog:silk
+        version: 3.21.0
     publishDirectory: dist/dev
 
 packages:
@@ -129,13 +141,13 @@ packages:
     resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/parser@7.29.0':
-    resolution: {integrity: sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww==}
+  '@babel/parser@7.29.2':
+    resolution: {integrity: sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
-  '@babel/runtime@7.28.6':
-    resolution: {integrity: sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==}
+  '@babel/runtime@7.29.2':
+    resolution: {integrity: sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==}
     engines: {node: '>=6.9.0'}
 
   '@babel/types@7.29.0':
@@ -204,61 +216,61 @@ packages:
   '@changesets/write@0.4.0':
     resolution: {integrity: sha512-CdTLvIOPiCNuH71pyDu3rA+Q0n65cmAbXnwWH84rKGiFumFzkmHNT8KHTMEchcxN+Kl8I54xGUhJ7l3E7X396Q==}
 
-  '@commitlint/cli@20.4.3':
-    resolution: {integrity: sha512-Z37EMoDT7+Upg500vlr/vZrgRsb6Xc5JAA3Tv7BYbobnN/ZpqUeZnSLggBg2+1O+NptRDtyujr2DD1CPV2qwhA==}
+  '@commitlint/cli@20.5.0':
+    resolution: {integrity: sha512-yNkyN/tuKTJS3wdVfsZ2tXDM4G4Gi7z+jW54Cki8N8tZqwKBltbIvUUrSbT4hz1bhW/h0CdR+5sCSpXD+wMKaQ==}
     engines: {node: '>=v18'}
     hasBin: true
 
-  '@commitlint/config-conventional@20.4.3':
-    resolution: {integrity: sha512-9RtLySbYQAs8yEqWEqhSZo9nYhbm57jx7qHXtgRmv/nmeQIjjMcwf6Dl+y5UZcGWgWx435TAYBURONaJIuCjWg==}
+  '@commitlint/config-conventional@20.5.0':
+    resolution: {integrity: sha512-t3Ni88rFw1XMa4nZHgOKJ8fIAT9M2j5TnKyTqJzsxea7FUetlNdYFus9dz+MhIRZmc16P0PPyEfh6X2d/qw8SA==}
     engines: {node: '>=v18'}
 
-  '@commitlint/config-validator@20.4.4':
-    resolution: {integrity: sha512-K8hMS9PTLl7EYe5vWtSFQ/sgsV2PHUOtEnosg8k3ZQxCyfKD34I4C7FxWEfRTR54rFKeUYmM3pmRQqBNQeLdlw==}
+  '@commitlint/config-validator@20.5.0':
+    resolution: {integrity: sha512-T/Uh6iJUzyx7j35GmHWdIiGRQB+ouZDk0pwAaYq4SXgB54KZhFdJ0vYmxiW6AMYICTIWuyMxDBl1jK74oFp/Gw==}
     engines: {node: '>=v18'}
 
-  '@commitlint/ensure@20.4.4':
-    resolution: {integrity: sha512-QivV0M1MGL867XCaF+jJkbVXEPKBALhUUXdjae66hes95aY1p3vBJdrcl3x8jDv2pdKWvIYIz+7DFRV/v0dRkA==}
+  '@commitlint/ensure@20.5.0':
+    resolution: {integrity: sha512-IpHqAUesBeW1EDDdjzJeaOxU9tnogLAyXLRBn03SHlj1SGENn2JGZqSWGkFvBJkJzfXAuCNtsoYzax+ZPS+puw==}
     engines: {node: '>=v18'}
 
   '@commitlint/execute-rule@20.0.0':
     resolution: {integrity: sha512-xyCoOShoPuPL44gVa+5EdZsBVao/pNzpQhkzq3RdtlFdKZtjWcLlUFQHSWBuhk5utKYykeJPSz2i8ABHQA+ZZw==}
     engines: {node: '>=v18'}
 
-  '@commitlint/format@20.4.4':
-    resolution: {integrity: sha512-jLi/JBA4GEQxc5135VYCnkShcm1/rarbXMn2Tlt3Si7DHiiNKHm4TaiJCLnGbZ1r8UfwDRk+qrzZ80kwh08Aow==}
+  '@commitlint/format@20.5.0':
+    resolution: {integrity: sha512-TI9EwFU/qZWSK7a5qyXMpKPPv3qta7FO4tKW+Wt2al7sgMbLWTsAcDpX1cU8k16TRdsiiet9aOw0zpvRXNJu7Q==}
     engines: {node: '>=v18'}
 
-  '@commitlint/is-ignored@20.4.4':
-    resolution: {integrity: sha512-y76rT8yq02x+pMDBI2vY4y/ByAwmJTkta/pASbgo8tldBiKLduX8/2NCRTSCjb3SumE5FBeopERKx3oMIm8RTQ==}
+  '@commitlint/is-ignored@20.5.0':
+    resolution: {integrity: sha512-JWLarAsurHJhPozbuAH6GbP4p/hdOCoqS9zJMfqwswne+/GPs5V0+rrsfOkP68Y8PSLphwtFXV0EzJ+GTXTTGg==}
     engines: {node: '>=v18'}
 
-  '@commitlint/lint@20.4.4':
-    resolution: {integrity: sha512-svOEW+RptcNpXKE7UllcAsV0HDIdOck9reC2TP1QA6K5Fo0xxQV+QPjV8Zqx9g6X/hQBkF2S9ZQZ78Xrv1Eiog==}
+  '@commitlint/lint@20.5.0':
+    resolution: {integrity: sha512-jiM3hNUdu04jFBf1VgPdjtIPvbuVfDTBAc6L98AWcoLjF5sYqkulBHBzlVWll4rMF1T5zeQFB6r//a+s+BBKlA==}
     engines: {node: '>=v18'}
 
-  '@commitlint/load@20.4.4':
-    resolution: {integrity: sha512-kvFrzvoIACa/fMjXEP0LNEJB1joaH3q3oeMJsLajXE5IXjYrNGVcW1ZFojXUruVJ7odTZbC3LdE/6+ONW4f2Dg==}
+  '@commitlint/load@20.5.0':
+    resolution: {integrity: sha512-sLhhYTL/KxeOTZjjabKDhwidGZan84XKK1+XFkwDYL/4883kIajcz/dZFAhBJmZPtL8+nBx6bnkzA95YxPeDPw==}
     engines: {node: '>=v18'}
 
   '@commitlint/message@20.4.3':
     resolution: {integrity: sha512-6akwCYrzcrFcTYz9GyUaWlhisY4lmQ3KvrnabmhoeAV8nRH4dXJAh4+EUQ3uArtxxKQkvxJS78hNX2EU3USgxQ==}
     engines: {node: '>=v18'}
 
-  '@commitlint/parse@20.4.4':
-    resolution: {integrity: sha512-AjfgOgrjEozeQNzhFu1KL5N0nDx4JZmswVJKNfOTLTUGp6xODhZHCHqb//QUHKOzx36If5DQ7tci2o7szYxu1A==}
+  '@commitlint/parse@20.5.0':
+    resolution: {integrity: sha512-SeKWHBMk7YOTnnEWUhx+d1a9vHsjjuo6Uo1xRfPNfeY4bdYFasCH1dDpAv13Lyn+dDPOels+jP6D2GRZqzc5fA==}
     engines: {node: '>=v18'}
 
-  '@commitlint/read@20.4.4':
-    resolution: {integrity: sha512-jvgdAQDdEY6L8kCxOo21IWoiAyNFzvrZb121wU2eBxI1DzWAUZgAq+a8LlJRbT0Qsj9INhIPVWgdaBbEzlF0dQ==}
+  '@commitlint/read@20.5.0':
+    resolution: {integrity: sha512-JDEIJ2+GnWpK8QqwfmW7O42h0aycJEWNqcdkJnyzLD11nf9dW2dWLTVEa8Wtlo4IZFGLPATjR5neA5QlOvIH1w==}
     engines: {node: '>=v18'}
 
-  '@commitlint/resolve-extends@20.4.4':
-    resolution: {integrity: sha512-pyOf+yX3c3m/IWAn2Jop+7s0YGKPQ8YvQaxt9IQxnLIM3yZAlBdkKiQCT14TnrmZTkVGTXiLtckcnFTXYwlY0A==}
+  '@commitlint/resolve-extends@20.5.0':
+    resolution: {integrity: sha512-3SHPWUW2v0tyspCTcfSsYml0gses92l6TlogwzvM2cbxDgmhSRc+fldDjvGkCXJrjSM87BBaWYTPWwwyASZRrg==}
     engines: {node: '>=v18'}
 
-  '@commitlint/rules@20.4.4':
-    resolution: {integrity: sha512-PmUp8QPLICn9w05dAx5r1rdOYoTk7SkfusJJh5tP3TqHwo2mlQ9jsOm8F0HSXU9kuLfgTEGNrunAx/dlK/RyPQ==}
+  '@commitlint/rules@20.5.0':
+    resolution: {integrity: sha512-5NdQXQEdnDPT5pK8O39ZA7HohzPRHEsDGU23cyVCNPQy4WegAbAwrQk3nIu7p2sl3dutPk8RZd91yKTrMTnRkQ==}
     engines: {node: '>=v18'}
 
   '@commitlint/to-lines@20.0.0':
@@ -269,8 +281,8 @@ packages:
     resolution: {integrity: sha512-qD9xfP6dFg5jQ3NMrOhG0/w5y3bBUsVGyJvXxdWEwBm8hyx4WOk3kKXw28T5czBYvyeCVJgJJ6aoJZUWDpaacQ==}
     engines: {node: '>=v18'}
 
-  '@commitlint/types@20.4.4':
-    resolution: {integrity: sha512-dwTGzyAblFXHJNBOgrTuO5Ee48ioXpS5XPRLLatxhQu149DFAHUcB3f0Q5eea3RM4USSsP1+WVT2dBtLVod4fg==}
+  '@commitlint/types@20.5.0':
+    resolution: {integrity: sha512-ZJoS8oSq2CAZEpc/YI9SulLrdiIyXeHb/OGqGrkUP6Q7YV+0ouNAa7GjqRdXeQPncHQIDz/jbCTlHScvYvO/gA==}
     engines: {node: '>=v18'}
 
   '@conventional-changelog/git-client@2.6.0':
@@ -285,28 +297,28 @@ packages:
       conventional-commits-parser:
         optional: true
 
-  '@effect/cli@0.73.2':
-    resolution: {integrity: sha512-K8IJo81+qa1LU8dhxcDU4QO/bIjL/dPd3zUOSCpLiuUNz8Y3/T+WNs3GqIXEhMfCFMSlRZERN0YgmtRlEZUREA==}
+  '@effect/cli@0.75.0':
+    resolution: {integrity: sha512-SAJj1a1kb5yoSUz4yORmwjyOBv89y2wf2Q08KC/RwskUCZunj29eNZgl8Pkbv6nDFTGlre6EW/Kl2S/aOtQWwQ==}
     peerDependencies:
-      '@effect/platform': ^0.94.3
-      '@effect/printer': ^0.47.0
-      '@effect/printer-ansi': ^0.47.0
-      effect: ^3.19.16
+      '@effect/platform': ^0.96.0
+      '@effect/printer': ^0.49.0
+      '@effect/printer-ansi': ^0.49.0
+      effect: ^3.21.0
 
-  '@effect/cluster@0.56.4':
-    resolution: {integrity: sha512-7Je5/JlbZOlsSxsbKjr97dJed2cNGWsb+TLNgMcr5mRDbcWlFOTUGvsrisEJV6waosYLIg+2omPdvnvRoYKdhA==}
+  '@effect/cluster@0.58.0':
+    resolution: {integrity: sha512-0Zog7s7XdntWcTqdqWPoj6nc7hPaWIzp0k0DsFUWyCynXNPK9dAtgFrSce04NhddNqqbhtZck/lhuqJwNBrprQ==}
     peerDependencies:
-      '@effect/platform': ^0.94.5
-      '@effect/rpc': ^0.73.1
-      '@effect/sql': ^0.49.0
-      '@effect/workflow': ^0.16.0
-      effect: ^3.19.17
+      '@effect/platform': ^0.96.0
+      '@effect/rpc': ^0.75.0
+      '@effect/sql': ^0.51.0
+      '@effect/workflow': ^0.18.0
+      effect: ^3.21.0
 
-  '@effect/experimental@0.58.0':
-    resolution: {integrity: sha512-IEP9sapjF6rFy5TkoqDPc86st/fnqUfjT7Xa3pWJrFGr1hzaMXHo+mWsYOZS9LAOVKnpHuVziDK97EP5qsCHVA==}
+  '@effect/experimental@0.60.0':
+    resolution: {integrity: sha512-i5zIg7Xup2KgHyqHlYtkgqSE1bNzCL0GbbTQxrpIzKF0q/ebknOk/ox8B/gIq2vImjoEE81h/oxU+6i1NH210g==}
     peerDependencies:
-      '@effect/platform': ^0.94.0
-      effect: ^3.19.13
+      '@effect/platform': ^0.96.0
+      effect: ^3.21.0
       ioredis: ^5
       lmdb: ^3
     peerDependenciesMeta:
@@ -315,231 +327,83 @@ packages:
       lmdb:
         optional: true
 
-  '@effect/platform-node-shared@0.57.1':
-    resolution: {integrity: sha512-oX/bApMdoKsyrDiNdJxo7U9Rz1RXsjRv+ecfAPp1qGlSdGIo32wVRvJ2XCHqYj0sqaYJS0pU0/GCulRfVGuJag==}
+  '@effect/platform-node-shared@0.59.0':
+    resolution: {integrity: sha512-3bq2YKKfLY7UFauZSxqZUneCXoA3SMSls82V+0RKunvRlfPuPQW0hVn6t1RkvEdh0PDoygWG2mZXYQa6Iqgp9A==}
     peerDependencies:
-      '@effect/cluster': ^0.56.1
-      '@effect/platform': ^0.94.2
-      '@effect/rpc': ^0.73.0
-      '@effect/sql': ^0.49.0
-      effect: ^3.19.15
+      '@effect/cluster': ^0.58.0
+      '@effect/platform': ^0.96.0
+      '@effect/rpc': ^0.75.0
+      '@effect/sql': ^0.51.0
+      effect: ^3.21.0
 
-  '@effect/platform-node@0.104.1':
-    resolution: {integrity: sha512-jT1a/z98niK6fnEU8pWHPPCdJMVDRCIdB65lolcOjse5rsTwVbczMjvKkhVQpF63mNWoOnol7OTRNkw5L54llg==}
+  '@effect/platform-node@0.106.0':
+    resolution: {integrity: sha512-mpsJK2jNLVd0jQAjHKBo8j3wdKWznSGvfnKBcAuG/9Rr4mb8bMRZFLXHHT9wUP7EvnZ0tDZJgEDxkC+j+ByRag==}
     peerDependencies:
-      '@effect/cluster': ^0.56.1
-      '@effect/platform': ^0.94.2
-      '@effect/rpc': ^0.73.0
-      '@effect/sql': ^0.49.0
-      effect: ^3.19.15
+      '@effect/cluster': ^0.58.0
+      '@effect/platform': ^0.96.0
+      '@effect/rpc': ^0.75.0
+      '@effect/sql': ^0.51.0
+      effect: ^3.21.0
 
-  '@effect/platform@0.94.5':
-    resolution: {integrity: sha512-z05APUiDDPbodhTkH/RJqOLoCU11bU2IZLfcwLFrld03+ob1VeqRnELQlmueLIYm6NZifHAtjl32V+GRt34y4A==}
+  '@effect/platform@0.96.0':
+    resolution: {integrity: sha512-U7PLhkVzg7zzrgFvyWATOzD6reL87KG/fcdOxgLWBQ/J5CCU6qdPAVG+0o6o+IxcsLoqGwxs+rFxaFzrdtDV1A==}
     peerDependencies:
-      effect: ^3.19.17
+      effect: ^3.21.0
 
-  '@effect/printer-ansi@0.47.0':
-    resolution: {integrity: sha512-tDEQ9XJpXDNYoWMQJHFRMxKGmEOu6z32x3Kb8YLOV5nkauEKnKmWNs7NBp8iio/pqoJbaSwqDwUg9jXVquxfWQ==}
+  '@effect/printer-ansi@0.49.0':
+    resolution: {integrity: sha512-N2OyqDTqcGLKeUy2URowThoU5issZQwG/Ihv5qOYWJD0neq9qBIgC57/9BkFpTRPNSMtPHyCOk1TFj297HGLLQ==}
     peerDependencies:
-      '@effect/typeclass': ^0.38.0
-      effect: ^3.19.0
+      '@effect/typeclass': ^0.40.0
+      effect: ^3.21.0
 
-  '@effect/printer@0.47.0':
-    resolution: {integrity: sha512-VgR8e+YWWhMEAh9qFOjwiZ3OXluAbcVLIOtvp2S5di1nSrPOZxj78g8LE77JSvyfp5y5bS2gmFW+G7xD5uU+2Q==}
+  '@effect/printer@0.49.0':
+    resolution: {integrity: sha512-hrjTuExF87wuWjOnnND1c2fKcCWhleQBVaoA7JlrU3rC7s+RYPETDOXtpgAK3/uuMCRnDhfVFQMevtKT8MBdKg==}
     peerDependencies:
-      '@effect/typeclass': ^0.38.0
-      effect: ^3.19.0
+      '@effect/typeclass': ^0.40.0
+      effect: ^3.21.0
 
-  '@effect/rpc@0.73.2':
-    resolution: {integrity: sha512-td7LHDgBOYKg+VgGWEelD8rSAmvjXz7am17vfxZROX5qIYuvH7drL/z4p5xQFadhHZ7DYdlFpqdO9ggc77OCIw==}
+  '@effect/rpc@0.75.0':
+    resolution: {integrity: sha512-VFeJ16cZUXqiIzG9UHOVKGuiBPJ7fV+0lEbJU6xi12JnnxXe/19BQPpOwiRawCUbPOR3/xIURDUgGxU+Ft0pvQ==}
     peerDependencies:
-      '@effect/platform': ^0.94.5
-      effect: ^3.19.18
+      '@effect/platform': ^0.96.0
+      effect: ^3.21.0
 
-  '@effect/sql@0.49.0':
-    resolution: {integrity: sha512-9UEKR+z+MrI/qMAmSvb/RiD9KlgIazjZUCDSpwNgm0lEK9/Q6ExEyfziiYFVCPiptp52cBw8uBHRic8hHnwqXA==}
+  '@effect/sql-sqlite-node@0.52.0':
+    resolution: {integrity: sha512-yijDbly4MwxAPebvd2ZBI62qDpGdXKL96drMzflXDnjEh2JiVr/xVyy1VB0JsVxqw8IJ9TUIgOvAJWQ88oVMXA==}
     peerDependencies:
-      '@effect/experimental': ^0.58.0
-      '@effect/platform': ^0.94.0
-      effect: ^3.19.13
+      '@effect/experimental': ^0.60.0
+      '@effect/platform': ^0.96.0
+      '@effect/sql': ^0.51.0
+      effect: ^3.21.0
 
-  '@effect/typeclass@0.38.0':
-    resolution: {integrity: sha512-lMUcJTRtG8KXhXoczapZDxbLK5os7M6rn0zkvOgncJW++A0UyelZfMVMKdT5R+fgpZcsAU/1diaqw3uqLJwGxA==}
+  '@effect/sql@0.51.0':
+    resolution: {integrity: sha512-e7hWe46QD15eMCr4kNBMVdItIVK/WLHJG+d8DLL1FjVf5Ra82k2mwUYIXplJewVbHjt3my6GSKPPd1ZrQjVd5A==}
     peerDependencies:
-      effect: ^3.19.0
+      '@effect/experimental': ^0.60.0
+      '@effect/platform': ^0.96.0
+      effect: ^3.21.0
 
-  '@effect/workflow@0.16.0':
-    resolution: {integrity: sha512-MiAdlxx3TixkgHdbw+Yf1Z3tHAAE0rOQga12kIydJqj05Fnod+W/I+kQGRMY/XWRg+QUsVxhmh1qTr7Ype6lrw==}
+  '@effect/typeclass@0.40.0':
+    resolution: {integrity: sha512-L/2o2ImeqbemFlqH0b3y2PqQTFc+E0/DUnffCU8bkJUGh0yUZmh2RXuXhR8QOpfNCe718JQjI+mLnpVF2MMmaQ==}
     peerDependencies:
-      '@effect/experimental': ^0.58.0
-      '@effect/platform': ^0.94.0
-      '@effect/rpc': ^0.73.0
-      effect: ^3.19.13
+      effect: ^3.21.0
 
-  '@emnapi/core@1.9.0':
-    resolution: {integrity: sha512-0DQ98G9ZQZOxfUcQn1waV2yS8aWdZ6kJMbYCJB3oUBecjWYO1fqJ+a1DRfPF3O5JEkwqwP1A9QEN/9mYm2Yd0w==}
+  '@effect/workflow@0.18.0':
+    resolution: {integrity: sha512-9Zp+x9ADtR0H6CRhU6wLyPcIRjO1PXjvSpUlFlBQ8piw7ldjPmnUWEY8YQuH6eExV2dalQ4z2LMiZ5Bd7XAJbA==}
+    peerDependencies:
+      '@effect/experimental': ^0.60.0
+      '@effect/platform': ^0.96.0
+      '@effect/rpc': ^0.75.0
+      effect: ^3.21.0
 
-  '@emnapi/runtime@1.9.0':
-    resolution: {integrity: sha512-QN75eB0IH2ywSpRpNddCRfQIhmJYBCJ1x5Lb3IscKAL8bMnVAKnRg8dCoXbHzVLLH7P38N2Z3mtulB7W0J0FKw==}
+  '@emnapi/core@1.9.1':
+    resolution: {integrity: sha512-mukuNALVsoix/w1BJwFzwXBN/dHeejQtuVzcDsfOEsdpCumXb/E9j8w11h5S54tT1xhifGfbbSm/ICrObRb3KA==}
+
+  '@emnapi/runtime@1.9.1':
+    resolution: {integrity: sha512-VYi5+ZVLhpgK4hQ0TAjiQiZ6ol0oe4mBx7mVv7IflsiEp0OWoVsp/+f9Vc1hOhE0TtkORVrI1GvzyreqpgWtkA==}
 
   '@emnapi/wasi-threads@1.2.0':
     resolution: {integrity: sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg==}
-
-  '@esbuild/aix-ppc64@0.27.4':
-    resolution: {integrity: sha512-cQPwL2mp2nSmHHJlCyoXgHGhbEPMrEEU5xhkcy3Hs/O7nGZqEpZ2sUtLaL9MORLtDfRvVl2/3PAuEkYZH0Ty8Q==}
-    engines: {node: '>=18'}
-    cpu: [ppc64]
-    os: [aix]
-
-  '@esbuild/android-arm64@0.27.4':
-    resolution: {integrity: sha512-gdLscB7v75wRfu7QSm/zg6Rx29VLdy9eTr2t44sfTW7CxwAtQghZ4ZnqHk3/ogz7xao0QAgrkradbBzcqFPasw==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [android]
-
-  '@esbuild/android-arm@0.27.4':
-    resolution: {integrity: sha512-X9bUgvxiC8CHAGKYufLIHGXPJWnr0OCdR0anD2e21vdvgCI8lIfqFbnoeOz7lBjdrAGUhqLZLcQo6MLhTO2DKQ==}
-    engines: {node: '>=18'}
-    cpu: [arm]
-    os: [android]
-
-  '@esbuild/android-x64@0.27.4':
-    resolution: {integrity: sha512-PzPFnBNVF292sfpfhiyiXCGSn9HZg5BcAz+ivBuSsl6Rk4ga1oEXAamhOXRFyMcjwr2DVtm40G65N3GLeH1Lvw==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [android]
-
-  '@esbuild/darwin-arm64@0.27.4':
-    resolution: {integrity: sha512-b7xaGIwdJlht8ZFCvMkpDN6uiSmnxxK56N2GDTMYPr2/gzvfdQN8rTfBsvVKmIVY/X7EM+/hJKEIbbHs9oA4tQ==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@esbuild/darwin-x64@0.27.4':
-    resolution: {integrity: sha512-sR+OiKLwd15nmCdqpXMnuJ9W2kpy0KigzqScqHI3Hqwr7IXxBp3Yva+yJwoqh7rE8V77tdoheRYataNKL4QrPw==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [darwin]
-
-  '@esbuild/freebsd-arm64@0.27.4':
-    resolution: {integrity: sha512-jnfpKe+p79tCnm4GVav68A7tUFeKQwQyLgESwEAUzyxk/TJr4QdGog9sqWNcUbr/bZt/O/HXouspuQDd9JxFSw==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [freebsd]
-
-  '@esbuild/freebsd-x64@0.27.4':
-    resolution: {integrity: sha512-2kb4ceA/CpfUrIcTUl1wrP/9ad9Atrp5J94Lq69w7UwOMolPIGrfLSvAKJp0RTvkPPyn6CIWrNy13kyLikZRZQ==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [freebsd]
-
-  '@esbuild/linux-arm64@0.27.4':
-    resolution: {integrity: sha512-7nQOttdzVGth1iz57kxg9uCz57dxQLHWxopL6mYuYthohPKEK0vU0C3O21CcBK6KDlkYVcnDXY099HcCDXd9dA==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [linux]
-
-  '@esbuild/linux-arm@0.27.4':
-    resolution: {integrity: sha512-aBYgcIxX/wd5n2ys0yESGeYMGF+pv6g0DhZr3G1ZG4jMfruU9Tl1i2Z+Wnj9/KjGz1lTLCcorqE2viePZqj4Eg==}
-    engines: {node: '>=18'}
-    cpu: [arm]
-    os: [linux]
-
-  '@esbuild/linux-ia32@0.27.4':
-    resolution: {integrity: sha512-oPtixtAIzgvzYcKBQM/qZ3R+9TEUd1aNJQu0HhGyqtx6oS7qTpvjheIWBbes4+qu1bNlo2V4cbkISr8q6gRBFA==}
-    engines: {node: '>=18'}
-    cpu: [ia32]
-    os: [linux]
-
-  '@esbuild/linux-loong64@0.27.4':
-    resolution: {integrity: sha512-8mL/vh8qeCoRcFH2nM8wm5uJP+ZcVYGGayMavi8GmRJjuI3g1v6Z7Ni0JJKAJW+m0EtUuARb6Lmp4hMjzCBWzA==}
-    engines: {node: '>=18'}
-    cpu: [loong64]
-    os: [linux]
-
-  '@esbuild/linux-mips64el@0.27.4':
-    resolution: {integrity: sha512-1RdrWFFiiLIW7LQq9Q2NES+HiD4NyT8Itj9AUeCl0IVCA459WnPhREKgwrpaIfTOe+/2rdntisegiPWn/r/aAw==}
-    engines: {node: '>=18'}
-    cpu: [mips64el]
-    os: [linux]
-
-  '@esbuild/linux-ppc64@0.27.4':
-    resolution: {integrity: sha512-tLCwNG47l3sd9lpfyx9LAGEGItCUeRCWeAx6x2Jmbav65nAwoPXfewtAdtbtit/pJFLUWOhpv0FpS6GQAmPrHA==}
-    engines: {node: '>=18'}
-    cpu: [ppc64]
-    os: [linux]
-
-  '@esbuild/linux-riscv64@0.27.4':
-    resolution: {integrity: sha512-BnASypppbUWyqjd1KIpU4AUBiIhVr6YlHx/cnPgqEkNoVOhHg+YiSVxM1RLfiy4t9cAulbRGTNCKOcqHrEQLIw==}
-    engines: {node: '>=18'}
-    cpu: [riscv64]
-    os: [linux]
-
-  '@esbuild/linux-s390x@0.27.4':
-    resolution: {integrity: sha512-+eUqgb/Z7vxVLezG8bVB9SfBie89gMueS+I0xYh2tJdw3vqA/0ImZJ2ROeWwVJN59ihBeZ7Tu92dF/5dy5FttA==}
-    engines: {node: '>=18'}
-    cpu: [s390x]
-    os: [linux]
-
-  '@esbuild/linux-x64@0.27.4':
-    resolution: {integrity: sha512-S5qOXrKV8BQEzJPVxAwnryi2+Iq5pB40gTEIT69BQONqR7JH1EPIcQ/Uiv9mCnn05jff9umq/5nqzxlqTOg9NA==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [linux]
-
-  '@esbuild/netbsd-arm64@0.27.4':
-    resolution: {integrity: sha512-xHT8X4sb0GS8qTqiwzHqpY00C95DPAq7nAwX35Ie/s+LO9830hrMd3oX0ZMKLvy7vsonee73x0lmcdOVXFzd6Q==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [netbsd]
-
-  '@esbuild/netbsd-x64@0.27.4':
-    resolution: {integrity: sha512-RugOvOdXfdyi5Tyv40kgQnI0byv66BFgAqjdgtAKqHoZTbTF2QqfQrFwa7cHEORJf6X2ht+l9ABLMP0dnKYsgg==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [netbsd]
-
-  '@esbuild/openbsd-arm64@0.27.4':
-    resolution: {integrity: sha512-2MyL3IAaTX+1/qP0O1SwskwcwCoOI4kV2IBX1xYnDDqthmq5ArrW94qSIKCAuRraMgPOmG0RDTA74mzYNQA9ow==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [openbsd]
-
-  '@esbuild/openbsd-x64@0.27.4':
-    resolution: {integrity: sha512-u8fg/jQ5aQDfsnIV6+KwLOf1CmJnfu1ShpwqdwC0uA7ZPwFws55Ngc12vBdeUdnuWoQYx/SOQLGDcdlfXhYmXQ==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [openbsd]
-
-  '@esbuild/openharmony-arm64@0.27.4':
-    resolution: {integrity: sha512-JkTZrl6VbyO8lDQO3yv26nNr2RM2yZzNrNHEsj9bm6dOwwu9OYN28CjzZkH57bh4w0I2F7IodpQvUAEd1mbWXg==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [openharmony]
-
-  '@esbuild/sunos-x64@0.27.4':
-    resolution: {integrity: sha512-/gOzgaewZJfeJTlsWhvUEmUG4tWEY2Spp5M20INYRg2ZKl9QPO3QEEgPeRtLjEWSW8FilRNacPOg8R1uaYkA6g==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [sunos]
-
-  '@esbuild/win32-arm64@0.27.4':
-    resolution: {integrity: sha512-Z9SExBg2y32smoDQdf1HRwHRt6vAHLXcxD2uGgO/v2jK7Y718Ix4ndsbNMU/+1Qiem9OiOdaqitioZwxivhXYg==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [win32]
-
-  '@esbuild/win32-ia32@0.27.4':
-    resolution: {integrity: sha512-DAyGLS0Jz5G5iixEbMHi5KdiApqHBWMGzTtMiJ72ZOLhbu/bzxgAe8Ue8CTS3n3HbIUHQz/L51yMdGMeoxXNJw==}
-    engines: {node: '>=18'}
-    cpu: [ia32]
-    os: [win32]
-
-  '@esbuild/win32-x64@0.27.4':
-    resolution: {integrity: sha512-+knoa0BDoeXgkNvvV1vvbZX4+hizelrkwmGJBdT17t8FNPwG2lKemmuMZlmaNQ3ws3DKKCxpb4zRZEIp3UxFCg==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [win32]
 
   '@eslint-community/eslint-utils@4.9.1':
     resolution: {integrity: sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==}
@@ -574,6 +438,12 @@ packages:
   '@gwhitney/detect-indent@7.0.1':
     resolution: {integrity: sha512-7bQW+gkKa2kKZPeJf6+c6gFK9ARxQfn+FKy9ScTBppyKRWH2KzsmweXUoklqeEiHiNVWaeP5csIdsNq6w7QhzA==}
     engines: {node: '>=12.20'}
+
+  '@hono/node-server@1.19.11':
+    resolution: {integrity: sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g==}
+    engines: {node: '>=18.14.1'}
+    peerDependencies:
+      hono: ^4
 
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
@@ -629,23 +499,15 @@ packages:
   '@microsoft/tsdoc@0.16.0':
     resolution: {integrity: sha512-xgAyonlVVS+q7Vc7qLW0UrJU7rSFcETRWsqdXZtjzRU8dF+6CkozTK4V4y1LwOX7j8r/vHphjDeMeGI4tNGeGA==}
 
-  '@module-federation/error-codes@0.22.0':
-    resolution: {integrity: sha512-xF9SjnEy7vTdx+xekjPCV5cIHOGCkdn3pIxo9vU7gEZMIw0SvAEdsy6Uh17xaCpm8V0FWvR0SZoK9Ik6jGOaug==}
-
-  '@module-federation/runtime-core@0.22.0':
-    resolution: {integrity: sha512-GR1TcD6/s7zqItfhC87zAp30PqzvceoeDGYTgF3Vx2TXvsfDrhP6Qw9T4vudDQL3uJRne6t7CzdT29YyVxlgIA==}
-
-  '@module-federation/runtime-tools@0.22.0':
-    resolution: {integrity: sha512-4ScUJ/aUfEernb+4PbLdhM/c60VHl698Gn1gY21m9vyC1Ucn69fPCA1y2EwcCB7IItseRMoNhdcWQnzt/OPCNA==}
-
-  '@module-federation/runtime@0.22.0':
-    resolution: {integrity: sha512-38g5iPju2tPC3KHMPxRKmy4k4onNp6ypFPS1eKGsNLUkXgHsPMBFqAjDw96iEcjri91BrahG4XcdyKi97xZzlA==}
-
-  '@module-federation/sdk@0.22.0':
-    resolution: {integrity: sha512-x4aFNBKn2KVQRuNVC5A7SnrSCSqyfIWmm1DvubjbO9iKFe7ith5niw8dqSFBekYBg2Fwy+eMg4sEFNVvCAdo6g==}
-
-  '@module-federation/webpack-bundler-runtime@0.22.0':
-    resolution: {integrity: sha512-aM8gCqXu+/4wBmJtVeMeeMN5guw3chf+2i6HajKtQv7SJfxV/f4IyNQJUeUQu9HfiAZHjqtMV5Lvq/Lvh8LdyA==}
+  '@modelcontextprotocol/sdk@1.27.1':
+    resolution: {integrity: sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@cfworker/json-schema': ^4.1.1
+      zod: ^3.25 || ^4.0
+    peerDependenciesMeta:
+      '@cfworker/json-schema':
+        optional: true
 
   '@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.3':
     resolution: {integrity: sha512-QZHtlVgbAdy2zAqNA9Gu1UpIuI8Xvsd1v8ic6B2pZmeFnFcMWiPLfWXh7TVw4eGEZ/C9TH281KwhVoeQUKbyjw==}
@@ -680,6 +542,9 @@ packages:
   '@napi-rs/wasm-runtime@1.0.7':
     resolution: {integrity: sha512-SeDnOO0Tk7Okiq6DbXmmBODgOAb9dp9gjlphokTUxmt8U3liIP1ZsozBahH69j/RJv+Rfs6IwUKHTgQYJ/HBAw==}
 
+  '@napi-rs/wasm-runtime@1.1.1':
+    resolution: {integrity: sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A==}
+
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
     engines: {node: '>= 8'}
@@ -691,6 +556,9 @@ packages:
   '@nodelib/fs.walk@1.2.8':
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
+
+  '@oxc-project/types@0.122.0':
+    resolution: {integrity: sha512-oLAl5kBpV4w69UtFZ9xqcmTi+GENWOcPF7FCrczTiBbmC0ibXxCwyvZGbO39rCVEuLGAZM84DH0pUIyyv/YJzA==}
 
   '@parcel/watcher-android-arm64@2.5.6':
     resolution: {integrity: sha512-YQxSS34tPF/6ZG7r/Ih9xy+kP/WwediEUsqmtf0cuCV5TPPKw/PQHRhueUo6JdeFJaqV3pyjm0GdYjZotbRt/A==}
@@ -780,8 +648,8 @@ packages:
     resolution: {integrity: sha512-tmmZ3lQxAe/k/+rNnXQRawJ4NjxO2hqiOLTHvWchtGZULp4RyFeh6aU4XdOYBFe2KE1oShQTv4AblOs2iOrNnQ==}
     engines: {node: '>= 10.0.0'}
 
-  '@pnpm/catalogs.config@1000.0.5':
-    resolution: {integrity: sha512-PG8LEiI77kXULdwcq6p2uj4T1AjQ2sjBMiL6DHi2eZjGCSWgigoGCGzZ7Rkm2Y/hK0r6CyvbZozGjwjetSOIBA==}
+  '@pnpm/catalogs.config@1000.0.6':
+    resolution: {integrity: sha512-B/ZQj/pzHFgzkTKbP/8klI03bfimk0QdcG/fq7gQPqo2ExmbGeXEre4skZGyguhjp03xLr5/a4GNYSrLUsUUUQ==}
     engines: {node: '>=18.12'}
 
   '@pnpm/catalogs.protocol-parser@1001.0.0':
@@ -814,12 +682,12 @@ packages:
     resolution: {integrity: sha512-PNImtV2SmNTDpLi4HdN86tJPmsOeIxm4VhmxgBVsMrJPEBfkNEWFcflR3wU6XVn/26g9qWdvlNHaawtCjeB93Q==}
     engines: {node: '>=18.12'}
 
-  '@pnpm/error@1000.0.5':
-    resolution: {integrity: sha512-GjH0TPjbVNrPnl/BAGoFuBLJ2sFfXNKbS33lll/Ehe9yw0fyc8Kdw7kO9if37yQqn6vaa4dAHKkPllum7f/IPQ==}
+  '@pnpm/error@1000.1.0':
+    resolution: {integrity: sha512-Dqc2IJJPjUatwc9Letw+vG29rnaMrDGi5g6WCx1HiZYm0obXbTmLygeRafMbgf+sLKXrWE1shOeiayQuczBdoA==}
     engines: {node: '>=18.12'}
 
-  '@pnpm/exportable-manifest@1000.4.1':
-    resolution: {integrity: sha512-kZ5d6eiNNRqOHk/UPvcFUF8K79vf7WJ5MwJxRt3pkb1MR7//rQCeUG+qsb+fZZNwvamF/klanSaHVcywf8A6RA==}
+  '@pnpm/exportable-manifest@1000.4.2':
+    resolution: {integrity: sha512-rtUWmIKzloHwxgP16PYxTdr3+1lyuBH1JG5Gkgyca32dfmqy3Y55oEfkLywU2NYf/Zvk0C5gHaAMTFZOxuW8kg==}
     engines: {node: '>=18.12'}
 
   '@pnpm/git-utils@1000.0.0':
@@ -830,33 +698,33 @@ packages:
     resolution: {integrity: sha512-EsMX4slK0qJN2AR0/AYohY5m0HQNYGMNe+jhN74O994zp22/WbX+PbkIKyw3UQn39yQm2+z6SgwklDxbeapsmQ==}
     engines: {node: '>=18.12'}
 
-  '@pnpm/lockfile.fs@1001.1.31':
-    resolution: {integrity: sha512-0pafMSTWlu2NcDB92nvS8aIS/4MSFQq0qonslU4tk1IJe2D1QNMNERc3jgeOP52UJCHokgG+kEAtVezhDtQu5w==}
+  '@pnpm/lockfile.fs@1001.1.32':
+    resolution: {integrity: sha512-I+aHBjbgDy2Ftxla8FVZkx/ARuKOyGag1zaCuVuZDzH4Xb2ETUuTeGAf1GTr1XqM7UnCNse1GKgr5KZJ0cz43w==}
     engines: {node: '>=18.12'}
     peerDependencies:
-      '@pnpm/logger': '>=1001.0.0 <1002.0.0'
+      '@pnpm/logger': ^1001.0.1
 
-  '@pnpm/lockfile.merger@1001.0.19':
-    resolution: {integrity: sha512-YTnc4lcCGg1iK/+XFDyBnuZ+iR8VBCF9+F/k2Efy2XZhMK2eLUFeTHnjhXog6g/mjVEcUTvdFSNYvX0d1VkxFw==}
+  '@pnpm/lockfile.merger@1001.0.20':
+    resolution: {integrity: sha512-93MKB5fObr49PMRoDZVcUewe2uuR6TRj8In0y1CeXeDzXY1SPVKZsODCVvAA2z2UxZ1YXKcw9Oaak31E9ln5CQ==}
     engines: {node: '>=18.12'}
 
-  '@pnpm/lockfile.types@1002.0.9':
-    resolution: {integrity: sha512-cSdmJAXTab/hJz+RxvlZgWWZxFsP8rCbaUxSfgT7rwj6+1EFV9DcJYr4vh395Da5KgpIPxPceAs1iYO+5/MCqA==}
+  '@pnpm/lockfile.types@1002.1.0':
+    resolution: {integrity: sha512-Oa9Fhwo4Ipodj3hyUPC5wUt5ucVkuttyct2DbFUkB79Fq5HL9MHHQ+JFYh03eajmLqWrN1t8+6DbmcKqRtNjNg==}
     engines: {node: '>=18.12'}
 
-  '@pnpm/lockfile.utils@1004.0.2':
-    resolution: {integrity: sha512-nc1Z9TwEIz6/sUp9HN0fFwxVGr2Q8aXiSzBAo2EFShXptqNztbkhT3kNtrjuuEJ5OJA2bq7g4v5bAMwrxV/CkQ==}
+  '@pnpm/lockfile.utils@1004.0.3':
+    resolution: {integrity: sha512-02hFBFk/BGmZYhqd7paBjJm5mHy7GwI6DOJL25dakctRIPCr2kUZkPs/DH3WLKAjNLykEh7Dp/dPs5rnUsUE5g==}
     engines: {node: '>=18.12'}
 
   '@pnpm/logger@1001.0.1':
     resolution: {integrity: sha512-gdwlAMXC4Wc0s7Dmg/4wNybMEd/4lSd9LsXQxeg/piWY0PPXjgz1IXJWnVScx6dZRaaodWP3c1ornrw8mZdFZw==}
     engines: {node: '>=18.12'}
 
-  '@pnpm/manifest-utils@1002.0.4':
-    resolution: {integrity: sha512-0wRtGVvIHqnRKL2DeiktSNvbGiH/DZ2e/Wn+7BNN09zICTIcd9nhiFAepGrXd4bT3/ru6zJMwGGbvqEE/HtI+A==}
+  '@pnpm/manifest-utils@1002.0.5':
+    resolution: {integrity: sha512-2DSwQ6pP73IuJS5mCCtPd5fibJwuAdufXKuSL/Oq1n6AggCqy8616Xea1X3RH3z5dL4mn7Z4EZ+vnX8jX3Wrfw==}
     engines: {node: '>=18.12'}
     peerDependencies:
-      '@pnpm/logger': '>=1001.0.0 <1002.0.0'
+      '@pnpm/logger': ^1001.0.1
 
   '@pnpm/object.key-sorting@1000.0.1':
     resolution: {integrity: sha512-YTJCXyUGOrJuj4QqhSKqZa1vlVAm82h1/uw00ZmD/kL2OViggtyUwWyIe62kpwWVPwEYixfGjfvaFKVJy2mjzA==}
@@ -873,18 +741,18 @@ packages:
   '@pnpm/ramda@0.28.1':
     resolution: {integrity: sha512-zcAG+lvU0fMziNeGXpPyCyCJYp5ZVrPElEE4t14jAmViaihohocZ+dDkcRIyAomox8pQsuZnv1EyHR+pOhmUWw==}
 
-  '@pnpm/read-project-manifest@1001.2.5':
-    resolution: {integrity: sha512-5ob6p6D7vBpAAGtZpqPvqlvkJlDfugb8TWnQgRDiSYr4/o8nIiV2t1ejlp3f34b0E76SbsbBuIfrJCsHAqhkrw==}
+  '@pnpm/read-project-manifest@1001.2.6':
+    resolution: {integrity: sha512-BcNO50lAkE4m9JaJ0WmG3m/DH/qLSvMgZywtmb/dfyyLVu5nDZfDqmOd8U+f1NhLcLMbBK6AnS3hyUqZYvw9Vg==}
     engines: {node: '>=18.12'}
     peerDependencies:
-      '@pnpm/logger': '>=1001.0.0 <1002.0.0'
+      '@pnpm/logger': ^1001.0.1
 
   '@pnpm/resolver-base@1005.4.1':
     resolution: {integrity: sha512-47zGgACkbZWLOmM61kaE0nkqxiYx63C6DJ4wzDsdj0iXDZJ9SJEl+T035pkhquHe8XEh3YxvwMg2BRyZSgmZ9Q==}
     engines: {node: '>=18.12'}
 
-  '@pnpm/resolving.jsr-specifier-parser@1000.0.3':
-    resolution: {integrity: sha512-VaGXRwSez71iZ65nOat/B0oPViWyLzAdgAfNJjmt1eDoNZ0Npu+9lrI0ZNRVZ0NDH3U+TQ8LVesCZOdvr0+5SQ==}
+  '@pnpm/resolving.jsr-specifier-parser@1000.0.4':
+    resolution: {integrity: sha512-oxf+Y5lumvfNx9Igss/dvDb0t4iWtE0wjrmdDPFkVrXTlQbdWLujnyYSp3Obim/65K+r5RspoizJgjWJRe69nw==}
     engines: {node: '>=18.12'}
 
   '@pnpm/semver.peer-range@1000.0.0':
@@ -903,160 +771,125 @@ packages:
     resolution: {integrity: sha512-blFO4Ws97tWv/SNE6N39ZdGmZBrocXnBOfVp0ln4kELmns4pGPZizqyRtR8EjfOLMLstbmNCTReBoDvLz1isVg==}
     engines: {node: '>=18.12'}
 
-  '@pnpm/workspace.read-manifest@1000.3.0':
-    resolution: {integrity: sha512-aBTT6pViHvR+ARJYpMpxbs5+OcIq/9HKQLvYxyTm6ozoRoVgrNogWTRNDnnQptc02h1EvdVSoR36cCB+aoKkLw==}
+  '@pnpm/workspace.read-manifest@1000.3.1':
+    resolution: {integrity: sha512-ojO1Anf4ITL7OskuUYoLI3bldQ36XNLpG2cYQZ4F6LZbBZnRY8umW6TeWzb9h/aX8UFwYp9vWbQ8R/FaMtMEeg==}
     engines: {node: '>=18.12'}
 
   '@pnpm/write-project-manifest@1000.0.16':
     resolution: {integrity: sha512-zG68fk03ryot7TWUl9S/ShQ91uHWzIL9sVr2aQCuNHJo8G9kjsG6S0p58Zj/voahdDQeakZYYBSJ0mjNZeiJnw==}
     engines: {node: '>=18.12'}
 
-  '@rollup/rollup-android-arm-eabi@4.59.0':
-    resolution: {integrity: sha512-upnNBkA6ZH2VKGcBj9Fyl9IGNPULcjXRlg0LLeaioQWueH30p6IXtJEbKAgvyv+mJaMxSm1l6xwDXYjpEMiLMg==}
-    cpu: [arm]
-    os: [android]
-
-  '@rollup/rollup-android-arm64@4.59.0':
-    resolution: {integrity: sha512-hZ+Zxj3SySm4A/DylsDKZAeVg0mvi++0PYVceVyX7hemkw7OreKdCvW2oQ3T1FMZvCaQXqOTHb8qmBShoqk69Q==}
+  '@rolldown/binding-android-arm64@1.0.0-rc.11':
+    resolution: {integrity: sha512-SJ+/g+xNnOh6NqYxD0V3uVN4W3VfnrGsC9/hoglicgTNfABFG9JjISvkkU0dNY84MNHLWyOgxP9v9Y9pX4S7+A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [android]
 
-  '@rollup/rollup-darwin-arm64@4.59.0':
-    resolution: {integrity: sha512-W2Psnbh1J8ZJw0xKAd8zdNgF9HRLkdWwwdWqubSVk0pUuQkoHnv7rx4GiF9rT4t5DIZGAsConRE3AxCdJ4m8rg==}
+  '@rolldown/binding-darwin-arm64@1.0.0-rc.11':
+    resolution: {integrity: sha512-7WQgR8SfOPwmDZGFkThUvsmd/nwAWv91oCO4I5LS7RKrssPZmOt7jONN0cW17ydGC1n/+puol1IpoieKqQidmg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [darwin]
 
-  '@rollup/rollup-darwin-x64@4.59.0':
-    resolution: {integrity: sha512-ZW2KkwlS4lwTv7ZVsYDiARfFCnSGhzYPdiOU4IM2fDbL+QGlyAbjgSFuqNRbSthybLbIJ915UtZBtmuLrQAT/w==}
+  '@rolldown/binding-darwin-x64@1.0.0-rc.11':
+    resolution: {integrity: sha512-39Ks6UvIHq4rEogIfQBoBRusj0Q0nPVWIvqmwBLaT6aqQGIakHdESBVOPRRLacy4WwUPIx4ZKzfZ9PMW+IeyUQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [darwin]
 
-  '@rollup/rollup-freebsd-arm64@4.59.0':
-    resolution: {integrity: sha512-EsKaJ5ytAu9jI3lonzn3BgG8iRBjV4LxZexygcQbpiU0wU0ATxhNVEpXKfUa0pS05gTcSDMKpn3Sx+QB9RlTTA==}
-    cpu: [arm64]
-    os: [freebsd]
-
-  '@rollup/rollup-freebsd-x64@4.59.0':
-    resolution: {integrity: sha512-d3DuZi2KzTMjImrxoHIAODUZYoUUMsuUiY4SRRcJy6NJoZ6iIqWnJu9IScV9jXysyGMVuW+KNzZvBLOcpdl3Vg==}
+  '@rolldown/binding-freebsd-x64@1.0.0-rc.11':
+    resolution: {integrity: sha512-jfsm0ZHfhiqrvWjJAmzsqiIFPz5e7mAoCOPBNTcNgkiid/LaFKiq92+0ojH+nmJmKYkre4t71BWXUZDNp7vsag==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [freebsd]
 
-  '@rollup/rollup-linux-arm-gnueabihf@4.59.0':
-    resolution: {integrity: sha512-t4ONHboXi/3E0rT6OZl1pKbl2Vgxf9vJfWgmUoCEVQVxhW6Cw/c8I6hbbu7DAvgp82RKiH7TpLwxnJeKv2pbsw==}
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.11':
+    resolution: {integrity: sha512-zjQaUtSyq1nVe3nxmlSCuR96T1LPlpvmJ0SZy0WJFEsV4kFbXcq2u68L4E6O0XeFj4aex9bEauqjW8UQBeAvfQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
-  '@rollup/rollup-linux-arm-musleabihf@4.59.0':
-    resolution: {integrity: sha512-CikFT7aYPA2ufMD086cVORBYGHffBo4K8MQ4uPS/ZnY54GKj36i196u8U+aDVT2LX4eSMbyHtyOh7D7Zvk2VvA==}
-    cpu: [arm]
-    os: [linux]
-    libc: [musl]
-
-  '@rollup/rollup-linux-arm64-gnu@4.59.0':
-    resolution: {integrity: sha512-jYgUGk5aLd1nUb1CtQ8E+t5JhLc9x5WdBKew9ZgAXg7DBk0ZHErLHdXM24rfX+bKrFe+Xp5YuJo54I5HFjGDAA==}
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.11':
+    resolution: {integrity: sha512-WMW1yE6IOnehTcFE9eipFkm3XN63zypWlrJQ2iF7NrQ9b2LDRjumFoOGJE8RJJTJCTBAdmLMnJ8uVitACUUo1Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@rollup/rollup-linux-arm64-musl@4.59.0':
-    resolution: {integrity: sha512-peZRVEdnFWZ5Bh2KeumKG9ty7aCXzzEsHShOZEFiCQlDEepP1dpUl/SrUNXNg13UmZl+gzVDPsiCwnV1uI0RUA==}
+  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.11':
+    resolution: {integrity: sha512-jfndI9tsfm4APzjNt6QdBkYwre5lRPUgHeDHoI7ydKUuJvz3lZeCfMsI56BZj+7BYqiKsJm7cfd/6KYV7ubrBg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@rollup/rollup-linux-loong64-gnu@4.59.0':
-    resolution: {integrity: sha512-gbUSW/97f7+r4gHy3Jlup8zDG190AuodsWnNiXErp9mT90iCy9NKKU0Xwx5k8VlRAIV2uU9CsMnEFg/xXaOfXg==}
-    cpu: [loong64]
-    os: [linux]
-    libc: [glibc]
-
-  '@rollup/rollup-linux-loong64-musl@4.59.0':
-    resolution: {integrity: sha512-yTRONe79E+o0FWFijasoTjtzG9EBedFXJMl888NBEDCDV9I2wGbFFfJQQe63OijbFCUZqxpHz1GzpbtSFikJ4Q==}
-    cpu: [loong64]
-    os: [linux]
-    libc: [musl]
-
-  '@rollup/rollup-linux-ppc64-gnu@4.59.0':
-    resolution: {integrity: sha512-sw1o3tfyk12k3OEpRddF68a1unZ5VCN7zoTNtSn2KndUE+ea3m3ROOKRCZxEpmT9nsGnogpFP9x6mnLTCaoLkA==}
+  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.11':
+    resolution: {integrity: sha512-ZlFgw46NOAGMgcdvdYwAGu2Q+SLFA9LzbJLW+iyMOJyhj5wk6P3KEE9Gct4xWwSzFoPI7JCdYmYMzVtlgQ+zfw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
     libc: [glibc]
 
-  '@rollup/rollup-linux-ppc64-musl@4.59.0':
-    resolution: {integrity: sha512-+2kLtQ4xT3AiIxkzFVFXfsmlZiG5FXYW7ZyIIvGA7Bdeuh9Z0aN4hVyXS/G1E9bTP/vqszNIN/pUKCk/BTHsKA==}
-    cpu: [ppc64]
-    os: [linux]
-    libc: [musl]
-
-  '@rollup/rollup-linux-riscv64-gnu@4.59.0':
-    resolution: {integrity: sha512-NDYMpsXYJJaj+I7UdwIuHHNxXZ/b/N2hR15NyH3m2qAtb/hHPA4g4SuuvrdxetTdndfj9b1WOmy73kcPRoERUg==}
-    cpu: [riscv64]
-    os: [linux]
-    libc: [glibc]
-
-  '@rollup/rollup-linux-riscv64-musl@4.59.0':
-    resolution: {integrity: sha512-nLckB8WOqHIf1bhymk+oHxvM9D3tyPndZH8i8+35p/1YiVoVswPid2yLzgX7ZJP0KQvnkhM4H6QZ5m0LzbyIAg==}
-    cpu: [riscv64]
-    os: [linux]
-    libc: [musl]
-
-  '@rollup/rollup-linux-s390x-gnu@4.59.0':
-    resolution: {integrity: sha512-oF87Ie3uAIvORFBpwnCvUzdeYUqi2wY6jRFWJAy1qus/udHFYIkplYRW+wo+GRUP4sKzYdmE1Y3+rY5Gc4ZO+w==}
+  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.11':
+    resolution: {integrity: sha512-hIOYmuT6ofM4K04XAZd3OzMySEO4K0/nc9+jmNcxNAxRi6c5UWpqfw3KMFV4MVFWL+jQsSh+bGw2VqmaPMTLyw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
     libc: [glibc]
 
-  '@rollup/rollup-linux-x64-gnu@4.59.0':
-    resolution: {integrity: sha512-3AHmtQq/ppNuUspKAlvA8HtLybkDflkMuLK4DPo77DfthRb71V84/c4MlWJXixZz4uruIH4uaa07IqoAkG64fg==}
+  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.11':
+    resolution: {integrity: sha512-qXBQQO9OvkjjQPLdUVr7Nr2t3QTZI7s4KZtfw7HzBgjbmAPSFwSv4rmET9lLSgq3rH/ndA3ngv3Qb8l2njoPNA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@rollup/rollup-linux-x64-musl@4.59.0':
-    resolution: {integrity: sha512-2UdiwS/9cTAx7qIUZB/fWtToJwvt0Vbo0zmnYt7ED35KPg13Q0ym1g442THLC7VyI6JfYTP4PiSOWyoMdV2/xg==}
+  '@rolldown/binding-linux-x64-musl@1.0.0-rc.11':
+    resolution: {integrity: sha512-/tpFfoSTzUkH9LPY+cYbqZBDyyX62w5fICq9qzsHLL8uTI6BHip3Q9Uzft0wylk/i8OOwKik8OxW+QAhDmzwmg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@rollup/rollup-openbsd-x64@4.59.0':
-    resolution: {integrity: sha512-M3bLRAVk6GOwFlPTIxVBSYKUaqfLrn8l0psKinkCFxl4lQvOSz8ZrKDz2gxcBwHFpci0B6rttydI4IpS4IS/jQ==}
-    cpu: [x64]
-    os: [openbsd]
-
-  '@rollup/rollup-openharmony-arm64@4.59.0':
-    resolution: {integrity: sha512-tt9KBJqaqp5i5HUZzoafHZX8b5Q2Fe7UjYERADll83O4fGqJ49O1FsL6LpdzVFQcpwvnyd0i+K/VSwu/o/nWlA==}
+  '@rolldown/binding-openharmony-arm64@1.0.0-rc.11':
+    resolution: {integrity: sha512-mcp3Rio2w72IvdZG0oQ4bM2c2oumtwHfUfKncUM6zGgz0KgPz4YmDPQfnXEiY5t3+KD/i8HG2rOB/LxdmieK2g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [openharmony]
 
-  '@rollup/rollup-win32-arm64-msvc@4.59.0':
-    resolution: {integrity: sha512-V5B6mG7OrGTwnxaNUzZTDTjDS7F75PO1ae6MJYdiMu60sq0CqN5CVeVsbhPxalupvTX8gXVSU9gq+Rx1/hvu6A==}
+  '@rolldown/binding-wasm32-wasi@1.0.0-rc.11':
+    resolution: {integrity: sha512-LXk5Hii1Ph9asuGRjBuz8TUxdc1lWzB7nyfdoRgI0WGPZKmCxvlKk8KfYysqtr4MfGElu/f/pEQRh8fcEgkrWw==}
+    engines: {node: '>=14.0.0'}
+    cpu: [wasm32]
+
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.11':
+    resolution: {integrity: sha512-dDwf5otnx0XgRY1yqxOC4ITizcdzS/8cQ3goOWv3jFAo4F+xQYni+hnMuO6+LssHHdJW7+OCVL3CoU4ycnh35Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [win32]
 
-  '@rollup/rollup-win32-ia32-msvc@4.59.0':
-    resolution: {integrity: sha512-UKFMHPuM9R0iBegwzKF4y0C4J9u8C6MEJgFuXTBerMk7EJ92GFVFYBfOZaSGLu6COf7FxpQNqhNS4c4icUPqxA==}
-    cpu: [ia32]
-    os: [win32]
-
-  '@rollup/rollup-win32-x64-gnu@4.59.0':
-    resolution: {integrity: sha512-laBkYlSS1n2L8fSo1thDNGrCTQMmxjYY5G0WFWjFFYZkKPjsMBsgJfGf4TLxXrF6RyhI60L8TMOjBMvXiTcxeA==}
+  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.11':
+    resolution: {integrity: sha512-LN4/skhSggybX71ews7dAj6r2geaMJfm3kMbK2KhFMg9B10AZXnKoLCVVgzhMHL0S+aKtr4p8QbAW8k+w95bAA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
 
-  '@rollup/rollup-win32-x64-msvc@4.59.0':
-    resolution: {integrity: sha512-2HRCml6OztYXyJXAvdDXPKcawukWY2GpR5/nxKp4iBgiO3wcoEGkAaqctIbZcNB6KlUQBIqt8VYkNSj2397EfA==}
-    cpu: [x64]
-    os: [win32]
+  '@rolldown/pluginutils@1.0.0-rc.11':
+    resolution: {integrity: sha512-xQO9vbwBecJRv9EUcQ/y0dzSTJgA7Q6UVN7xp6B81+tBGSLVAK03yJ9NkJaUA7JFD91kbjxRSC/mDnmvXzbHoQ==}
 
-  '@rsbuild/core@1.7.3':
-    resolution: {integrity: sha512-kI1oQvCXbQYxUvQPnDLdjSX4gFsbrFNpuUj6jXEJ7IcJ74Q+n4oeFj74/8tKerhxhe0L90m/ZQfzLeN5ORGA9w==}
-    engines: {node: '>=18.12.0'}
+  '@rsbuild/core@2.0.0-beta.8':
+    resolution: {integrity: sha512-MUxbKJPE1agOK3eCHjKvBIiA+CcZ0TJU/ANKDBLMjK2Er+wq4r5c2ne53+Pi7DtIExoMbSSWBx+RP3CMewKGVA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
+    peerDependencies:
+      core-js: '>= 3.0.0'
+    peerDependenciesMeta:
+      core-js:
+        optional: true
 
-  '@rslib/core@0.19.6':
-    resolution: {integrity: sha512-/znUZlPX252DhAf2WvzmkZ2rBi85d8TadkABYvWoUGAVGsmFOiX+anDwLOqQ+7m5KsMFzM/SCqB2yEBvAj/T2g==}
-    engines: {node: '>=18.12.0'}
+  '@rslib/core@0.20.0':
+    resolution: {integrity: sha512-hsRwjMbBla8lyKIVR0gFsK5M3j+LSbFOTafvbT0QR90ehZXwlu+EhpHJv8v/uIRT50RVlgCrcT+LCVr1oU3pbA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
       '@microsoft/api-extractor': ^7
@@ -1067,73 +900,73 @@ packages:
       typescript:
         optional: true
 
-  '@rspack/binding-darwin-arm64@1.7.8':
-    resolution: {integrity: sha512-KS6SRc+4VYRdX1cKr1j1HEuMNyEzt7onBS0rkenaiCRRYF0z4WNZNyZqRiuxgM3qZ3TISF7gdmgJQyd4ZB43ig==}
+  '@rspack/binding-darwin-arm64@2.0.0-beta.6':
+    resolution: {integrity: sha512-FQ8zflthQJJf0cM0vDFnfnXrTOnRvwz886tiafbwu1RO5qmh+pJH+xg1eQaLPnRPqLTlcmnpngyacYFUxw+1AA==}
     cpu: [arm64]
     os: [darwin]
 
-  '@rspack/binding-darwin-x64@1.7.8':
-    resolution: {integrity: sha512-uyXSDKLg2CtqIJrsJDlCqQH80YIPsCUiTToJ59cXAG3v4eke0Qbiv6d/+pV0h/mc0u4inAaSkr5dD18zkMIghw==}
+  '@rspack/binding-darwin-x64@2.0.0-beta.6':
+    resolution: {integrity: sha512-Cr4P19anOIaHtK8Z20Hl12PPUcs3LM24ZSQPfs0gPS0etzSOE4JRsqW/79GnnjZd/A+Wola/dZcnMVS44e3c3A==}
     cpu: [x64]
     os: [darwin]
 
-  '@rspack/binding-linux-arm64-gnu@1.7.8':
-    resolution: {integrity: sha512-dD6gSHA18Uj0eqc1FCwwQ5IO5mIckrpYN4H4kPk9Pjau+1mxWvC4y5Lryz1Z8P/Rh1lnQ/wwGE0XL9nd80+LqQ==}
+  '@rspack/binding-linux-arm64-gnu@2.0.0-beta.6':
+    resolution: {integrity: sha512-MgTzspaj3v9/4T3KQ/fRuj+cit3BnEcgFe4OP+BvUWlTQvxlckDWpDymVhPuIqpx7pJvLcXwdz8mQhvZ87AD5g==}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@rspack/binding-linux-arm64-musl@1.7.8':
-    resolution: {integrity: sha512-m+uBi9mEVGkZ02PPOAYN2BSmmvc00XGa6v9CjV8qLpolpUXQIMzDNG+i1fD5SHp8LO+XWsZJOHypMsT0MzGTGw==}
+  '@rspack/binding-linux-arm64-musl@2.0.0-beta.6':
+    resolution: {integrity: sha512-5vyjbrj3u8x4Crb77QvFJSZkq7QwOuVJff8oStbS/v7cC+NEAQQYB/6Bl0JwyDFAcMMX8ZRyaDjc1o1qQ0Q31g==}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@rspack/binding-linux-x64-gnu@1.7.8':
-    resolution: {integrity: sha512-IAPp2L3yS33MAEkcGn/I1gO+a+WExJHXz2ZlRlL2oFCUGpYi2ZQHyAcJ3o2tJqkXmdqsTiN+OjEVMd/RcLa24g==}
+  '@rspack/binding-linux-x64-gnu@2.0.0-beta.6':
+    resolution: {integrity: sha512-GmNJgFHoK5LFQ2m96HrXIgf1zZNe+4yaaOD/5qqcI163QXRqRflfZprmdr2L4R6VsU2i+YQ2Ap2s20Y/zSt6RQ==}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@rspack/binding-linux-x64-musl@1.7.8':
-    resolution: {integrity: sha512-do/QNzb4GWdXCsipblDcroqRDR3BFcbyzpZpAw/3j9ajvEqsOKpdHZpILT2NZX/VahhjqfqB3k0kJVt3uK7UYQ==}
+  '@rspack/binding-linux-x64-musl@2.0.0-beta.6':
+    resolution: {integrity: sha512-tI2S3v8yXel5GL3yPnBNnFZ/dye4TyRM2j7mfJ49M6uTWjfRFyAcuxqw7z9Pyvyhsc1AoOnnXejtqqJpZkBQoA==}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@rspack/binding-wasm32-wasi@1.7.8':
-    resolution: {integrity: sha512-mHtgYTpdhx01i0XNKFYBZyCjtv9YUe/sDfpD1QK4FytPFB+1VpYnmZiaJIMM77VpNsjxGAqWhmUYxi2P6jWifw==}
+  '@rspack/binding-wasm32-wasi@2.0.0-beta.6':
+    resolution: {integrity: sha512-Bv9o1zZIDTOzjbliyAwMOGjsL6wiGIPRttJ9CLsdRoKI5XcMTEFHjwlnm1Zs4/EP+zC+bTgseq1EFngIy+nZRg==}
     cpu: [wasm32]
 
-  '@rspack/binding-win32-arm64-msvc@1.7.8':
-    resolution: {integrity: sha512-Mkxg86F7kIT4pM9XvE/1LAGjK5NOQi/GJxKyyiKbUAeKM8XBUizVeNuvKR0avf2V5IDAIRXiH1SX8SpujMJteA==}
+  '@rspack/binding-win32-arm64-msvc@2.0.0-beta.6':
+    resolution: {integrity: sha512-R/j0VTVKn3gU4a0xKAXJUX6jzmanHsuBHtLSpgnRqKW/20csFzsnsqY9PxaiAObTHVPMCrNvTG5KXHYIqYgACg==}
     cpu: [arm64]
     os: [win32]
 
-  '@rspack/binding-win32-ia32-msvc@1.7.8':
-    resolution: {integrity: sha512-VmTOZ/X7M85lKFNwb2qJpCRzr4SgO42vucq/X7Uz1oSoTPAf8UUMNdi7BPnu+D4lgy6l8PwV804ZyHO3gGsvPA==}
+  '@rspack/binding-win32-ia32-msvc@2.0.0-beta.6':
+    resolution: {integrity: sha512-v3Gc+gRFTBNLSmyHAgI6mE30W94T0g8jD7S1qamUfX6i50YjDylyiMG1prG/8i/YVNWQynQeQi4Cjfg+Hi7alQ==}
     cpu: [ia32]
     os: [win32]
 
-  '@rspack/binding-win32-x64-msvc@1.7.8':
-    resolution: {integrity: sha512-BK0I4HAwp/yQLnmdJpUtGHcht3x11e9fZwyaiMzznznFc+Oypbf+FS5h+aBgpb53QnNkPpdG7MfAPoKItOcU8A==}
+  '@rspack/binding-win32-x64-msvc@2.0.0-beta.6':
+    resolution: {integrity: sha512-PjaKOG2rQqzOwsmu03EAyTb7oA52CrO1I8JXiBT07adrDysHvKV/Gi+P0XPuDLDMnxNpndoGJMmvfxsymRpwyA==}
     cpu: [x64]
     os: [win32]
 
-  '@rspack/binding@1.7.8':
-    resolution: {integrity: sha512-P4fbrQx5hRhAiC8TBTEMCTnNawrIzJLjWwAgrTwRxjgenpjNvimEkQBtSGrXOY+c+MV5Q74P+9wPvVWLKzRkQQ==}
+  '@rspack/binding@2.0.0-beta.6':
+    resolution: {integrity: sha512-oJytPDJT57cz2is0e/e1myWVNxn+ZcII1/fF2Y3TiXVUIihLC/KDm6ISTgaZKr8ZyjTlVIV3V4wSO7IHlYV6aw==}
 
-  '@rspack/core@1.7.8':
-    resolution: {integrity: sha512-kT6yYo8xjKoDfM7iB8N9AmN9DJIlrs7UmQDbpTu1N4zaZocN1/t2fIAWOKjr5+3eJlZQR2twKZhDVHNLbLPjOw==}
-    engines: {node: '>=18.12.0'}
+  '@rspack/core@2.0.0-beta.6':
+    resolution: {integrity: sha512-dvi10ijR9Rr0W75GRFqWvswAEdLBsbXCGhxzm6zXxFNSanNL9s9xPelZ8XfnIU13QZkN2VNHGl9O/8KQEmYdEw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     peerDependencies:
+      '@module-federation/runtime-tools': ^0.24.1 || ^2.0.0
       '@swc/helpers': '>=0.5.1'
     peerDependenciesMeta:
+      '@module-federation/runtime-tools':
+        optional: true
       '@swc/helpers':
         optional: true
-
-  '@rspack/lite-tapable@1.1.0':
-    resolution: {integrity: sha512-E2B0JhYFmVAwdDiG14+DW0Di4Ze4Jg10Pc4/lILUrd5DRCaklduz2OvJ5HYQ6G+hd+WTzqQb3QnDNfK4yvAFYw==}
 
   '@rushstack/node-core-library@5.20.3':
     resolution: {integrity: sha512-95JgEPq2k7tHxhF9/OJnnyHDXfC9cLhhta0An/6MlkDsX2A6dTzDrTUG18vx4vjc280V0fi0xDH9iQczpSuWsw==}
@@ -1165,15 +998,15 @@ packages:
   '@rushstack/ts-command-line@5.3.3':
     resolution: {integrity: sha512-c+ltdcvC7ym+10lhwR/vWiOhsrm/bP3By2VsFcs5qTKv+6tTmxgbVrtJ5NdNjANiV5TcmOZgUN+5KYQ4llsvEw==}
 
-  '@savvy-web/changesets@0.5.1':
-    resolution: {integrity: sha512-YjCPvhlQUSZ6gBfHrCNCS0TgR76YKx3jp3ArxOPzl85IaXCsapnHxRwgI9KRTO0c0DIgCar+OcDsXCovkIiDsA==}
+  '@savvy-web/changesets@0.6.0':
+    resolution: {integrity: sha512-3CJi5Wubyeq+9AqgWSDwNiIRkul9IMzaiNA8aCAEsR9myM0ExCrm1zAFx+cnG0jrUFyhvZN+9MzSER6xJYGcUQ==}
     engines: {node: '>=24.0.0'}
     hasBin: true
     peerDependencies:
       '@changesets/cli': ^2.30.0
 
-  '@savvy-web/commitlint@0.4.1':
-    resolution: {integrity: sha512-sRSZoathZlbQq3SJXpBp4+kVei35XM57zXXFgQfZgA207PiePos1mgfImI/CagBaTLVI3yB3TPhwTGcnDlLuUQ==}
+  '@savvy-web/commitlint@0.4.3':
+    resolution: {integrity: sha512-yhmyKzgK4kyb1aulh/dzsBAEl5cmCXVYzfRNkphCRAlnpzgQEbTpUv6LhgKBeCqmgoIShiTlhunrxJjJlvlPow==}
     hasBin: true
     peerDependencies:
       '@commitlint/cli': ^20.4.3
@@ -1184,42 +1017,55 @@ packages:
       commitizen:
         optional: true
 
-  '@savvy-web/lint-staged@0.5.2':
-    resolution: {integrity: sha512-RG/nVZDz/wAJwVZAdBcfrKdzKR1vNPsRl6iL9A4lXTJ9Mk5b3S5zTo9Iq33VQSTnv05O3oMXwNLy5A5BVRrAMA==}
+  '@savvy-web/lint-staged@0.6.2':
+    resolution: {integrity: sha512-nhXpNZ3hCo/2g1J4FxwAf+Kn0bPb5Z2UXrvaFlIhm5xjQZVGLJxJ90ilBzC1idTOnZCBo8rOyGukkZnTVikaJg==}
     engines: {node: '>=24.0.0'}
     hasBin: true
     peerDependencies:
       '@biomejs/biome': 2.4.5
-      '@types/node': ^25.2.0
+      '@types/node': ^25.5.0
       '@typescript/native-preview': ^7.0.0-dev.20260124.1
       husky: ^9.1.0
-      lint-staged: ^16.3.2
-      markdownlint-cli2: ^0.21.0
+      lint-staged: ^16.4.0
+      markdownlint-cli2: ^0.22.0
       markdownlint-cli2-formatter-codequality: ^0.0.7
-      turbo: ^2.8.13
+      turbo: ^2.8.20
       typescript: ^5.9.3
     peerDependenciesMeta:
       '@biomejs/biome':
         optional: true
 
-  '@savvy-web/rslib-builder@0.18.1':
-    resolution: {integrity: sha512-aqaeAGhVd0zUYxLduzSLCDG6y5Rn+PR+0WBkIof6JCJHe9GLblGQPoim/ncSw3rc5XA4uUi6cIH/4oJd0xHkQA==}
-    engines: {node: '>=24.0.0'}
+  '@savvy-web/rslib-builder@0.19.0':
+    resolution: {integrity: sha512-DzCZiaH4+5scSXpOjEe79cJhxPSGnmWEQEtxOLnsTdLMML4buft+q0XL3jDl/kSCV4//UkG565D6eSSne46dbw==}
     peerDependencies:
-      '@microsoft/api-extractor': ^7.57.6
-      '@rslib/core': ^0.19.6
+      '@microsoft/api-extractor': ^7.57.7
+      '@rsbuild/plugin-react': ^1.4.0
+      '@rslib/core': ^0.20.0
       '@types/node': ^25.2.0
+      '@types/react': ^19.0.0
       '@typescript/native-preview': ^7.0.0-dev.20260124.1
+      react: ^19.0.0
+      react-dom: ^19.0.0
       typescript: ^5.9.3
+    peerDependenciesMeta:
+      '@rsbuild/plugin-react':
+        optional: true
+      '@types/react':
+        optional: true
+      react:
+        optional: true
+      react-dom:
+        optional: true
 
-  '@savvy-web/vitest@0.2.1':
-    resolution: {integrity: sha512-wjFWBrRnYNX5aVRb95O/dlke137QEwKwpsmIgijtcT/vqf3URaDKZwzXFgN2pj+KvJtfDIgBojA19/nyP3dSnw==}
+  '@savvy-web/vitest@1.0.0':
+    resolution: {integrity: sha512-HJFXGf5bSODD674919eInpz+x0nWvx494f6jPSTHs8xat/GbaJuiwHTqApgXXq/DM5bO9Hk8lsbhX7bYkmkFlA==}
     peerDependencies:
-      '@types/node': ^25.2.0
+      '@types/node': ^25.5.0
       '@typescript/native-preview': ^7.0.0-dev.20260124.1
-      '@vitest/coverage-v8': ^4.0.18
+      '@vitest/coverage-v8': ^4.1.0
       typescript: ^5.9.3
-      vitest: ^4.0.18
+      vitest: ^4.1.0
+      vitest-agent-reporter: ^1.0.0
 
   '@simple-libs/child-process-utils@1.0.2':
     resolution: {integrity: sha512-/4R8QKnd/8agJynkNdJmNw2MBxuFTRcNFnE5Sg/G+jkSsV8/UBgULMzhizWWW42p8L5H7flImV2ATi79Ove2Tw==}
@@ -1239,6 +1085,42 @@ packages:
   '@swc/helpers@0.5.19':
     resolution: {integrity: sha512-QamiFeIK3txNjgUTNppE6MiG3p7TdninpZu0E0PbqVh1a9FNLT2FRhisaa4NcaX52XVhA5l7Pk58Ft7Sqi/2sA==}
 
+  '@trpc/server@11.15.0':
+    resolution: {integrity: sha512-qLcodARy05fzMSrNG6VYtynsAmUCRaQ7SDm3Ynvryhylp2Zq4KN28qJeMlMqLeJKwZ05KukkcIsVTKzscWX1pQ==}
+    hasBin: true
+    peerDependencies:
+      typescript: '>=5.7.2'
+
+  '@turbo/darwin-64@2.8.20':
+    resolution: {integrity: sha512-FQ9EX1xMU5nbwjxXxM3yU88AQQ6Sqc6S44exPRroMcx9XZHqqppl5ymJF0Ig/z3nvQNwDmz1Gsnvxubo+nXWjQ==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@turbo/darwin-arm64@2.8.20':
+    resolution: {integrity: sha512-Gpyh9ATFGThD6/s9L95YWY54cizg/VRWl2B67h0yofG8BpHf67DFAh9nuJVKG7bY0+SBJDAo5cMur+wOl9YOYw==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@turbo/linux-64@2.8.20':
+    resolution: {integrity: sha512-p2QxWUYyYUgUFG0b0kR+pPi8t7c9uaVlRtjTTI1AbCvVqkpjUfCcReBn6DgG/Hu8xrWdKLuyQFaLYFzQskZbcA==}
+    cpu: [x64]
+    os: [linux]
+
+  '@turbo/linux-arm64@2.8.20':
+    resolution: {integrity: sha512-Gn5yjlZGLRZWarLWqdQzv0wMqyBNIdq1QLi48F1oY5Lo9kiohuf7BPQWtWxeNVS2NgJ1+nb/DzK1JduYC4AWOA==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@turbo/windows-64@2.8.20':
+    resolution: {integrity: sha512-vyaDpYk/8T6Qz5V/X+ihKvKFEZFUoC0oxYpC1sZanK6gaESJlmV3cMRT3Qhcg4D2VxvtC2Jjs9IRkrZGL+exLw==}
+    cpu: [x64]
+    os: [win32]
+
+  '@turbo/windows-arm64@2.8.20':
+    resolution: {integrity: sha512-voicVULvUV5yaGXo0Iue13BcHGYW3u0VgqSbfQwBaHbpj1zLjYV4KIe+7fYIo6DO8FVUJzxFps3ODCQG/Wy2Qw==}
+    cpu: [arm64]
+    os: [win32]
+
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
 
@@ -1248,8 +1130,8 @@ packages:
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
 
-  '@types/debug@4.1.12':
-    resolution: {integrity: sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==}
+  '@types/debug@4.1.13':
+    resolution: {integrity: sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==}
 
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
@@ -1275,8 +1157,8 @@ packages:
   '@types/node@12.20.55':
     resolution: {integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==}
 
-  '@types/node@25.4.0':
-    resolution: {integrity: sha512-9wLpoeWuBlcbBpOY3XmzSTG3oscB6xjBEEtn+pYXTfhyXhIxC5FsBer2KTopBlvKEiW9l13po9fq+SJY/5lkhw==}
+  '@types/node@25.5.0':
+    resolution: {integrity: sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==}
 
   '@types/parse-path@7.1.0':
     resolution: {integrity: sha512-EULJ8LApcVEPbrfND0cRQqutIOdiIgJ1Mgrhpy755r14xMohPTEpkV/k28SJvuOs9bHRFW8x+KeDAEPiGQPB9Q==}
@@ -1288,8 +1170,8 @@ packages:
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
 
-  '@typescript-eslint/parser@8.57.0':
-    resolution: {integrity: sha512-XZzOmihLIr8AD1b9hL9ccNMzEMWt/dE2u7NyTY9jJG6YNiNthaD5XtUHVF2uCXZ15ng+z2hT3MVuxnUYhq6k1g==}
+  '@typescript-eslint/parser@8.57.2':
+    resolution: {integrity: sha512-30ScMRHIAD33JJQkgfGW1t8CURZtjc2JpTrq5n2HFhOefbAhb7ucc7xJwdWcrEtqUIYJ73Nybpsggii6GtAHjA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
@@ -1301,8 +1183,8 @@ packages:
     peerDependencies:
       typescript: '>=4.8.4 <6.0.0'
 
-  '@typescript-eslint/project-service@8.57.0':
-    resolution: {integrity: sha512-pR+dK0BlxCLxtWfaKQWtYr7MhKmzqZxuii+ZjuFlZlIGRZm22HnXFqa2eY+90MUz8/i80YJmzFGDUsi8dMOV5w==}
+  '@typescript-eslint/project-service@8.57.2':
+    resolution: {integrity: sha512-FuH0wipFywXRTHf+bTTjNyuNQQsQC3qh/dYzaM4I4W0jrCqjCVuUh99+xd9KamUfmCGPvbO8NDngo/vsnNVqgw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       typescript: '>=4.8.4 <6.0.0'
@@ -1311,8 +1193,8 @@ packages:
     resolution: {integrity: sha512-YAi4VDKcIZp0O4tz/haYKhmIDZFEUPOreKbfdAN3SzUDMcPhJ8QI99xQXqX+HoUVq8cs85eRKnD+rne2UAnj2w==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@typescript-eslint/scope-manager@8.57.0':
-    resolution: {integrity: sha512-nvExQqAHF01lUM66MskSaZulpPL5pgy5hI5RfrxviLgzZVffB5yYzw27uK/ft8QnKXI2X0LBrHJFr1TaZtAibw==}
+  '@typescript-eslint/scope-manager@8.57.2':
+    resolution: {integrity: sha512-snZKH+W4WbWkrBqj4gUNRIGb/jipDW3qMqVJ4C9rzdFc+wLwruxk+2a5D+uoFcKPAqyqEnSb4l2ULuZf95eSkw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@typescript-eslint/tsconfig-utils@8.56.1':
@@ -1321,8 +1203,8 @@ packages:
     peerDependencies:
       typescript: '>=4.8.4 <6.0.0'
 
-  '@typescript-eslint/tsconfig-utils@8.57.0':
-    resolution: {integrity: sha512-LtXRihc5ytjJIQEH+xqjB0+YgsV4/tW35XKX3GTZHpWtcC8SPkT/d4tqdf1cKtesryHm2bgp6l555NYcT2NLvA==}
+  '@typescript-eslint/tsconfig-utils@8.57.2':
+    resolution: {integrity: sha512-3Lm5DSM+DCowsUOJC+YqHHnKEfFh5CoGkj5Z31NQSNF4l5wdOwqGn99wmwN/LImhfY3KJnmordBq/4+VDe2eKw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       typescript: '>=4.8.4 <6.0.0'
@@ -1331,8 +1213,8 @@ packages:
     resolution: {integrity: sha512-dbMkdIUkIkchgGDIv7KLUpa0Mda4IYjo4IAMJUZ+3xNoUXxMsk9YtKpTHSChRS85o+H9ftm51gsK1dZReY9CVw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@typescript-eslint/types@8.57.0':
-    resolution: {integrity: sha512-dTLI8PEXhjUC7B9Kre+u0XznO696BhXcTlOn0/6kf1fHaQW8+VjJAVHJ3eTI14ZapTxdkOmc80HblPQLaEeJdg==}
+  '@typescript-eslint/types@8.57.2':
+    resolution: {integrity: sha512-/iZM6FnM4tnx9csuTxspMW4BOSegshwX5oBDznJ7S4WggL7Vczz5d2W11ecc4vRrQMQHXRSxzrCsyG5EsPPTbA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@typescript-eslint/typescript-estree@8.56.1':
@@ -1341,8 +1223,8 @@ packages:
     peerDependencies:
       typescript: '>=4.8.4 <6.0.0'
 
-  '@typescript-eslint/typescript-estree@8.57.0':
-    resolution: {integrity: sha512-m7faHcyVg0BT3VdYTlX8GdJEM7COexXxS6KqGopxdtkQRvBanK377QDHr4W/vIPAR+ah9+B/RclSW5ldVniO1Q==}
+  '@typescript-eslint/typescript-estree@8.57.2':
+    resolution: {integrity: sha512-2MKM+I6g8tJxfSmFKOnHv2t8Sk3T6rF20A1Puk0svLK+uVapDZB/4pfAeB7nE83uAZrU6OxW+HmOd5wHVdXwXA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       typescript: '>=4.8.4 <6.0.0'
@@ -1358,86 +1240,86 @@ packages:
     resolution: {integrity: sha512-KiROIzYdEV85YygXw6BI/Dx4fnBlFQu6Mq4QE4MOH9fFnhohw6wX/OAvDY2/C+ut0I3RSPKenvZJIVYqJNkhEw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@typescript-eslint/visitor-keys@8.57.0':
-    resolution: {integrity: sha512-zm6xx8UT/Xy2oSr2ZXD0pZo7Jx2XsCoID2IUh9YSTFRu7z+WdwYTRk6LhUftm1crwqbuoF6I8zAFeCMw0YjwDg==}
+  '@typescript-eslint/visitor-keys@8.57.2':
+    resolution: {integrity: sha512-zhahknjobV2FiD6Ee9iLbS7OV9zi10rG26odsQdfBO/hjSzUQbkIYgda+iNKK1zNiW2ey+Lf8MU5btN17V3dUw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260311.1':
-    resolution: {integrity: sha512-k3UqlA40U9m8meAyliJdbTayDSGZRBGNsEDP2rtjOomLUo2IA0eIi4vNAjQKzsXFtyfoQ59MGAqOLSO/CzVrQA==}
+  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260324.1':
+    resolution: {integrity: sha512-Yg4zANP69mquBH4VwgfaSGj98Bc1o1mKFX4kk6WFEGvUX7BKvakiMXmKRKc79zY8HtpSKXiqTYcbOtumoRKfTA==}
     cpu: [arm64]
     os: [darwin]
 
-  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260311.1':
-    resolution: {integrity: sha512-8PNUCS1HPeXMK1F+1D3A4MyD+9Nil2mM3mWSwayUZpqT/A+dfEtcoo4Oe7Gz6qvMZbhCjbipwhTC84ilisiE1g==}
+  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260324.1':
+    resolution: {integrity: sha512-hlMIJQjlbwNTH3iS8IivAxeu7I4OLm645kErSynAR4i8O6lZiSeaZndUqIDYx/+er4bb01X0Fnxa8BTW2Emv2A==}
     cpu: [x64]
     os: [darwin]
 
-  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260311.1':
-    resolution: {integrity: sha512-WwRJO5ryMEs4Flro6JKNq0T+hR78eYFrItautu9o6EsIpeevk7Cq7T0BBgCrAf+A5aKts21HpiWzfHI0YP/CuQ==}
+  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260324.1':
+    resolution: {integrity: sha512-1oCTzfOOujaa0DhFj7epM3xqhoI4l+d2f584zeQjPCvk8FJBj4kwfOMZV139bEe+G5IoGsvhJzzRYzfu2diZkA==}
     cpu: [arm64]
     os: [linux]
 
-  '@typescript/native-preview-linux-arm@7.0.0-dev.20260311.1':
-    resolution: {integrity: sha512-9T8kwNALCWzuNe00ri/f6wwoVD64YZW24cqkycFeptIF+DfNxfHMddWd7fvtHf0OKzPtkL83mkjBtviNeVKOfQ==}
+  '@typescript/native-preview-linux-arm@7.0.0-dev.20260324.1':
+    resolution: {integrity: sha512-uWcNrDuCdJb3TCAWI7TvrEzgluDiWmnNFeyE48mlgiVpcf7XVD9PwD0AIxvlO27NyF+NkQ3guHFssmjkhi0E9w==}
     cpu: [arm]
     os: [linux]
 
-  '@typescript/native-preview-linux-x64@7.0.0-dev.20260311.1':
-    resolution: {integrity: sha512-oMm3cb4njzMLBb61TI4EGq5Igxc+hoPHHNpMWqORfiYu/uQZWnter/twamTrZo6boCFtIa59mrGkhR3Qz7kauA==}
+  '@typescript/native-preview-linux-x64@7.0.0-dev.20260324.1':
+    resolution: {integrity: sha512-MzGh802vVwm9pCuFD6n7MrfaHn44ewayqZ5MSnSMmOZZzaOGwmGCCNDJUvsSsDSwIrYt8bU6LbUxx7TvlpJ8dQ==}
     cpu: [x64]
     os: [linux]
 
-  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260311.1':
-    resolution: {integrity: sha512-EQ5nz4qrwtzMZ5bjdMVQ2ke5BHQWDBz9IQsdh/8UU819cs5ZBnKmFFe5wOrIngqFvq4EoWKDXf983Vw0q4erkg==}
+  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260324.1':
+    resolution: {integrity: sha512-CyxCw3Rj+nqI2cVP4CmdEAn+8UkGJM1vWmNQ2q3z5ZF3V+JdnlmhALEzk4bu0ddu5pyHwM1fOHLsD7xcGUcKtQ==}
     cpu: [arm64]
     os: [win32]
 
-  '@typescript/native-preview-win32-x64@7.0.0-dev.20260311.1':
-    resolution: {integrity: sha512-Y/5A7BaRFV1Pro4BqNW3nVDuId7YdPXktl769x1yUjTDQLH6YJEJVeBkFkT0+4e1O5IL92rxxr8rWMLypNKnTw==}
+  '@typescript/native-preview-win32-x64@7.0.0-dev.20260324.1':
+    resolution: {integrity: sha512-6J8V5cHOrh7Cjl6lv8+zsDY5NkbMYBwXroKlFUzThZ7vpJlEaa51DPQyCyILIXodv5XODd5arRcbaY+cC6Et8Q==}
     cpu: [x64]
     os: [win32]
 
-  '@typescript/native-preview@7.0.0-dev.20260311.1':
-    resolution: {integrity: sha512-BnyOW/mdZVZGevyeJ4RRY60CI4F121QBa++8Rwd+/Ms48OKQ30eMhaIKWGowz/u4WjJZmrzhFxIzN92XeSWMCQ==}
+  '@typescript/native-preview@7.0.0-dev.20260324.1':
+    resolution: {integrity: sha512-AzuC/jEAucVCay7ckwexa8Ao4NfDUeVYBTIxGG9fc1qh2q1JphdUW50PLRyNJXCDcnLtghSIDBi+wfFgVBtcMQ==}
     hasBin: true
 
-  '@vitest/coverage-v8@4.0.18':
-    resolution: {integrity: sha512-7i+N2i0+ME+2JFZhfuz7Tg/FqKtilHjGyGvoHYQ6iLV0zahbsJ9sljC9OcFcPDbhYKCet+sG8SsVqlyGvPflZg==}
+  '@vitest/coverage-v8@4.1.1':
+    resolution: {integrity: sha512-nZ4RWwGCoGOQRMmU/Q9wlUY540RVRxJZ9lxFsFfy0QV7Zmo5VVBhB6Sl9Xa0KIp2iIs3zWfPlo9LcY1iqbpzCw==}
     peerDependencies:
-      '@vitest/browser': 4.0.18
-      vitest: 4.0.18
+      '@vitest/browser': 4.1.1
+      vitest: 4.1.1
     peerDependenciesMeta:
       '@vitest/browser':
         optional: true
 
-  '@vitest/expect@4.0.18':
-    resolution: {integrity: sha512-8sCWUyckXXYvx4opfzVY03EOiYVxyNrHS5QxX3DAIi5dpJAAkyJezHCP77VMX4HKA2LDT/Jpfo8i2r5BE3GnQQ==}
+  '@vitest/expect@4.1.1':
+    resolution: {integrity: sha512-xAV0fqBTk44Rn6SjJReEQkHP3RrqbJo6JQ4zZ7/uVOiJZRarBtblzrOfFIZeYUrukp2YD6snZG6IBqhOoHTm+A==}
 
-  '@vitest/mocker@4.0.18':
-    resolution: {integrity: sha512-HhVd0MDnzzsgevnOWCBj5Otnzobjy5wLBe4EdeeFGv8luMsGcYqDuFRMcttKWZA5vVO8RFjexVovXvAM4JoJDQ==}
+  '@vitest/mocker@4.1.1':
+    resolution: {integrity: sha512-h3BOylsfsCLPeceuCPAAJ+BvNwSENgJa4hXoXu4im0bs9Lyp4URc4JYK4pWLZ4pG/UQn7AT92K6IByi6rE6g3A==}
     peerDependencies:
       msw: ^2.4.9
-      vite: ^6.0.0 || ^7.0.0-0
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
     peerDependenciesMeta:
       msw:
         optional: true
       vite:
         optional: true
 
-  '@vitest/pretty-format@4.0.18':
-    resolution: {integrity: sha512-P24GK3GulZWC5tz87ux0m8OADrQIUVDPIjjj65vBXYG17ZeU3qD7r+MNZ1RNv4l8CGU2vtTRqixrOi9fYk/yKw==}
+  '@vitest/pretty-format@4.1.1':
+    resolution: {integrity: sha512-GM+TEQN5WhOygr1lp7skeVjdLPqqWMHsfzXrcHAqZJi/lIVh63H0kaRCY8MDhNWikx19zBUK8ceaLB7X5AH9NQ==}
 
-  '@vitest/runner@4.0.18':
-    resolution: {integrity: sha512-rpk9y12PGa22Jg6g5M3UVVnTS7+zycIGk9ZNGN+m6tZHKQb7jrP7/77WfZy13Y/EUDd52NDsLRQhYKtv7XfPQw==}
+  '@vitest/runner@4.1.1':
+    resolution: {integrity: sha512-f7+FPy75vN91QGWsITueq0gedwUZy1fLtHOCMeQpjs8jTekAHeKP80zfDEnhrleviLHzVSDXIWuCIOFn3D3f8A==}
 
-  '@vitest/snapshot@4.0.18':
-    resolution: {integrity: sha512-PCiV0rcl7jKQjbgYqjtakly6T1uwv/5BQ9SwBLekVg/EaYeQFPiXcgrC2Y7vDMA8dM1SUEAEV82kgSQIlXNMvA==}
+  '@vitest/snapshot@4.1.1':
+    resolution: {integrity: sha512-kMVSgcegWV2FibXEx9p9WIKgje58lcTbXgnJixfcg15iK8nzCXhmalL0ZLtTWLW9PH1+1NEDShiFFedB3tEgWg==}
 
-  '@vitest/spy@4.0.18':
-    resolution: {integrity: sha512-cbQt3PTSD7P2OARdVW3qWER5EGq7PHlvE+QfzSC0lbwO+xnt7+XH06ZzFjFRgzUX//JmpxrCu92VdwvEPlWSNw==}
+  '@vitest/spy@4.1.1':
+    resolution: {integrity: sha512-6Ti/KT5OVaiupdIZEuZN7l3CZcR0cxnxt70Z0//3CtwgObwA6jZhmVBA3yrXSVN3gmwjgd7oDNLlsXz526gpRA==}
 
-  '@vitest/utils@4.0.18':
-    resolution: {integrity: sha512-msMRKLMVLWygpK3u2Hybgi4MNjcYJvwTb0Ru09+fOyCXIgT5raYP041DRRdiJiI3k/2U6SEbAETB3YtBrUkCFA==}
+  '@vitest/utils@4.1.1':
+    resolution: {integrity: sha512-cNxAlaB3sHoCdL6pj6yyUXv9Gry1NHNg0kFTXdvSIZXLHsqKH7chiWOkwJ5s5+d/oMwcoG9T0bKU38JZWKusrQ==}
 
   '@yarnpkg/lockfile@1.1.0':
     resolution: {integrity: sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==}
@@ -1454,6 +1336,10 @@ packages:
     resolution: {integrity: sha512-C1ReN7vt2/2O0fyTsx5xnbQuxBrmG5NMSbcIkPKCCfCTJgpZBsuRYzFXHj3nVq8vTfK7vxHUmzfCpSHgO7j4rg==}
     engines: {node: '>= 8'}
     hasBin: true
+
+  accepts@2.0.0:
+    resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
+    engines: {node: '>= 0.6'}
 
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
@@ -1532,8 +1418,8 @@ packages:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
 
-  ast-v8-to-istanbul@0.3.12:
-    resolution: {integrity: sha512-BRRC8VRZY2R4Z4lFIL35MwNXmwVqBityvOIwETtsCSwvjl0IdgFsy9NhdaA6j74nUdtJJlIypeRhpDam19Wq3g==}
+  ast-v8-to-istanbul@1.0.0:
+    resolution: {integrity: sha512-1fSfIwuDICFA4LKkCzRPO7F0hzFf0B7+Xqrl27ynQaa+Rh0e1Es0v6kWHPott3lU10AyAr7oKHa65OppjLn3Rg==}
 
   async@3.2.6:
     resolution: {integrity: sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==}
@@ -1549,20 +1435,44 @@ packages:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
 
+  base64-js@1.5.1:
+    resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
+
   better-path-resolve@1.0.0:
     resolution: {integrity: sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g==}
     engines: {node: '>=4'}
 
+  better-sqlite3@12.8.0:
+    resolution: {integrity: sha512-RxD2Vd96sQDjQr20kdP+F+dK/1OUNiVOl200vKBZY8u0vTwysfolF6Hq+3ZK2+h8My9YvZhHsF+RSGZW2VYrPQ==}
+    engines: {node: 20.x || 22.x || 23.x || 24.x || 25.x}
+
+  bindings@1.5.0:
+    resolution: {integrity: sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==}
+
+  bl@4.1.0:
+    resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
+
+  body-parser@2.2.2:
+    resolution: {integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==}
+    engines: {node: '>=18'}
+
   bole@5.0.28:
     resolution: {integrity: sha512-l+yybyZLV7zTD6EuGxoXsilpER1ctMCpdOqjSYNigJJma39ha85fzCtYccPx06oR1u7uCQLOcUAFFzvfXVBmuQ==}
 
-  brace-expansion@5.0.4:
-    resolution: {integrity: sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==}
+  brace-expansion@5.0.5:
+    resolution: {integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==}
     engines: {node: 18 || 20 || >=22}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
     engines: {node: '>=8'}
+
+  buffer@5.7.1:
+    resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
+
+  bytes@3.1.2:
+    resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
+    engines: {node: '>= 0.8'}
 
   call-bind-apply-helpers@1.0.2:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
@@ -1598,6 +1508,9 @@ packages:
 
   chardet@2.1.1:
     resolution: {integrity: sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ==}
+
+  chownr@1.1.4:
+    resolution: {integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==}
 
   cli-cursor@5.0.0:
     resolution: {integrity: sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==}
@@ -1642,6 +1555,14 @@ packages:
   consola@2.15.3:
     resolution: {integrity: sha512-9vAdYbHj6x2fLKC4+oPH0kFzY/orMZyG2Aj+kNylHxKGJ/Ed4dpNyAQYwJOdqO4zdM7XpVHmyejQDcQHrnuXbw==}
 
+  content-disposition@1.0.1:
+    resolution: {integrity: sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==}
+    engines: {node: '>=18'}
+
+  content-type@1.0.5:
+    resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
+    engines: {node: '>= 0.6'}
+
   conventional-changelog-angular@8.3.0:
     resolution: {integrity: sha512-DOuBwYSqWzfwuRByY9O4oOIvDlkUCTDzfbOgcSbkY+imXXj+4tmrEFao3K+FxemClYfYnZzsvudbwrhje9VHDA==}
     engines: {node: '>=18'}
@@ -1655,8 +1576,20 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
-  core-js@3.47.0:
-    resolution: {integrity: sha512-c3Q2VVkGAUyupsjRnaNX6u8Dq2vAdzm9iuPj5FW0fRxzlxgq9Q39MDq10IvmQSpLgHQNyQzQmOo6bgGHmH3NNg==}
+  convert-source-map@2.0.0:
+    resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  cookie-signature@1.2.2:
+    resolution: {integrity: sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==}
+    engines: {node: '>=6.6.0'}
+
+  cookie@0.7.2:
+    resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
+    engines: {node: '>= 0.6'}
+
+  cors@2.8.6:
+    resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
+    engines: {node: '>= 0.10'}
 
   cosmiconfig-typescript-loader@6.2.0:
     resolution: {integrity: sha512-GEN39v7TgdxgIoNcdkRE3uiAzQt3UXLyHbRHD6YoL048XAeOomyxaP+Hh/+2C6C2wYjxJ2onhJcsQp+L4YEkVQ==}
@@ -1694,9 +1627,17 @@ packages:
   decode-named-character-reference@1.3.0:
     resolution: {integrity: sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==}
 
+  decompress-response@6.0.0:
+    resolution: {integrity: sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==}
+    engines: {node: '>=10'}
+
   deep-equal@2.2.3:
     resolution: {integrity: sha512-ZIwpnevOurS8bpT4192sqAowWM76JDKSHYzMLty3BZGSswgq6pBaH3DhCSW5xVAZICZyKdOBPjwww5wfgT/6PA==}
     engines: {node: '>= 0.4'}
+
+  deep-extend@0.6.0:
+    resolution: {integrity: sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==}
+    engines: {node: '>=4.0.0'}
 
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
@@ -1708,6 +1649,10 @@ packages:
   define-properties@1.2.1:
     resolution: {integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==}
     engines: {node: '>= 0.4'}
+
+  depd@2.0.0:
+    resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
+    engines: {node: '>= 0.8'}
 
   dequal@2.0.3:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
@@ -1732,8 +1677,8 @@ packages:
   devlop@1.1.0:
     resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
 
-  diff@8.0.3:
-    resolution: {integrity: sha512-qejHi7bcSD4hQAZE0tNAawRK1ZtafHDmMTMkrrIGgSLl7hTnQHmKCeB45xAcbfTqK2zowkM3j3bHt/4b/ARbYQ==}
+  diff@8.0.4:
+    resolution: {integrity: sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==}
     engines: {node: '>=0.3.1'}
 
   dir-glob@3.0.1:
@@ -1748,14 +1693,24 @@ packages:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
 
-  effect@3.19.19:
-    resolution: {integrity: sha512-Yc8U/SVXo2dHnaP7zNBlAo83h/nzSJpi7vph6Hzyl4ulgMBIgPmz3UzOjb9sBgpFE00gC0iETR244sfXDNLHRg==}
+  ee-first@1.1.1:
+    resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
+
+  effect@3.21.0:
+    resolution: {integrity: sha512-PPN80qRokCd1f015IANNhrwOnLO7GrrMQfk4/lnZRE/8j7UPWrNNjPV0uBrZutI/nHzernbW+J0hdqQysHiSnQ==}
 
   emoji-regex@10.6.0:
     resolution: {integrity: sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==}
 
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
+
+  encodeurl@2.0.0:
+    resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
+    engines: {node: '>= 0.8'}
+
+  end-of-stream@1.4.5:
+    resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
 
   enquirer@2.4.1:
     resolution: {integrity: sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==}
@@ -1787,21 +1742,19 @@ packages:
   es-get-iterator@1.1.3:
     resolution: {integrity: sha512-sPZmqHBe6JIiTfN5q2pEi//TwxmAFHwj/XEuYjTuse78i8KxaqMTTzxPoFKuzRpDpTJ+0NAbpfenkmH2rePtuw==}
 
-  es-module-lexer@1.7.0:
-    resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
+  es-module-lexer@2.0.0:
+    resolution: {integrity: sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==}
 
   es-object-atoms@1.1.1:
     resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
     engines: {node: '>= 0.4'}
 
-  esbuild@0.27.4:
-    resolution: {integrity: sha512-Rq4vbHnYkK5fws5NF7MYTU68FPRE1ajX7heQ/8QXXWqNgqqJ/GkmmyxIzUnf2Sr/bakf8l54716CcMGHYhMrrQ==}
-    engines: {node: '>=18'}
-    hasBin: true
-
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
+
+  escape-html@1.0.3:
+    resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
 
   escape-string-regexp@4.0.0:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
@@ -1826,8 +1779,8 @@ packages:
     resolution: {integrity: sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
-  eslint@10.0.3:
-    resolution: {integrity: sha512-COV33RzXZkqhG9P2rZCFl9ZmJ7WL+gQSCRzE7RhkbclbQPtLAWReL7ysA0Sh4c8Im2U9ynybdR56PV0XcKvqaQ==}
+  eslint@10.1.0:
+    resolution: {integrity: sha512-S9jlY/ELKEUwwQnqWDO+f+m6sercqOPSqXM5Go94l7DOmxHVDgmSFGWEzeE/gwgTAr0W103BWt0QLe/7mabIvA==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
     hasBin: true
     peerDependencies:
@@ -1864,16 +1817,42 @@ packages:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
 
+  etag@1.8.1:
+    resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
+    engines: {node: '>= 0.6'}
+
   eventemitter3@5.0.4:
     resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
+
+  eventsource-parser@3.0.6:
+    resolution: {integrity: sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==}
+    engines: {node: '>=18.0.0'}
+
+  eventsource@3.0.7:
+    resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
+    engines: {node: '>=18.0.0'}
 
   execa@5.1.1:
     resolution: {integrity: sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==}
     engines: {node: '>=10'}
 
+  expand-template@2.0.3:
+    resolution: {integrity: sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==}
+    engines: {node: '>=6'}
+
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
+
+  express-rate-limit@8.3.1:
+    resolution: {integrity: sha512-D1dKN+cmyPWuvB+G2SREQDzPY1agpBIcTa9sJxOPMCNeH3gwzhqJRDWCXW3gg0y//+LQ/8j52JbMROWyrKdMdw==}
+    engines: {node: '>= 16'}
+    peerDependencies:
+      express: '>= 4.11'
+
+  express@5.2.1:
+    resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
+    engines: {node: '>= 18'}
 
   extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
@@ -1920,9 +1899,16 @@ packages:
     resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
     engines: {node: '>=16.0.0'}
 
+  file-uri-to-path@1.0.0:
+    resolution: {integrity: sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==}
+
   fill-range@7.1.1:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
+
+  finalhandler@2.1.1:
+    resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
+    engines: {node: '>= 18.0.0'}
 
   find-my-way-ts@0.1.6:
     resolution: {integrity: sha512-a85L9ZoXtNAey3Y6Z+eBWW658kO/MwR7zIafkIUPUMf3isZG0NCs2pjW2wtjxAKuJPxMAsHUIP4ZPGv0o5gyTA==}
@@ -1939,12 +1925,23 @@ packages:
     resolution: {integrity: sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==}
     engines: {node: '>=16'}
 
-  flatted@3.4.1:
-    resolution: {integrity: sha512-IxfVbRFVlV8V/yRaGzk0UVIcsKKHMSfYw66T/u4nTwlWteQePsxe//LjudR1AMX4tZW3WFCh3Zqa/sjlqpbURQ==}
+  flatted@3.4.2:
+    resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
 
   for-each@0.3.5:
     resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
     engines: {node: '>= 0.4'}
+
+  forwarded@0.2.0:
+    resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
+    engines: {node: '>= 0.6'}
+
+  fresh@2.0.0:
+    resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
+    engines: {node: '>= 0.8'}
+
+  fs-constants@1.0.0:
+    resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
 
   fs-extra@11.3.4:
     resolution: {integrity: sha512-CTXd6rk/M3/ULNQj8FBqBWHYBVYybQ3VPBw0xGKFe3tuH7ytT6ACnvzpIQ3UZtB8yvUKC2cXn1a+x+5EVQLovA==}
@@ -2007,6 +2004,9 @@ packages:
   git-url-parse@16.1.0:
     resolution: {integrity: sha512-cPLz4HuK86wClEW7iDdeAKcCVlWXmrLpb2L+G9goW0Z1dtpNS6BXXSOckUTlJT/LDQViE1QZKstNORzHsLnobw==}
 
+  github-from-package@0.0.0:
+    resolution: {integrity: sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==}
+
   glob-parent@5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
     engines: {node: '>= 6'}
@@ -2027,8 +2027,8 @@ packages:
     resolution: {integrity: sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==}
     engines: {node: '>=10'}
 
-  globby@16.1.0:
-    resolution: {integrity: sha512-+A4Hq7m7Ze592k9gZRy4gJ27DrXRNnC1vPjxTt1qQxEY8RxagBkBxivkCwg7FxSTG0iLLEMaUx13oOr0R2/qcQ==}
+  globby@16.1.1:
+    resolution: {integrity: sha512-dW7vl+yiAJSp6aCekaVnVJxurRv7DCOLyXqEG3RYMYUg7AuJ2jCqPkZTA8ooqC2vtnkaMcV5WfFBMuEnTu1OQg==}
     engines: {node: '>=20'}
 
   gopd@1.2.0:
@@ -2061,8 +2061,16 @@ packages:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
 
+  hono@4.12.9:
+    resolution: {integrity: sha512-wy3T8Zm2bsEvxKZM5w21VdHDDcwVS1yUFFY6i8UobSsKfFceT7TOwhbhfKsDyx7tYQlmRM5FLpIuYvNFyjctiA==}
+    engines: {node: '>=16.9.0'}
+
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
+
+  http-errors@2.0.1:
+    resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
+    engines: {node: '>= 0.8'}
 
   human-id@4.1.3:
     resolution: {integrity: sha512-tsYlhAYpjCKa//8rXZ9DqKEawhPoSytweBC2eNvcaDK+57RZLHGqNs3PZTQO6yekLFSuvA6AlnAfrw1uBvtb+Q==}
@@ -2080,6 +2088,9 @@ packages:
   iconv-lite@0.7.2:
     resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
     engines: {node: '>=0.10.0'}
+
+  ieee754@1.2.1:
+    resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
 
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
@@ -2107,6 +2118,12 @@ packages:
   individual@3.0.0:
     resolution: {integrity: sha512-rUY5vtT748NMRbEMrTNiFfy29BgGZwGXUi2NFUVMWQrogSLzlJvQV9eeMWi+g1aVaQ53tpyLAQtd5x/JH0Nh1g==}
 
+  inherits@2.0.4:
+    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+
+  ini@1.3.8:
+    resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==}
+
   ini@2.0.0:
     resolution: {integrity: sha512-7PnF4oN3CvZF23ADhA5wRaYEQpJ8qygSkbtTXWBeXWXmEVRXK+1ITciHWwHhsjv1TmW0MgacIv6hEi5pX5NQdA==}
     engines: {node: '>=10'}
@@ -2122,6 +2139,14 @@ packages:
   internal-slot@1.1.0:
     resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
     engines: {node: '>= 0.4'}
+
+  ip-address@10.1.0:
+    resolution: {integrity: sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==}
+    engines: {node: '>= 12'}
+
+  ipaddr.js@1.9.1:
+    resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
+    engines: {node: '>= 0.10'}
 
   is-alphabetical@2.0.1:
     resolution: {integrity: sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==}
@@ -2210,6 +2235,9 @@ packages:
     resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
     engines: {node: '>=12'}
 
+  is-promise@4.0.0:
+    resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
+
   is-regex@1.2.1:
     resolution: {integrity: sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==}
     engines: {node: '>= 0.4'}
@@ -2278,6 +2306,9 @@ packages:
   jju@1.4.0:
     resolution: {integrity: sha512-8wb9Yw966OSxApiCt0K3yNJL8pnNeIv+OEq2YMidz4FKP6nonSRoOXc80iXY4JaN2FC11B9qsNmDsm+ZOfMROA==}
 
+  jose@6.2.2:
+    resolution: {integrity: sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==}
+
   js-tokens@10.0.0:
     resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
 
@@ -2304,6 +2335,9 @@ packages:
   json-schema-traverse@1.0.0:
     resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
 
+  json-schema-typed@8.0.2:
+    resolution: {integrity: sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==}
+
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
 
@@ -2324,8 +2358,12 @@ packages:
   jsonfile@6.2.0:
     resolution: {integrity: sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==}
 
-  katex@0.16.38:
-    resolution: {integrity: sha512-cjHooZUmIAUmDsHBN+1n8LaZdpmbj03LtYeYPyuYB7OuloiaeaV6N4LcfjcnHVzGWjVQmKrxxTrpDcmSzEZQwQ==}
+  jsonpointer@5.0.1:
+    resolution: {integrity: sha512-p/nXbhSEcu3pZRdkW1OfJhpsVtW1gd4Wa1fnQc9YLiTfAjn0312eMKimbdIQzuZl9aa9xUGaRlP9T/CJE/ditQ==}
+    engines: {node: '>=0.10.0'}
+
+  katex@0.16.42:
+    resolution: {integrity: sha512-sZ4jqyEXfHTLEFK+qsFYToa3UZ0rtFcPGwKpyiRYh2NJn8obPWOQ+/u7ux0F6CAU/y78+Mksh1YkxTPXTh47TQ==}
     hasBin: true
 
   keyv@4.5.4:
@@ -2338,14 +2376,88 @@ packages:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
     engines: {node: '>= 0.8.0'}
 
+  lightningcss-android-arm64@1.32.0:
+    resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [android]
+
+  lightningcss-darwin-arm64@1.32.0:
+    resolution: {integrity: sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  lightningcss-darwin-x64@1.32.0:
+    resolution: {integrity: sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  lightningcss-freebsd-x64@1.32.0:
+    resolution: {integrity: sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    resolution: {integrity: sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm]
+    os: [linux]
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    resolution: {integrity: sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  lightningcss-linux-arm64-musl@1.32.0:
+    resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  lightningcss-linux-x64-musl@1.32.0:
+    resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  lightningcss-win32-x64-msvc@1.32.0:
+    resolution: {integrity: sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [win32]
+
+  lightningcss@1.32.0:
+    resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
+    engines: {node: '>= 12.0.0'}
+
   lines-and-columns@1.2.4:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
 
   linkify-it@5.0.0:
     resolution: {integrity: sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==}
 
-  lint-staged@16.3.3:
-    resolution: {integrity: sha512-RLq2koZ5fGWrx7tcqx2tSTMQj4lRkfNJaebO/li/uunhCJbtZqwTuwPHpgIimAHHi/2nZIiGrkCHDCOeR1onxA==}
+  lint-staged@16.4.0:
+    resolution: {integrity: sha512-lBWt8hujh/Cjysw5GYVmZpFHXDCgZzhrOm8vbcUdobADZNOK/bRshr2kM3DfgrrtR1DQhfupW9gnIXOfiFi+bw==}
     engines: {node: '>=20.17'}
     hasBin: true
 
@@ -2424,8 +2536,8 @@ packages:
     peerDependencies:
       markdownlint-cli2: '>=0.0.4'
 
-  markdownlint-cli2@0.21.0:
-    resolution: {integrity: sha512-DzzmbqfMW3EzHsunP66x556oZDzjcdjjlL2bHG4PubwnL58ZPAfz07px4GqteZkoCGnBYi779Y2mg7+vgNCwbw==}
+  markdownlint-cli2@0.22.0:
+    resolution: {integrity: sha512-mOC9BY/XGtdX3M9n3AgERd79F0+S7w18yBBTNIQ453sI87etZfp1z4eajqSMV70CYjbxKe5ktKvT2HCpvcWx9w==}
     engines: {node: '>=20'}
     hasBin: true
 
@@ -2476,8 +2588,16 @@ packages:
   mdurl@2.0.0:
     resolution: {integrity: sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==}
 
+  media-typer@1.1.0:
+    resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==}
+    engines: {node: '>= 0.8'}
+
   meow@13.2.0:
     resolution: {integrity: sha512-pxQJQzB6djGPXh08dacEloMFopsOqGVRKFPYvPOt9XDZ1HasbgDZA74CJGreSU4G3Ak7EFJGoiH2auq+yXISgA==}
+    engines: {node: '>=18'}
+
+  merge-descriptors@2.0.0:
+    resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
     engines: {node: '>=18'}
 
   merge-stream@2.0.0:
@@ -2581,6 +2701,14 @@ packages:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
     engines: {node: '>=8.6'}
 
+  mime-db@1.54.0:
+    resolution: {integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==}
+    engines: {node: '>= 0.6'}
+
+  mime-types@3.0.2:
+    resolution: {integrity: sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==}
+    engines: {node: '>=18'}
+
   mime@3.0.0:
     resolution: {integrity: sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==}
     engines: {node: '>=10.0.0'}
@@ -2594,6 +2722,10 @@ packages:
     resolution: {integrity: sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==}
     engines: {node: '>=18'}
 
+  mimic-response@3.1.0:
+    resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
+    engines: {node: '>=10'}
+
   minimatch@10.2.4:
     resolution: {integrity: sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==}
     engines: {node: 18 || 20 || >=22}
@@ -2604,6 +2736,9 @@ packages:
   minipass@7.1.3:
     resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
     engines: {node: '>=16 || 14 >=14.17'}
+
+  mkdirp-classic@0.5.3:
+    resolution: {integrity: sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==}
 
   mri@1.2.0:
     resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
@@ -2627,12 +2762,23 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
+  napi-build-utils@2.0.0:
+    resolution: {integrity: sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==}
+
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
 
   nconf@0.12.1:
     resolution: {integrity: sha512-p2cfF+B3XXacQdswUYWZ0w6Vld0832A/tuqjLBu3H1sfUcby4N2oVbGhyuCkZv+t3iY3aiFEj7gZGqax9Q2c1w==}
     engines: {node: '>= 0.4.0'}
+
+  negotiator@1.0.0:
+    resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
+    engines: {node: '>= 0.6'}
+
+  node-abi@3.89.0:
+    resolution: {integrity: sha512-6u9UwL0HlAl21+agMN3YAMXcKByMqwGx+pq+P76vii5f7hTPtKDp08/H9py6DY+cfDw7kQNTGEj/rly3IgbNQA==}
+    engines: {node: '>=10'}
 
   node-addon-api@7.1.1:
     resolution: {integrity: sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==}
@@ -2658,6 +2804,10 @@ packages:
     resolution: {integrity: sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==}
     engines: {node: '>=8'}
 
+  object-assign@4.1.1:
+    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
+    engines: {node: '>=0.10.0'}
+
   object-inspect@1.13.4:
     resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
     engines: {node: '>= 0.4'}
@@ -2676,6 +2826,13 @@ packages:
 
   obug@2.1.1:
     resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
+
+  on-finished@2.4.1:
+    resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
+    engines: {node: '>= 0.8'}
+
+  once@1.4.0:
+    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
   onetime@5.1.2:
     resolution: {integrity: sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==}
@@ -2745,6 +2902,10 @@ packages:
     resolution: {integrity: sha512-bCgsFI+GeGWPAvAiUv63ZorMeif3/U0zaXABGJbOWt5OH2KCaPHF6S+0ok4aqM9RuIPGyZdx9tR9l13PsW4AYQ==}
     engines: {node: '>=14.13.0'}
 
+  parseurl@1.3.3:
+    resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
+    engines: {node: '>= 0.8'}
+
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
@@ -2763,6 +2924,9 @@ packages:
     resolution: {integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==}
     engines: {node: 18 || 20 || >=22}
 
+  path-to-regexp@8.3.0:
+    resolution: {integrity: sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==}
+
   path-type@4.0.0:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
     engines: {node: '>=8'}
@@ -2773,17 +2937,21 @@ packages:
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
-  picomatch@2.3.1:
-    resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
+  picomatch@2.3.2:
+    resolution: {integrity: sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==}
     engines: {node: '>=8.6'}
 
-  picomatch@4.0.3:
-    resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
+  picomatch@4.0.4:
+    resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
 
   pify@4.0.1:
     resolution: {integrity: sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==}
     engines: {node: '>=6'}
+
+  pkce-challenge@5.0.1:
+    resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
+    engines: {node: '>=16.20.0'}
 
   possible-typed-array-names@1.1.0:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
@@ -2792,6 +2960,12 @@ packages:
   postcss@8.5.8:
     resolution: {integrity: sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==}
     engines: {node: ^10 || ^12 || >=14}
+
+  prebuild-install@7.1.3:
+    resolution: {integrity: sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==}
+    engines: {node: '>=10'}
+    deprecated: No longer maintained. Please contact the author of the relevant native addon; alternatives are available.
+    hasBin: true
 
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
@@ -2810,6 +2984,13 @@ packages:
   protocols@2.0.2:
     resolution: {integrity: sha512-hHVTzba3wboROl0/aWRRG9dMytgH6ow//STBZh43l/wQgmMhYhOFi0EHWAPtoCz9IAUymsyP0TSBHkhgMEGNnQ==}
 
+  proxy-addr@2.0.7:
+    resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
+    engines: {node: '>= 0.10'}
+
+  pump@3.0.4:
+    resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
+
   punycode.js@2.3.1:
     resolution: {integrity: sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==}
     engines: {node: '>=6'}
@@ -2821,11 +3002,27 @@ packages:
   pure-rand@6.1.0:
     resolution: {integrity: sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==}
 
+  qs@6.15.0:
+    resolution: {integrity: sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==}
+    engines: {node: '>=0.6'}
+
   quansync@0.2.11:
     resolution: {integrity: sha512-AifT7QEbW9Nri4tAwR5M/uzpBuqfZf+zwaEM/QkzEjj7NBuFD2rBuy0K3dE+8wltbezDV7JMA0WfnCPYRSYbXA==}
 
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
+
+  range-parser@1.2.1:
+    resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
+    engines: {node: '>= 0.6'}
+
+  raw-body@3.0.2:
+    resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
+    engines: {node: '>= 0.10'}
+
+  rc@1.2.8:
+    resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
+    hasBin: true
 
   read-yaml-file@1.1.0:
     resolution: {integrity: sha512-VIMnQi/Z4HT2Fxuwg5KrY174U1VdUIASQVWXXyqtNRtxSr9IYkn1rsI6Tb6HsrHCmB7gVpNwX6JxPTHcH6IoTA==}
@@ -2834,6 +3031,10 @@ packages:
   read-yaml-file@2.1.0:
     resolution: {integrity: sha512-UkRNRIwnhG+y7hpqnycCL/xbTk7+ia9VuVTC0S+zVbwd65DI9eUpRMfsWIGrCWxTU/mi+JW8cHQCrv+zfCbEPQ==}
     engines: {node: '>=10.13'}
+
+  readable-stream@3.6.2:
+    resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
+    engines: {node: '>= 6'}
 
   regexp.prototype.flags@1.5.4:
     resolution: {integrity: sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==}
@@ -2880,17 +3081,21 @@ packages:
   rfdc@1.4.1:
     resolution: {integrity: sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==}
 
-  rollup@4.59.0:
-    resolution: {integrity: sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==}
-    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+  rolldown@1.0.0-rc.11:
+    resolution: {integrity: sha512-NRjoKMusSjfRbSYiH3VSumlkgFe7kYAa3pzVOsVYVFY3zb5d7nS+a3KGQ7hJKXuYWbzJKPVQ9Wxq2UvyK+ENpw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
-  rsbuild-plugin-dts@0.19.6:
-    resolution: {integrity: sha512-ehD3P432VJq6djxfAdWeWSUXPhEAnISlma2EXOSCZSzjerzRrG4H4f6WWw1sxN5qMQXgu5hLPqlUHsFZM9sEIg==}
-    engines: {node: '>=18.12.0'}
+  router@2.2.0:
+    resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
+    engines: {node: '>= 18'}
+
+  rsbuild-plugin-dts@0.20.0:
+    resolution: {integrity: sha512-CnTJTB59zzQFjPVEjpOaaEw5BeK/eTY6kwt4l5Lr9d3HQk3VRDSKfLWY/hpeZMbZzpCk2TqLrqIhS6a+jg7k7g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     peerDependencies:
       '@microsoft/api-extractor': ^7
-      '@rsbuild/core': 1.x
+      '@rsbuild/core': ^1.0.0 || ^2.0.0-0
       '@typescript/native-preview': 7.x
       typescript: ^5
     peerDependenciesMeta:
@@ -2903,6 +3108,9 @@ packages:
 
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
+
+  safe-buffer@5.2.1:
+    resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
 
   safe-execa@0.1.2:
     resolution: {integrity: sha512-vdTshSQ2JsRCgT8eKZWNJIL26C6bVqy1SOmuCMlKHegVeo8KYRobRrefOdUq9OozSPUUiSxrylteeRmLOMFfWg==}
@@ -2918,10 +3126,10 @@ packages:
   secure-keys@1.0.0:
     resolution: {integrity: sha512-nZi59hW3Sl5P3+wOO89eHBAAGwmCPd2aE1+dLZV5MO+ItQctIvAqihzaAXIQhvtH4KJPxM080HsnqltR2y8cWg==}
 
-  semver-effect@0.1.0:
-    resolution: {integrity: sha512-QMV5tYjNaw0rshAg9niTMkqdQrCZ/0js4nskBIzzdEx/LAcHEGPMGQbTlR++YC9JUkSssGjh/YC/JaMRV7JExw==}
+  semver-effect@0.2.0:
+    resolution: {integrity: sha512-N2ieg9JiBQ3DZDzklqyUHF/1Lx4nOxHeKkAb0YYOkwj8sz4PyqPFEXzPHotLKdgCchIVUpvJpO/+ekPgH2T+6w==}
     peerDependencies:
-      effect: ^3.19.19
+      effect: ^3.19.0
 
   semver@7.5.4:
     resolution: {integrity: sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==}
@@ -2933,6 +3141,14 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  send@1.2.1:
+    resolution: {integrity: sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==}
+    engines: {node: '>= 18'}
+
+  serve-static@2.2.1:
+    resolution: {integrity: sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==}
+    engines: {node: '>= 18'}
+
   set-function-length@1.2.2:
     resolution: {integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==}
     engines: {node: '>= 0.4'}
@@ -2940,6 +3156,9 @@ packages:
   set-function-name@2.0.2:
     resolution: {integrity: sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==}
     engines: {node: '>= 0.4'}
+
+  setprototypeof@1.2.0:
+    resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
 
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
@@ -2975,6 +3194,12 @@ packages:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
 
+  simple-concat@1.0.1:
+    resolution: {integrity: sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==}
+
+  simple-get@4.0.1:
+    resolution: {integrity: sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==}
+
   slash@3.0.0:
     resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
     engines: {node: '>=8'}
@@ -2990,6 +3215,10 @@ packages:
   slice-ansi@8.0.0:
     resolution: {integrity: sha512-stxByr12oeeOyY2BlviTNQlYV5xOj47GirPr4yA1hE9JCtxfQN0+tVbkxwCtYDQWhEKWFHsEK48ORg5jrouCAg==}
     engines: {node: '>=20'}
+
+  smol-toml@1.6.0:
+    resolution: {integrity: sha512-4zemZi0HvTnYwLfrpk/CF9LOd9Lt87kAt50GnqhMpyF9U3poDAP2+iukq2bZsO/ufegbYehBkqINbsWxj4l4cw==}
+    engines: {node: '>= 18'}
 
   sort-keys@4.2.0:
     resolution: {integrity: sha512-aUYIEU/UviqPgc8mHR6IW1EGxkAXpeRETYcrzg8cLAvUPZcpAlleSXHV2mY7G12GphSH6Gzv+4MMVSSkbdteHg==}
@@ -3028,8 +3257,12 @@ packages:
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
-  std-env@3.10.0:
-    resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
+  statuses@2.0.2:
+    resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
+    engines: {node: '>= 0.8'}
+
+  std-env@4.0.0:
+    resolution: {integrity: sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==}
 
   stop-iteration-iterator@1.1.0:
     resolution: {integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==}
@@ -3055,6 +3288,9 @@ packages:
     resolution: {integrity: sha512-6hJPQ8N0V0P3SNmP6h2J99RLuzrWz2gvT7VnK5tKvrNqJoyS9W4/Fb8mo31UiPvy00z7DQXkP2hnKBVav76thw==}
     engines: {node: '>=20'}
 
+  string_decoder@1.3.0:
+    resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
+
   strip-ansi@6.0.1:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
     engines: {node: '>=8'}
@@ -3078,6 +3314,10 @@ packages:
     resolution: {integrity: sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==}
     engines: {node: '>=6'}
 
+  strip-json-comments@2.0.1:
+    resolution: {integrity: sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==}
+    engines: {node: '>=0.10.0'}
+
   strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
@@ -3093,6 +3333,13 @@ packages:
   supports-preserve-symlinks-flag@1.0.0:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
+
+  tar-fs@2.1.4:
+    resolution: {integrity: sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==}
+
+  tar-stream@2.2.0:
+    resolution: {integrity: sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==}
+    engines: {node: '>=6'}
 
   term-size@2.2.1:
     resolution: {integrity: sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg==}
@@ -3121,6 +3368,10 @@ packages:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
 
+  toidentifier@1.0.1:
+    resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
+    engines: {node: '>=0.6'}
+
   toml@3.0.0:
     resolution: {integrity: sha512-y/mWCZinnvxjTKYhJ+pYxwD0mRLVvOtdS2Awbgxln6iEnt4rk0yBxeSBHkGJcPucRiG0e55mwWp+g/05rsrd6w==}
 
@@ -3130,8 +3381,8 @@ packages:
   trough@2.2.0:
     resolution: {integrity: sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==}
 
-  ts-api-utils@2.4.0:
-    resolution: {integrity: sha512-3TaVTaAv2gTiMB35i3FiGJaRfwb3Pyn/j3m/bfAvGe8FB7CF6u+LMYqYlDh7reQf7UNvoTvdfAqHGmPGOSsPmA==}
+  ts-api-utils@2.5.0:
+    resolution: {integrity: sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==}
     engines: {node: '>=18.12'}
     peerDependencies:
       typescript: '>=4.8.4'
@@ -3139,43 +3390,20 @@ packages:
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
-  turbo-darwin-64@2.8.16:
-    resolution: {integrity: sha512-KWa4hUMWrpADC6Q/wIHRkBLw6X6MV9nx6X7hSXbTrrMz0KdaKhmfudUZ3sS76bJFmgArBU25cSc0AUyyrswYxg==}
-    cpu: [x64]
-    os: [darwin]
+  tunnel-agent@0.6.0:
+    resolution: {integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==}
 
-  turbo-darwin-arm64@2.8.16:
-    resolution: {integrity: sha512-NBgaqBDLQSZlJR4D5XCkQq6noaO0RvIgwm5eYFJYL3bH5dNu8o0UBpq7C5DYnQI8+ybyoHFjT5/icN4LeUYLow==}
-    cpu: [arm64]
-    os: [darwin]
-
-  turbo-linux-64@2.8.16:
-    resolution: {integrity: sha512-VYPdcCRevI9kR/hr1H1xwXy7QQt/jNKiim1e1mjANBXD2E9VZWMkIL74J1Huad5MbU3/jw7voHOqDPLJPC2p6w==}
-    cpu: [x64]
-    os: [linux]
-
-  turbo-linux-arm64@2.8.16:
-    resolution: {integrity: sha512-beq8tgUVI3uwkQkXJMiOr/hfxQRw54M3elpBwqgYFfemiK5LhCjjcwO0DkE8GZZfElBIlk+saMAQOZy3885wNQ==}
-    cpu: [arm64]
-    os: [linux]
-
-  turbo-windows-64@2.8.16:
-    resolution: {integrity: sha512-Ig7b46iUgiOIkea/D3Z7H+zNzvzSnIJcLYFpZLA0RxbUTrbLhv9qIPwv3pT9p/abmu0LXVKHxaOo+p26SuDhzw==}
-    cpu: [x64]
-    os: [win32]
-
-  turbo-windows-arm64@2.8.16:
-    resolution: {integrity: sha512-fOWjbEA2PiE2HEnFQrwNZKYEdjewyPc2no9GmrXklZnTCuMsxeCN39aVlKpKpim03Zq/ykIuvApGwq8ZbfS2Yw==}
-    cpu: [arm64]
-    os: [win32]
-
-  turbo@2.8.16:
-    resolution: {integrity: sha512-u6e9e3cTTpE2adQ1DYm3A3r8y3LAONEx1jYvJx6eIgSY4bMLxIxs0riWzI0Z/IK903ikiUzRPZ2c1Ph5lVLkhA==}
+  turbo@2.8.20:
+    resolution: {integrity: sha512-Rb4qk5YT8RUwwdXtkLpkVhNEe/lor6+WV7S5tTlLpxSz6MjV5Qi8jGNn4gS6NAvrYGA/rNrE6YUQM85sCZUDbQ==}
     hasBin: true
 
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
+
+  type-is@2.0.1:
+    resolution: {integrity: sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==}
+    engines: {node: '>= 0.6'}
 
   typescript@5.8.2:
     resolution: {integrity: sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==}
@@ -3193,8 +3421,8 @@ packages:
   undici-types@7.18.2:
     resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
 
-  undici@7.22.0:
-    resolution: {integrity: sha512-RqslV2Us5BrllB+JeiZnK4peryVTndy9Dnqq62S3yYRRTj0tFQCwEniUy2167skdGOy3vqRzEvl1Dm4sV2ReDg==}
+  undici@7.24.5:
+    resolution: {integrity: sha512-3IWdCpjgxp15CbJnsi/Y9TCDE7HWVN19j1hmzVhoAkY/+CJx449tVxT5wZc1Gwg8J+P0LWvzlBzxYRnHJ+1i7Q==}
     engines: {node: '>=20.18.1'}
 
   unicorn-magic@0.4.0:
@@ -3227,12 +3455,23 @@ packages:
     resolution: {integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==}
     engines: {node: '>= 10.0.0'}
 
+  unpipe@1.0.0:
+    resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
+    engines: {node: '>= 0.8'}
+
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
+
+  util-deprecate@1.0.2:
+    resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
   uuid@11.1.0:
     resolution: {integrity: sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==}
     hasBin: true
+
+  vary@1.1.2:
+    resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
+    engines: {node: '>= 0.8'}
 
   vfile-message@4.0.3:
     resolution: {integrity: sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==}
@@ -3240,15 +3479,16 @@ packages:
   vfile@6.0.3:
     resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
 
-  vite@7.3.1:
-    resolution: {integrity: sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==}
+  vite@8.0.2:
+    resolution: {integrity: sha512-1gFhNi+bHhRE/qKZOJXACm6tX4bA3Isy9KuKF15AgSRuRazNBOJfdDemPBU16/mpMxApDPrWvZ08DcLPEoRnuA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
       '@types/node': ^20.19.0 || >=22.12.0
+      '@vitejs/devtools': ^0.1.0
+      esbuild: ^0.27.0
       jiti: '>=1.21.0'
       less: ^4.0.0
-      lightningcss: ^1.21.0
       sass: ^1.70.0
       sass-embedded: ^1.70.0
       stylus: '>=0.54.8'
@@ -3259,11 +3499,13 @@ packages:
     peerDependenciesMeta:
       '@types/node':
         optional: true
+      '@vitejs/devtools':
+        optional: true
+      esbuild:
+        optional: true
       jiti:
         optional: true
       less:
-        optional: true
-      lightningcss:
         optional: true
       sass:
         optional: true
@@ -3280,20 +3522,27 @@ packages:
       yaml:
         optional: true
 
-  vitest@4.0.18:
-    resolution: {integrity: sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==}
+  vitest-agent-reporter@1.0.0:
+    resolution: {integrity: sha512-5mAw4twvkhVhDS1V+vfc/Ee18KBaugluXdOO4MkIAHdsD3Un81f1lKPGSHYjXMxAnGJRh56dPAM974uVn9IjVQ==}
+    hasBin: true
+    peerDependencies:
+      vitest: '>=4.1.0'
+
+  vitest@4.1.1:
+    resolution: {integrity: sha512-yF+o4POL41rpAzj5KVILUxm1GCjKnELvaqmU9TLLUbMfDzuN0UpUR9uaDs+mCtjPe+uYPksXDRLQGGPvj1cTmA==}
     engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
     hasBin: true
     peerDependencies:
       '@edge-runtime/vm': '*'
       '@opentelemetry/api': ^1.9.0
       '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
-      '@vitest/browser-playwright': 4.0.18
-      '@vitest/browser-preview': 4.0.18
-      '@vitest/browser-webdriverio': 4.0.18
-      '@vitest/ui': 4.0.18
+      '@vitest/browser-playwright': 4.1.1
+      '@vitest/browser-preview': 4.1.1
+      '@vitest/browser-webdriverio': 4.1.1
+      '@vitest/ui': 4.1.1
       happy-dom: '*'
       jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
     peerDependenciesMeta:
       '@edge-runtime/vm':
         optional: true
@@ -3357,6 +3606,9 @@ packages:
     resolution: {integrity: sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==}
     engines: {node: '>=18'}
 
+  wrappy@1.0.2:
+    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+
   write-file-atomic@5.0.1:
     resolution: {integrity: sha512-+QU2zd6OTD8XWIJCbffaiQeH9U73qIqafo1x6V1snCWYGJf6cVE0cDR4D8xRzcEnfI21IFrUPzPGtcPf8AC+Rw==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
@@ -3365,8 +3617,8 @@ packages:
     resolution: {integrity: sha512-FdNA4RyH1L43TlvGG8qOMIfcEczwA5ij+zLXUy3Z83CjxhLvcV7/Q/8pk22wnCgYw7PJhtK+7lhO+qqyT4NdvQ==}
     engines: {node: '>=16.14'}
 
-  ws@8.19.0:
-    resolution: {integrity: sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==}
+  ws@8.20.0:
+    resolution: {integrity: sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1
@@ -3384,17 +3636,17 @@ packages:
   yallist@4.0.0:
     resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
 
-  yaml-effect@0.1.0:
-    resolution: {integrity: sha512-N9Jie6ZFbaQNtRtpEFZs4ojAxXvN55sewvg5rSvqKJI/I1Pk0S+0tqmh75WwRvYxcicqy+1426g2/i7Hu2h06w==}
+  yaml-effect@0.2.2:
+    resolution: {integrity: sha512-Jnk+guKw4aSyn2PI8JubJ2zGVTtmpdFwFkgCfnTCOKBHb/iwf+VeKxmtevwtgw97CsZuKo4Wt6NzCXwvUdzXcA==}
     peerDependencies:
-      effect: ^3.19.19
+      effect: ^3.19.0
 
   yaml-lint@1.7.0:
     resolution: {integrity: sha512-zeBC/kskKQo4zuoGQ+IYjw6C9a/YILr2SXoEZA9jM0COrSwvwVbfTiFegT8qYBSBgOwLMWGL8sY137tOmFXGnQ==}
     hasBin: true
 
-  yaml@2.8.2:
-    resolution: {integrity: sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==}
+  yaml@2.8.3:
+    resolution: {integrity: sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==}
     engines: {node: '>= 14.6'}
     hasBin: true
 
@@ -3417,6 +3669,11 @@ packages:
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
+
+  zod-to-json-schema@3.25.1:
+    resolution: {integrity: sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA==}
+    peerDependencies:
+      zod: ^3.25 || ^4
 
   zod@4.3.6:
     resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
@@ -3475,11 +3732,11 @@ snapshots:
 
   '@babel/helper-validator-identifier@7.28.5': {}
 
-  '@babel/parser@7.29.0':
+  '@babel/parser@7.29.2':
     dependencies:
       '@babel/types': 7.29.0
 
-  '@babel/runtime@7.28.6': {}
+  '@babel/runtime@7.29.2': {}
 
   '@babel/types@7.29.0':
     dependencies:
@@ -3517,7 +3774,7 @@ snapshots:
     dependencies:
       '@changesets/types': 6.1.0
 
-  '@changesets/cli@2.30.0(@types/node@25.4.0)':
+  '@changesets/cli@2.30.0(@types/node@25.5.0)':
     dependencies:
       '@changesets/apply-release-plan': 7.1.0
       '@changesets/assemble-release-plan': 6.0.9
@@ -3533,7 +3790,7 @@ snapshots:
       '@changesets/should-skip-package': 0.1.2
       '@changesets/types': 6.1.0
       '@changesets/write': 0.4.0
-      '@inquirer/external-editor': 1.0.3(@types/node@25.4.0)
+      '@inquirer/external-editor': 1.0.3(@types/node@25.5.0)
       '@manypkg/get-packages': 1.1.3
       ansi-colors: 4.1.3
       enquirer: 2.4.1
@@ -3638,13 +3895,13 @@ snapshots:
       human-id: 4.1.3
       prettier: 2.8.8
 
-  '@commitlint/cli@20.4.3(@types/node@25.4.0)(conventional-commits-parser@6.3.0)(typescript@5.9.3)':
+  '@commitlint/cli@20.5.0(@types/node@25.5.0)(conventional-commits-parser@6.3.0)(typescript@5.9.3)':
     dependencies:
-      '@commitlint/format': 20.4.4
-      '@commitlint/lint': 20.4.4
-      '@commitlint/load': 20.4.4(@types/node@25.4.0)(typescript@5.9.3)
-      '@commitlint/read': 20.4.4(conventional-commits-parser@6.3.0)
-      '@commitlint/types': 20.4.4
+      '@commitlint/format': 20.5.0
+      '@commitlint/lint': 20.5.0
+      '@commitlint/load': 20.5.0(@types/node@25.5.0)(typescript@5.9.3)
+      '@commitlint/read': 20.5.0(conventional-commits-parser@6.3.0)
+      '@commitlint/types': 20.5.0
       tinyexec: 1.0.4
       yargs: 17.7.2
     transitivePeerDependencies:
@@ -3653,19 +3910,19 @@ snapshots:
       - conventional-commits-parser
       - typescript
 
-  '@commitlint/config-conventional@20.4.3':
+  '@commitlint/config-conventional@20.5.0':
     dependencies:
-      '@commitlint/types': 20.4.4
+      '@commitlint/types': 20.5.0
       conventional-changelog-conventionalcommits: 9.3.0
 
-  '@commitlint/config-validator@20.4.4':
+  '@commitlint/config-validator@20.5.0':
     dependencies:
-      '@commitlint/types': 20.4.4
+      '@commitlint/types': 20.5.0
       ajv: 8.18.0
 
-  '@commitlint/ensure@20.4.4':
+  '@commitlint/ensure@20.5.0':
     dependencies:
-      '@commitlint/types': 20.4.4
+      '@commitlint/types': 20.5.0
       lodash.camelcase: 4.3.0
       lodash.kebabcase: 4.1.1
       lodash.snakecase: 4.1.1
@@ -3674,31 +3931,31 @@ snapshots:
 
   '@commitlint/execute-rule@20.0.0': {}
 
-  '@commitlint/format@20.4.4':
+  '@commitlint/format@20.5.0':
     dependencies:
-      '@commitlint/types': 20.4.4
+      '@commitlint/types': 20.5.0
       picocolors: 1.1.1
 
-  '@commitlint/is-ignored@20.4.4':
+  '@commitlint/is-ignored@20.5.0':
     dependencies:
-      '@commitlint/types': 20.4.4
+      '@commitlint/types': 20.5.0
       semver: 7.7.4
 
-  '@commitlint/lint@20.4.4':
+  '@commitlint/lint@20.5.0':
     dependencies:
-      '@commitlint/is-ignored': 20.4.4
-      '@commitlint/parse': 20.4.4
-      '@commitlint/rules': 20.4.4
-      '@commitlint/types': 20.4.4
+      '@commitlint/is-ignored': 20.5.0
+      '@commitlint/parse': 20.5.0
+      '@commitlint/rules': 20.5.0
+      '@commitlint/types': 20.5.0
 
-  '@commitlint/load@20.4.4(@types/node@25.4.0)(typescript@5.9.3)':
+  '@commitlint/load@20.5.0(@types/node@25.5.0)(typescript@5.9.3)':
     dependencies:
-      '@commitlint/config-validator': 20.4.4
+      '@commitlint/config-validator': 20.5.0
       '@commitlint/execute-rule': 20.0.0
-      '@commitlint/resolve-extends': 20.4.4
-      '@commitlint/types': 20.4.4
+      '@commitlint/resolve-extends': 20.5.0
+      '@commitlint/types': 20.5.0
       cosmiconfig: 9.0.1(typescript@5.9.3)
-      cosmiconfig-typescript-loader: 6.2.0(@types/node@25.4.0)(cosmiconfig@9.0.1(typescript@5.9.3))(typescript@5.9.3)
+      cosmiconfig-typescript-loader: 6.2.0(@types/node@25.5.0)(cosmiconfig@9.0.1(typescript@5.9.3))(typescript@5.9.3)
       is-plain-obj: 4.1.0
       lodash.mergewith: 4.6.2
       picocolors: 1.1.1
@@ -3708,16 +3965,16 @@ snapshots:
 
   '@commitlint/message@20.4.3': {}
 
-  '@commitlint/parse@20.4.4':
+  '@commitlint/parse@20.5.0':
     dependencies:
-      '@commitlint/types': 20.4.4
+      '@commitlint/types': 20.5.0
       conventional-changelog-angular: 8.3.0
       conventional-commits-parser: 6.3.0
 
-  '@commitlint/read@20.4.4(conventional-commits-parser@6.3.0)':
+  '@commitlint/read@20.5.0(conventional-commits-parser@6.3.0)':
     dependencies:
       '@commitlint/top-level': 20.4.3
-      '@commitlint/types': 20.4.4
+      '@commitlint/types': 20.5.0
       git-raw-commits: 5.0.1(conventional-commits-parser@6.3.0)
       minimist: 1.2.8
       tinyexec: 1.0.4
@@ -3725,21 +3982,21 @@ snapshots:
       - conventional-commits-filter
       - conventional-commits-parser
 
-  '@commitlint/resolve-extends@20.4.4':
+  '@commitlint/resolve-extends@20.5.0':
     dependencies:
-      '@commitlint/config-validator': 20.4.4
-      '@commitlint/types': 20.4.4
+      '@commitlint/config-validator': 20.5.0
+      '@commitlint/types': 20.5.0
       global-directory: 4.0.1
       import-meta-resolve: 4.2.0
       lodash.mergewith: 4.6.2
       resolve-from: 5.0.0
 
-  '@commitlint/rules@20.4.4':
+  '@commitlint/rules@20.5.0':
     dependencies:
-      '@commitlint/ensure': 20.4.4
+      '@commitlint/ensure': 20.5.0
       '@commitlint/message': 20.4.3
       '@commitlint/to-lines': 20.0.0
-      '@commitlint/types': 20.4.4
+      '@commitlint/types': 20.5.0
 
   '@commitlint/to-lines@20.0.0': {}
 
@@ -3747,7 +4004,7 @@ snapshots:
     dependencies:
       escalade: 3.2.0
 
-  '@commitlint/types@20.4.4':
+  '@commitlint/types@20.5.0':
     dependencies:
       conventional-commits-parser: 6.3.0
       picocolors: 1.1.1
@@ -3760,109 +4017,117 @@ snapshots:
     optionalDependencies:
       conventional-commits-parser: 6.3.0
 
-  '@effect/cli@0.73.2(@effect/platform@0.94.5(effect@3.19.19))(@effect/printer-ansi@0.47.0(@effect/typeclass@0.38.0(effect@3.19.19))(effect@3.19.19))(@effect/printer@0.47.0(@effect/typeclass@0.38.0(effect@3.19.19))(effect@3.19.19))(effect@3.19.19)':
+  '@effect/cli@0.75.0(@effect/platform@0.96.0(effect@3.21.0))(@effect/printer-ansi@0.49.0(@effect/typeclass@0.40.0(effect@3.21.0))(effect@3.21.0))(@effect/printer@0.49.0(@effect/typeclass@0.40.0(effect@3.21.0))(effect@3.21.0))(effect@3.21.0)':
     dependencies:
-      '@effect/platform': 0.94.5(effect@3.19.19)
-      '@effect/printer': 0.47.0(@effect/typeclass@0.38.0(effect@3.19.19))(effect@3.19.19)
-      '@effect/printer-ansi': 0.47.0(@effect/typeclass@0.38.0(effect@3.19.19))(effect@3.19.19)
-      effect: 3.19.19
+      '@effect/platform': 0.96.0(effect@3.21.0)
+      '@effect/printer': 0.49.0(@effect/typeclass@0.40.0(effect@3.21.0))(effect@3.21.0)
+      '@effect/printer-ansi': 0.49.0(@effect/typeclass@0.40.0(effect@3.21.0))(effect@3.21.0)
+      effect: 3.21.0
       ini: 4.1.3
       toml: 3.0.0
-      yaml: 2.8.2
+      yaml: 2.8.3
 
-  '@effect/cluster@0.56.4(@effect/platform@0.94.5(effect@3.19.19))(@effect/rpc@0.73.2(@effect/platform@0.94.5(effect@3.19.19))(effect@3.19.19))(@effect/sql@0.49.0(@effect/experimental@0.58.0(@effect/platform@0.94.5(effect@3.19.19))(effect@3.19.19))(@effect/platform@0.94.5(effect@3.19.19))(effect@3.19.19))(@effect/workflow@0.16.0(@effect/experimental@0.58.0(@effect/platform@0.94.5(effect@3.19.19))(effect@3.19.19))(@effect/platform@0.94.5(effect@3.19.19))(@effect/rpc@0.73.2(@effect/platform@0.94.5(effect@3.19.19))(effect@3.19.19))(effect@3.19.19))(effect@3.19.19)':
+  '@effect/cluster@0.58.0(@effect/platform@0.96.0(effect@3.21.0))(@effect/rpc@0.75.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/sql@0.51.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/workflow@0.18.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/platform@0.96.0(effect@3.21.0))(@effect/rpc@0.75.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(effect@3.21.0))(effect@3.21.0)':
     dependencies:
-      '@effect/platform': 0.94.5(effect@3.19.19)
-      '@effect/rpc': 0.73.2(@effect/platform@0.94.5(effect@3.19.19))(effect@3.19.19)
-      '@effect/sql': 0.49.0(@effect/experimental@0.58.0(@effect/platform@0.94.5(effect@3.19.19))(effect@3.19.19))(@effect/platform@0.94.5(effect@3.19.19))(effect@3.19.19)
-      '@effect/workflow': 0.16.0(@effect/experimental@0.58.0(@effect/platform@0.94.5(effect@3.19.19))(effect@3.19.19))(@effect/platform@0.94.5(effect@3.19.19))(@effect/rpc@0.73.2(@effect/platform@0.94.5(effect@3.19.19))(effect@3.19.19))(effect@3.19.19)
-      effect: 3.19.19
+      '@effect/platform': 0.96.0(effect@3.21.0)
+      '@effect/rpc': 0.75.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0)
+      '@effect/sql': 0.51.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0)
+      '@effect/workflow': 0.18.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/platform@0.96.0(effect@3.21.0))(@effect/rpc@0.75.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(effect@3.21.0)
+      effect: 3.21.0
       kubernetes-types: 1.30.0
 
-  '@effect/experimental@0.58.0(@effect/platform@0.94.5(effect@3.19.19))(effect@3.19.19)':
+  '@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0)':
     dependencies:
-      '@effect/platform': 0.94.5(effect@3.19.19)
-      effect: 3.19.19
+      '@effect/platform': 0.96.0(effect@3.21.0)
+      effect: 3.21.0
       uuid: 11.1.0
 
-  '@effect/platform-node-shared@0.57.1(@effect/cluster@0.56.4(@effect/platform@0.94.5(effect@3.19.19))(@effect/rpc@0.73.2(@effect/platform@0.94.5(effect@3.19.19))(effect@3.19.19))(@effect/sql@0.49.0(@effect/experimental@0.58.0(@effect/platform@0.94.5(effect@3.19.19))(effect@3.19.19))(@effect/platform@0.94.5(effect@3.19.19))(effect@3.19.19))(@effect/workflow@0.16.0(@effect/experimental@0.58.0(@effect/platform@0.94.5(effect@3.19.19))(effect@3.19.19))(@effect/platform@0.94.5(effect@3.19.19))(@effect/rpc@0.73.2(@effect/platform@0.94.5(effect@3.19.19))(effect@3.19.19))(effect@3.19.19))(effect@3.19.19))(@effect/platform@0.94.5(effect@3.19.19))(@effect/rpc@0.73.2(@effect/platform@0.94.5(effect@3.19.19))(effect@3.19.19))(@effect/sql@0.49.0(@effect/experimental@0.58.0(@effect/platform@0.94.5(effect@3.19.19))(effect@3.19.19))(@effect/platform@0.94.5(effect@3.19.19))(effect@3.19.19))(effect@3.19.19)':
+  '@effect/platform-node-shared@0.59.0(@effect/cluster@0.58.0(@effect/platform@0.96.0(effect@3.21.0))(@effect/rpc@0.75.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/sql@0.51.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/workflow@0.18.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/platform@0.96.0(effect@3.21.0))(@effect/rpc@0.75.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(effect@3.21.0))(effect@3.21.0))(@effect/platform@0.96.0(effect@3.21.0))(@effect/rpc@0.75.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/sql@0.51.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(effect@3.21.0)':
     dependencies:
-      '@effect/cluster': 0.56.4(@effect/platform@0.94.5(effect@3.19.19))(@effect/rpc@0.73.2(@effect/platform@0.94.5(effect@3.19.19))(effect@3.19.19))(@effect/sql@0.49.0(@effect/experimental@0.58.0(@effect/platform@0.94.5(effect@3.19.19))(effect@3.19.19))(@effect/platform@0.94.5(effect@3.19.19))(effect@3.19.19))(@effect/workflow@0.16.0(@effect/experimental@0.58.0(@effect/platform@0.94.5(effect@3.19.19))(effect@3.19.19))(@effect/platform@0.94.5(effect@3.19.19))(@effect/rpc@0.73.2(@effect/platform@0.94.5(effect@3.19.19))(effect@3.19.19))(effect@3.19.19))(effect@3.19.19)
-      '@effect/platform': 0.94.5(effect@3.19.19)
-      '@effect/rpc': 0.73.2(@effect/platform@0.94.5(effect@3.19.19))(effect@3.19.19)
-      '@effect/sql': 0.49.0(@effect/experimental@0.58.0(@effect/platform@0.94.5(effect@3.19.19))(effect@3.19.19))(@effect/platform@0.94.5(effect@3.19.19))(effect@3.19.19)
+      '@effect/cluster': 0.58.0(@effect/platform@0.96.0(effect@3.21.0))(@effect/rpc@0.75.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/sql@0.51.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/workflow@0.18.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/platform@0.96.0(effect@3.21.0))(@effect/rpc@0.75.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(effect@3.21.0))(effect@3.21.0)
+      '@effect/platform': 0.96.0(effect@3.21.0)
+      '@effect/rpc': 0.75.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0)
+      '@effect/sql': 0.51.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0)
       '@parcel/watcher': 2.5.6
-      effect: 3.19.19
+      effect: 3.21.0
       multipasta: 0.2.7
-      ws: 8.19.0
+      ws: 8.20.0
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
 
-  '@effect/platform-node@0.104.1(@effect/cluster@0.56.4(@effect/platform@0.94.5(effect@3.19.19))(@effect/rpc@0.73.2(@effect/platform@0.94.5(effect@3.19.19))(effect@3.19.19))(@effect/sql@0.49.0(@effect/experimental@0.58.0(@effect/platform@0.94.5(effect@3.19.19))(effect@3.19.19))(@effect/platform@0.94.5(effect@3.19.19))(effect@3.19.19))(@effect/workflow@0.16.0(@effect/experimental@0.58.0(@effect/platform@0.94.5(effect@3.19.19))(effect@3.19.19))(@effect/platform@0.94.5(effect@3.19.19))(@effect/rpc@0.73.2(@effect/platform@0.94.5(effect@3.19.19))(effect@3.19.19))(effect@3.19.19))(effect@3.19.19))(@effect/platform@0.94.5(effect@3.19.19))(@effect/rpc@0.73.2(@effect/platform@0.94.5(effect@3.19.19))(effect@3.19.19))(@effect/sql@0.49.0(@effect/experimental@0.58.0(@effect/platform@0.94.5(effect@3.19.19))(effect@3.19.19))(@effect/platform@0.94.5(effect@3.19.19))(effect@3.19.19))(effect@3.19.19)':
+  '@effect/platform-node@0.106.0(@effect/cluster@0.58.0(@effect/platform@0.96.0(effect@3.21.0))(@effect/rpc@0.75.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/sql@0.51.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/workflow@0.18.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/platform@0.96.0(effect@3.21.0))(@effect/rpc@0.75.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(effect@3.21.0))(effect@3.21.0))(@effect/platform@0.96.0(effect@3.21.0))(@effect/rpc@0.75.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/sql@0.51.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(effect@3.21.0)':
     dependencies:
-      '@effect/cluster': 0.56.4(@effect/platform@0.94.5(effect@3.19.19))(@effect/rpc@0.73.2(@effect/platform@0.94.5(effect@3.19.19))(effect@3.19.19))(@effect/sql@0.49.0(@effect/experimental@0.58.0(@effect/platform@0.94.5(effect@3.19.19))(effect@3.19.19))(@effect/platform@0.94.5(effect@3.19.19))(effect@3.19.19))(@effect/workflow@0.16.0(@effect/experimental@0.58.0(@effect/platform@0.94.5(effect@3.19.19))(effect@3.19.19))(@effect/platform@0.94.5(effect@3.19.19))(@effect/rpc@0.73.2(@effect/platform@0.94.5(effect@3.19.19))(effect@3.19.19))(effect@3.19.19))(effect@3.19.19)
-      '@effect/platform': 0.94.5(effect@3.19.19)
-      '@effect/platform-node-shared': 0.57.1(@effect/cluster@0.56.4(@effect/platform@0.94.5(effect@3.19.19))(@effect/rpc@0.73.2(@effect/platform@0.94.5(effect@3.19.19))(effect@3.19.19))(@effect/sql@0.49.0(@effect/experimental@0.58.0(@effect/platform@0.94.5(effect@3.19.19))(effect@3.19.19))(@effect/platform@0.94.5(effect@3.19.19))(effect@3.19.19))(@effect/workflow@0.16.0(@effect/experimental@0.58.0(@effect/platform@0.94.5(effect@3.19.19))(effect@3.19.19))(@effect/platform@0.94.5(effect@3.19.19))(@effect/rpc@0.73.2(@effect/platform@0.94.5(effect@3.19.19))(effect@3.19.19))(effect@3.19.19))(effect@3.19.19))(@effect/platform@0.94.5(effect@3.19.19))(@effect/rpc@0.73.2(@effect/platform@0.94.5(effect@3.19.19))(effect@3.19.19))(@effect/sql@0.49.0(@effect/experimental@0.58.0(@effect/platform@0.94.5(effect@3.19.19))(effect@3.19.19))(@effect/platform@0.94.5(effect@3.19.19))(effect@3.19.19))(effect@3.19.19)
-      '@effect/rpc': 0.73.2(@effect/platform@0.94.5(effect@3.19.19))(effect@3.19.19)
-      '@effect/sql': 0.49.0(@effect/experimental@0.58.0(@effect/platform@0.94.5(effect@3.19.19))(effect@3.19.19))(@effect/platform@0.94.5(effect@3.19.19))(effect@3.19.19)
-      effect: 3.19.19
+      '@effect/cluster': 0.58.0(@effect/platform@0.96.0(effect@3.21.0))(@effect/rpc@0.75.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/sql@0.51.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/workflow@0.18.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/platform@0.96.0(effect@3.21.0))(@effect/rpc@0.75.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(effect@3.21.0))(effect@3.21.0)
+      '@effect/platform': 0.96.0(effect@3.21.0)
+      '@effect/platform-node-shared': 0.59.0(@effect/cluster@0.58.0(@effect/platform@0.96.0(effect@3.21.0))(@effect/rpc@0.75.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/sql@0.51.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/workflow@0.18.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/platform@0.96.0(effect@3.21.0))(@effect/rpc@0.75.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(effect@3.21.0))(effect@3.21.0))(@effect/platform@0.96.0(effect@3.21.0))(@effect/rpc@0.75.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/sql@0.51.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(effect@3.21.0)
+      '@effect/rpc': 0.75.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0)
+      '@effect/sql': 0.51.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0)
+      effect: 3.21.0
       mime: 3.0.0
-      undici: 7.22.0
-      ws: 8.19.0
+      undici: 7.24.5
+      ws: 8.20.0
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
 
-  '@effect/platform@0.94.5(effect@3.19.19)':
+  '@effect/platform@0.96.0(effect@3.21.0)':
     dependencies:
-      effect: 3.19.19
+      effect: 3.21.0
       find-my-way-ts: 0.1.6
       msgpackr: 1.11.9
       multipasta: 0.2.7
 
-  '@effect/printer-ansi@0.47.0(@effect/typeclass@0.38.0(effect@3.19.19))(effect@3.19.19)':
+  '@effect/printer-ansi@0.49.0(@effect/typeclass@0.40.0(effect@3.21.0))(effect@3.21.0)':
     dependencies:
-      '@effect/printer': 0.47.0(@effect/typeclass@0.38.0(effect@3.19.19))(effect@3.19.19)
-      '@effect/typeclass': 0.38.0(effect@3.19.19)
-      effect: 3.19.19
+      '@effect/printer': 0.49.0(@effect/typeclass@0.40.0(effect@3.21.0))(effect@3.21.0)
+      '@effect/typeclass': 0.40.0(effect@3.21.0)
+      effect: 3.21.0
 
-  '@effect/printer@0.47.0(@effect/typeclass@0.38.0(effect@3.19.19))(effect@3.19.19)':
+  '@effect/printer@0.49.0(@effect/typeclass@0.40.0(effect@3.21.0))(effect@3.21.0)':
     dependencies:
-      '@effect/typeclass': 0.38.0(effect@3.19.19)
-      effect: 3.19.19
+      '@effect/typeclass': 0.40.0(effect@3.21.0)
+      effect: 3.21.0
 
-  '@effect/rpc@0.73.2(@effect/platform@0.94.5(effect@3.19.19))(effect@3.19.19)':
+  '@effect/rpc@0.75.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0)':
     dependencies:
-      '@effect/platform': 0.94.5(effect@3.19.19)
-      effect: 3.19.19
+      '@effect/platform': 0.96.0(effect@3.21.0)
+      effect: 3.21.0
       msgpackr: 1.11.9
 
-  '@effect/sql@0.49.0(@effect/experimental@0.58.0(@effect/platform@0.94.5(effect@3.19.19))(effect@3.19.19))(@effect/platform@0.94.5(effect@3.19.19))(effect@3.19.19)':
+  '@effect/sql-sqlite-node@0.52.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/platform@0.96.0(effect@3.21.0))(@effect/sql@0.51.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(effect@3.21.0)':
     dependencies:
-      '@effect/experimental': 0.58.0(@effect/platform@0.94.5(effect@3.19.19))(effect@3.19.19)
-      '@effect/platform': 0.94.5(effect@3.19.19)
-      effect: 3.19.19
+      '@effect/experimental': 0.60.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0)
+      '@effect/platform': 0.96.0(effect@3.21.0)
+      '@effect/sql': 0.51.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0)
+      better-sqlite3: 12.8.0
+      effect: 3.21.0
+
+  '@effect/sql@0.51.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0)':
+    dependencies:
+      '@effect/experimental': 0.60.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0)
+      '@effect/platform': 0.96.0(effect@3.21.0)
+      effect: 3.21.0
       uuid: 11.1.0
 
-  '@effect/typeclass@0.38.0(effect@3.19.19)':
+  '@effect/typeclass@0.40.0(effect@3.21.0)':
     dependencies:
-      effect: 3.19.19
+      effect: 3.21.0
 
-  '@effect/workflow@0.16.0(@effect/experimental@0.58.0(@effect/platform@0.94.5(effect@3.19.19))(effect@3.19.19))(@effect/platform@0.94.5(effect@3.19.19))(@effect/rpc@0.73.2(@effect/platform@0.94.5(effect@3.19.19))(effect@3.19.19))(effect@3.19.19)':
+  '@effect/workflow@0.18.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/platform@0.96.0(effect@3.21.0))(@effect/rpc@0.75.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(effect@3.21.0)':
     dependencies:
-      '@effect/experimental': 0.58.0(@effect/platform@0.94.5(effect@3.19.19))(effect@3.19.19)
-      '@effect/platform': 0.94.5(effect@3.19.19)
-      '@effect/rpc': 0.73.2(@effect/platform@0.94.5(effect@3.19.19))(effect@3.19.19)
-      effect: 3.19.19
+      '@effect/experimental': 0.60.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0)
+      '@effect/platform': 0.96.0(effect@3.21.0)
+      '@effect/rpc': 0.75.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0)
+      effect: 3.21.0
 
-  '@emnapi/core@1.9.0':
+  '@emnapi/core@1.9.1':
     dependencies:
       '@emnapi/wasi-threads': 1.2.0
       tslib: 2.8.1
     optional: true
 
-  '@emnapi/runtime@1.9.0':
+  '@emnapi/runtime@1.9.1':
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -3872,87 +4137,9 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
-  '@esbuild/aix-ppc64@0.27.4':
-    optional: true
-
-  '@esbuild/android-arm64@0.27.4':
-    optional: true
-
-  '@esbuild/android-arm@0.27.4':
-    optional: true
-
-  '@esbuild/android-x64@0.27.4':
-    optional: true
-
-  '@esbuild/darwin-arm64@0.27.4':
-    optional: true
-
-  '@esbuild/darwin-x64@0.27.4':
-    optional: true
-
-  '@esbuild/freebsd-arm64@0.27.4':
-    optional: true
-
-  '@esbuild/freebsd-x64@0.27.4':
-    optional: true
-
-  '@esbuild/linux-arm64@0.27.4':
-    optional: true
-
-  '@esbuild/linux-arm@0.27.4':
-    optional: true
-
-  '@esbuild/linux-ia32@0.27.4':
-    optional: true
-
-  '@esbuild/linux-loong64@0.27.4':
-    optional: true
-
-  '@esbuild/linux-mips64el@0.27.4':
-    optional: true
-
-  '@esbuild/linux-ppc64@0.27.4':
-    optional: true
-
-  '@esbuild/linux-riscv64@0.27.4':
-    optional: true
-
-  '@esbuild/linux-s390x@0.27.4':
-    optional: true
-
-  '@esbuild/linux-x64@0.27.4':
-    optional: true
-
-  '@esbuild/netbsd-arm64@0.27.4':
-    optional: true
-
-  '@esbuild/netbsd-x64@0.27.4':
-    optional: true
-
-  '@esbuild/openbsd-arm64@0.27.4':
-    optional: true
-
-  '@esbuild/openbsd-x64@0.27.4':
-    optional: true
-
-  '@esbuild/openharmony-arm64@0.27.4':
-    optional: true
-
-  '@esbuild/sunos-x64@0.27.4':
-    optional: true
-
-  '@esbuild/win32-arm64@0.27.4':
-    optional: true
-
-  '@esbuild/win32-ia32@0.27.4':
-    optional: true
-
-  '@esbuild/win32-x64@0.27.4':
-    optional: true
-
-  '@eslint-community/eslint-utils@4.9.1(eslint@10.0.3(jiti@2.6.1))':
+  '@eslint-community/eslint-utils@4.9.1(eslint@10.1.0(jiti@2.6.1))':
     dependencies:
-      eslint: 10.0.3(jiti@2.6.1)
+      eslint: 10.1.0(jiti@2.6.1)
       eslint-visitor-keys: 3.4.3
 
   '@eslint-community/regexpp@4.12.2': {}
@@ -3982,6 +4169,10 @@ snapshots:
 
   '@gwhitney/detect-indent@7.0.1': {}
 
+  '@hono/node-server@1.19.11(hono@4.12.9)':
+    dependencies:
+      hono: 4.12.9
+
   '@humanfs/core@0.19.1': {}
 
   '@humanfs/node@0.16.7':
@@ -3993,12 +4184,12 @@ snapshots:
 
   '@humanwhocodes/retry@0.4.3': {}
 
-  '@inquirer/external-editor@1.0.3(@types/node@25.4.0)':
+  '@inquirer/external-editor@1.0.3(@types/node@25.5.0)':
     dependencies:
       chardet: 2.1.1
       iconv-lite: 0.7.2
     optionalDependencies:
-      '@types/node': 25.4.0
+      '@types/node': 25.5.0
 
   '@jridgewell/resolve-uri@3.1.2': {}
 
@@ -4011,38 +4202,38 @@ snapshots:
 
   '@manypkg/find-root@1.1.0':
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.2
       '@types/node': 12.20.55
       find-up: 4.1.0
       fs-extra: 8.1.0
 
   '@manypkg/get-packages@1.1.3':
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.2
       '@changesets/types': 4.1.0
       '@manypkg/find-root': 1.1.0
       fs-extra: 8.1.0
       globby: 11.1.0
       read-yaml-file: 1.1.0
 
-  '@microsoft/api-extractor-model@7.33.4(@types/node@25.4.0)':
+  '@microsoft/api-extractor-model@7.33.4(@types/node@25.5.0)':
     dependencies:
       '@microsoft/tsdoc': 0.16.0
       '@microsoft/tsdoc-config': 0.18.1
-      '@rushstack/node-core-library': 5.20.3(@types/node@25.4.0)
+      '@rushstack/node-core-library': 5.20.3(@types/node@25.5.0)
     transitivePeerDependencies:
       - '@types/node'
 
-  '@microsoft/api-extractor@7.57.7(@types/node@25.4.0)':
+  '@microsoft/api-extractor@7.57.7(@types/node@25.5.0)':
     dependencies:
-      '@microsoft/api-extractor-model': 7.33.4(@types/node@25.4.0)
+      '@microsoft/api-extractor-model': 7.33.4(@types/node@25.5.0)
       '@microsoft/tsdoc': 0.16.0
       '@microsoft/tsdoc-config': 0.18.1
-      '@rushstack/node-core-library': 5.20.3(@types/node@25.4.0)
+      '@rushstack/node-core-library': 5.20.3(@types/node@25.5.0)
       '@rushstack/rig-package': 0.7.2
-      '@rushstack/terminal': 0.22.3(@types/node@25.4.0)
-      '@rushstack/ts-command-line': 5.3.3(@types/node@25.4.0)
-      diff: 8.0.3
+      '@rushstack/terminal': 0.22.3(@types/node@25.5.0)
+      '@rushstack/ts-command-line': 5.3.3(@types/node@25.5.0)
+      diff: 8.0.4
       lodash: 4.17.23
       minimatch: 10.2.4
       resolve: 1.22.11
@@ -4061,30 +4252,27 @@ snapshots:
 
   '@microsoft/tsdoc@0.16.0': {}
 
-  '@module-federation/error-codes@0.22.0': {}
-
-  '@module-federation/runtime-core@0.22.0':
+  '@modelcontextprotocol/sdk@1.27.1(zod@4.3.6)':
     dependencies:
-      '@module-federation/error-codes': 0.22.0
-      '@module-federation/sdk': 0.22.0
-
-  '@module-federation/runtime-tools@0.22.0':
-    dependencies:
-      '@module-federation/runtime': 0.22.0
-      '@module-federation/webpack-bundler-runtime': 0.22.0
-
-  '@module-federation/runtime@0.22.0':
-    dependencies:
-      '@module-federation/error-codes': 0.22.0
-      '@module-federation/runtime-core': 0.22.0
-      '@module-federation/sdk': 0.22.0
-
-  '@module-federation/sdk@0.22.0': {}
-
-  '@module-federation/webpack-bundler-runtime@0.22.0':
-    dependencies:
-      '@module-federation/runtime': 0.22.0
-      '@module-federation/sdk': 0.22.0
+      '@hono/node-server': 1.19.11(hono@4.12.9)
+      ajv: 8.18.0
+      ajv-formats: 3.0.1(ajv@8.18.0)
+      content-type: 1.0.5
+      cors: 2.8.6
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.0.6
+      express: 5.2.1
+      express-rate-limit: 8.3.1(express@5.2.1)
+      hono: 4.12.9
+      jose: 6.2.2
+      json-schema-typed: 8.0.2
+      pkce-challenge: 5.0.1
+      raw-body: 3.0.2
+      zod: 4.3.6
+      zod-to-json-schema: 3.25.1(zod@4.3.6)
+    transitivePeerDependencies:
+      - supports-color
 
   '@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.3':
     optional: true
@@ -4106,8 +4294,15 @@ snapshots:
 
   '@napi-rs/wasm-runtime@1.0.7':
     dependencies:
-      '@emnapi/core': 1.9.0
-      '@emnapi/runtime': 1.9.0
+      '@emnapi/core': 1.9.1
+      '@emnapi/runtime': 1.9.1
+      '@tybys/wasm-util': 0.10.1
+    optional: true
+
+  '@napi-rs/wasm-runtime@1.1.1':
+    dependencies:
+      '@emnapi/core': 1.9.1
+      '@emnapi/runtime': 1.9.1
       '@tybys/wasm-util': 0.10.1
     optional: true
 
@@ -4122,6 +4317,8 @@ snapshots:
     dependencies:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.20.1
+
+  '@oxc-project/types@0.122.0': {}
 
   '@parcel/watcher-android-arm64@2.5.6':
     optional: true
@@ -4167,7 +4364,7 @@ snapshots:
       detect-libc: 2.1.2
       is-glob: 4.0.3
       node-addon-api: 7.1.1
-      picomatch: 4.0.3
+      picomatch: 4.0.4
     optionalDependencies:
       '@parcel/watcher-android-arm64': 2.5.6
       '@parcel/watcher-darwin-arm64': 2.5.6
@@ -4183,16 +4380,16 @@ snapshots:
       '@parcel/watcher-win32-ia32': 2.5.6
       '@parcel/watcher-win32-x64': 2.5.6
 
-  '@pnpm/catalogs.config@1000.0.5':
+  '@pnpm/catalogs.config@1000.0.6':
     dependencies:
-      '@pnpm/error': 1000.0.5
+      '@pnpm/error': 1000.1.0
 
   '@pnpm/catalogs.protocol-parser@1001.0.0': {}
 
   '@pnpm/catalogs.resolver@1000.0.5':
     dependencies:
       '@pnpm/catalogs.protocol-parser': 1001.0.0
-      '@pnpm/error': 1000.0.5
+      '@pnpm/error': 1000.1.0
 
   '@pnpm/constants@1001.3.1': {}
 
@@ -4215,16 +4412,16 @@ snapshots:
       '@pnpm/types': 1001.3.0
       semver: 7.7.4
 
-  '@pnpm/error@1000.0.5':
+  '@pnpm/error@1000.1.0':
     dependencies:
       '@pnpm/constants': 1001.3.1
 
-  '@pnpm/exportable-manifest@1000.4.1(@pnpm/logger@1001.0.1)':
+  '@pnpm/exportable-manifest@1000.4.2(@pnpm/logger@1001.0.1)':
     dependencies:
       '@pnpm/catalogs.resolver': 1000.0.5
-      '@pnpm/error': 1000.0.5
-      '@pnpm/read-project-manifest': 1001.2.5(@pnpm/logger@1001.0.1)
-      '@pnpm/resolving.jsr-specifier-parser': 1000.0.3
+      '@pnpm/error': 1000.1.0
+      '@pnpm/read-project-manifest': 1001.2.6(@pnpm/logger@1001.0.1)
+      '@pnpm/resolving.jsr-specifier-parser': 1000.0.4
       '@pnpm/types': 1001.3.0
       p-map-values: 1.0.0
       ramda: '@pnpm/ramda@0.28.1'
@@ -4239,15 +4436,15 @@ snapshots:
     dependencies:
       graceful-fs: 4.2.11
 
-  '@pnpm/lockfile.fs@1001.1.31(@pnpm/logger@1001.0.1)':
+  '@pnpm/lockfile.fs@1001.1.32(@pnpm/logger@1001.0.1)':
     dependencies:
       '@pnpm/constants': 1001.3.1
       '@pnpm/dependency-path': 1001.1.10
-      '@pnpm/error': 1000.0.5
+      '@pnpm/error': 1000.1.0
       '@pnpm/git-utils': 1000.0.0
-      '@pnpm/lockfile.merger': 1001.0.19
-      '@pnpm/lockfile.types': 1002.0.9
-      '@pnpm/lockfile.utils': 1004.0.2
+      '@pnpm/lockfile.merger': 1001.0.20
+      '@pnpm/lockfile.types': 1002.1.0
+      '@pnpm/lockfile.utils': 1004.0.3
       '@pnpm/logger': 1001.0.1
       '@pnpm/object.key-sorting': 1000.0.1
       '@pnpm/types': 1001.3.0
@@ -4260,24 +4457,24 @@ snapshots:
       strip-bom: 4.0.0
       write-file-atomic: 5.0.1
 
-  '@pnpm/lockfile.merger@1001.0.19':
+  '@pnpm/lockfile.merger@1001.0.20':
     dependencies:
-      '@pnpm/lockfile.types': 1002.0.9
+      '@pnpm/lockfile.types': 1002.1.0
       '@pnpm/types': 1001.3.0
       comver-to-semver: 1.0.0
       ramda: '@pnpm/ramda@0.28.1'
       semver: 7.7.4
 
-  '@pnpm/lockfile.types@1002.0.9':
+  '@pnpm/lockfile.types@1002.1.0':
     dependencies:
       '@pnpm/patching.types': 1000.1.0
       '@pnpm/resolver-base': 1005.4.1
       '@pnpm/types': 1001.3.0
 
-  '@pnpm/lockfile.utils@1004.0.2':
+  '@pnpm/lockfile.utils@1004.0.3':
     dependencies:
       '@pnpm/dependency-path': 1001.1.10
-      '@pnpm/lockfile.types': 1002.0.9
+      '@pnpm/lockfile.types': 1002.1.0
       '@pnpm/pick-fetcher': 1001.0.0
       '@pnpm/resolver-base': 1005.4.1
       '@pnpm/types': 1001.3.0
@@ -4289,10 +4486,10 @@ snapshots:
       bole: 5.0.28
       split2: 4.2.0
 
-  '@pnpm/manifest-utils@1002.0.4(@pnpm/logger@1001.0.1)':
+  '@pnpm/manifest-utils@1002.0.5(@pnpm/logger@1001.0.1)':
     dependencies:
       '@pnpm/core-loggers': 1001.0.9(@pnpm/logger@1001.0.1)
-      '@pnpm/error': 1000.0.5
+      '@pnpm/error': 1000.1.0
       '@pnpm/logger': 1001.0.1
       '@pnpm/semver.peer-range': 1000.0.0
       '@pnpm/types': 1001.3.0
@@ -4309,13 +4506,13 @@ snapshots:
 
   '@pnpm/ramda@0.28.1': {}
 
-  '@pnpm/read-project-manifest@1001.2.5(@pnpm/logger@1001.0.1)':
+  '@pnpm/read-project-manifest@1001.2.6(@pnpm/logger@1001.0.1)':
     dependencies:
       '@gwhitney/detect-indent': 7.0.1
-      '@pnpm/error': 1000.0.5
+      '@pnpm/error': 1000.1.0
       '@pnpm/graceful-fs': 1000.1.0
       '@pnpm/logger': 1001.0.1
-      '@pnpm/manifest-utils': 1002.0.4(@pnpm/logger@1001.0.1)
+      '@pnpm/manifest-utils': 1002.0.5(@pnpm/logger@1001.0.1)
       '@pnpm/text.comments-parser': 1000.0.0
       '@pnpm/types': 1001.3.0
       '@pnpm/write-project-manifest': 1000.0.16
@@ -4330,9 +4527,9 @@ snapshots:
     dependencies:
       '@pnpm/types': 1001.3.0
 
-  '@pnpm/resolving.jsr-specifier-parser@1000.0.3':
+  '@pnpm/resolving.jsr-specifier-parser@1000.0.4':
     dependencies:
-      '@pnpm/error': 1000.0.5
+      '@pnpm/error': 1000.1.0
 
   '@pnpm/semver.peer-range@1000.0.0':
     dependencies:
@@ -4346,10 +4543,10 @@ snapshots:
 
   '@pnpm/util.lex-comparator@3.0.2': {}
 
-  '@pnpm/workspace.read-manifest@1000.3.0':
+  '@pnpm/workspace.read-manifest@1000.3.1':
     dependencies:
       '@pnpm/constants': 1001.3.1
-      '@pnpm/error': 1000.0.5
+      '@pnpm/error': 1000.1.0
       '@pnpm/types': 1001.3.0
       read-yaml-file: 2.1.0
 
@@ -4361,155 +4558,126 @@ snapshots:
       write-file-atomic: 5.0.1
       write-yaml-file: 5.0.0
 
-  '@rollup/rollup-android-arm-eabi@4.59.0':
+  '@rolldown/binding-android-arm64@1.0.0-rc.11':
     optional: true
 
-  '@rollup/rollup-android-arm64@4.59.0':
+  '@rolldown/binding-darwin-arm64@1.0.0-rc.11':
     optional: true
 
-  '@rollup/rollup-darwin-arm64@4.59.0':
+  '@rolldown/binding-darwin-x64@1.0.0-rc.11':
     optional: true
 
-  '@rollup/rollup-darwin-x64@4.59.0':
+  '@rolldown/binding-freebsd-x64@1.0.0-rc.11':
     optional: true
 
-  '@rollup/rollup-freebsd-arm64@4.59.0':
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.11':
     optional: true
 
-  '@rollup/rollup-freebsd-x64@4.59.0':
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.11':
     optional: true
 
-  '@rollup/rollup-linux-arm-gnueabihf@4.59.0':
+  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.11':
     optional: true
 
-  '@rollup/rollup-linux-arm-musleabihf@4.59.0':
+  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.11':
     optional: true
 
-  '@rollup/rollup-linux-arm64-gnu@4.59.0':
+  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.11':
     optional: true
 
-  '@rollup/rollup-linux-arm64-musl@4.59.0':
+  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.11':
     optional: true
 
-  '@rollup/rollup-linux-loong64-gnu@4.59.0':
+  '@rolldown/binding-linux-x64-musl@1.0.0-rc.11':
     optional: true
 
-  '@rollup/rollup-linux-loong64-musl@4.59.0':
+  '@rolldown/binding-openharmony-arm64@1.0.0-rc.11':
     optional: true
 
-  '@rollup/rollup-linux-ppc64-gnu@4.59.0':
-    optional: true
-
-  '@rollup/rollup-linux-ppc64-musl@4.59.0':
-    optional: true
-
-  '@rollup/rollup-linux-riscv64-gnu@4.59.0':
-    optional: true
-
-  '@rollup/rollup-linux-riscv64-musl@4.59.0':
-    optional: true
-
-  '@rollup/rollup-linux-s390x-gnu@4.59.0':
-    optional: true
-
-  '@rollup/rollup-linux-x64-gnu@4.59.0':
-    optional: true
-
-  '@rollup/rollup-linux-x64-musl@4.59.0':
-    optional: true
-
-  '@rollup/rollup-openbsd-x64@4.59.0':
-    optional: true
-
-  '@rollup/rollup-openharmony-arm64@4.59.0':
-    optional: true
-
-  '@rollup/rollup-win32-arm64-msvc@4.59.0':
-    optional: true
-
-  '@rollup/rollup-win32-ia32-msvc@4.59.0':
-    optional: true
-
-  '@rollup/rollup-win32-x64-gnu@4.59.0':
-    optional: true
-
-  '@rollup/rollup-win32-x64-msvc@4.59.0':
-    optional: true
-
-  '@rsbuild/core@1.7.3':
+  '@rolldown/binding-wasm32-wasi@1.0.0-rc.11':
     dependencies:
-      '@rspack/core': 1.7.8(@swc/helpers@0.5.19)
-      '@rspack/lite-tapable': 1.1.0
+      '@napi-rs/wasm-runtime': 1.1.1
+    optional: true
+
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.11':
+    optional: true
+
+  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.11':
+    optional: true
+
+  '@rolldown/pluginutils@1.0.0-rc.11': {}
+
+  '@rsbuild/core@2.0.0-beta.8':
+    dependencies:
+      '@rspack/core': 2.0.0-beta.6(@swc/helpers@0.5.19)
       '@swc/helpers': 0.5.19
-      core-js: 3.47.0
-      jiti: 2.6.1
+    transitivePeerDependencies:
+      - '@module-federation/runtime-tools'
 
-  '@rslib/core@0.19.6(@microsoft/api-extractor@7.57.7(@types/node@25.4.0))(@typescript/native-preview@7.0.0-dev.20260311.1)(typescript@5.9.3)':
+  '@rslib/core@0.20.0(@microsoft/api-extractor@7.57.7(@types/node@25.5.0))(@typescript/native-preview@7.0.0-dev.20260324.1)(typescript@5.9.3)':
     dependencies:
-      '@rsbuild/core': 1.7.3
-      rsbuild-plugin-dts: 0.19.6(@microsoft/api-extractor@7.57.7(@types/node@25.4.0))(@rsbuild/core@1.7.3)(@typescript/native-preview@7.0.0-dev.20260311.1)(typescript@5.9.3)
+      '@rsbuild/core': 2.0.0-beta.8
+      rsbuild-plugin-dts: 0.20.0(@microsoft/api-extractor@7.57.7(@types/node@25.5.0))(@rsbuild/core@2.0.0-beta.8)(@typescript/native-preview@7.0.0-dev.20260324.1)(typescript@5.9.3)
     optionalDependencies:
-      '@microsoft/api-extractor': 7.57.7(@types/node@25.4.0)
+      '@microsoft/api-extractor': 7.57.7(@types/node@25.5.0)
       typescript: 5.9.3
     transitivePeerDependencies:
+      - '@module-federation/runtime-tools'
       - '@typescript/native-preview'
+      - core-js
 
-  '@rspack/binding-darwin-arm64@1.7.8':
+  '@rspack/binding-darwin-arm64@2.0.0-beta.6':
     optional: true
 
-  '@rspack/binding-darwin-x64@1.7.8':
+  '@rspack/binding-darwin-x64@2.0.0-beta.6':
     optional: true
 
-  '@rspack/binding-linux-arm64-gnu@1.7.8':
+  '@rspack/binding-linux-arm64-gnu@2.0.0-beta.6':
     optional: true
 
-  '@rspack/binding-linux-arm64-musl@1.7.8':
+  '@rspack/binding-linux-arm64-musl@2.0.0-beta.6':
     optional: true
 
-  '@rspack/binding-linux-x64-gnu@1.7.8':
+  '@rspack/binding-linux-x64-gnu@2.0.0-beta.6':
     optional: true
 
-  '@rspack/binding-linux-x64-musl@1.7.8':
+  '@rspack/binding-linux-x64-musl@2.0.0-beta.6':
     optional: true
 
-  '@rspack/binding-wasm32-wasi@1.7.8':
+  '@rspack/binding-wasm32-wasi@2.0.0-beta.6':
     dependencies:
       '@napi-rs/wasm-runtime': 1.0.7
     optional: true
 
-  '@rspack/binding-win32-arm64-msvc@1.7.8':
+  '@rspack/binding-win32-arm64-msvc@2.0.0-beta.6':
     optional: true
 
-  '@rspack/binding-win32-ia32-msvc@1.7.8':
+  '@rspack/binding-win32-ia32-msvc@2.0.0-beta.6':
     optional: true
 
-  '@rspack/binding-win32-x64-msvc@1.7.8':
+  '@rspack/binding-win32-x64-msvc@2.0.0-beta.6':
     optional: true
 
-  '@rspack/binding@1.7.8':
+  '@rspack/binding@2.0.0-beta.6':
     optionalDependencies:
-      '@rspack/binding-darwin-arm64': 1.7.8
-      '@rspack/binding-darwin-x64': 1.7.8
-      '@rspack/binding-linux-arm64-gnu': 1.7.8
-      '@rspack/binding-linux-arm64-musl': 1.7.8
-      '@rspack/binding-linux-x64-gnu': 1.7.8
-      '@rspack/binding-linux-x64-musl': 1.7.8
-      '@rspack/binding-wasm32-wasi': 1.7.8
-      '@rspack/binding-win32-arm64-msvc': 1.7.8
-      '@rspack/binding-win32-ia32-msvc': 1.7.8
-      '@rspack/binding-win32-x64-msvc': 1.7.8
+      '@rspack/binding-darwin-arm64': 2.0.0-beta.6
+      '@rspack/binding-darwin-x64': 2.0.0-beta.6
+      '@rspack/binding-linux-arm64-gnu': 2.0.0-beta.6
+      '@rspack/binding-linux-arm64-musl': 2.0.0-beta.6
+      '@rspack/binding-linux-x64-gnu': 2.0.0-beta.6
+      '@rspack/binding-linux-x64-musl': 2.0.0-beta.6
+      '@rspack/binding-wasm32-wasi': 2.0.0-beta.6
+      '@rspack/binding-win32-arm64-msvc': 2.0.0-beta.6
+      '@rspack/binding-win32-ia32-msvc': 2.0.0-beta.6
+      '@rspack/binding-win32-x64-msvc': 2.0.0-beta.6
 
-  '@rspack/core@1.7.8(@swc/helpers@0.5.19)':
+  '@rspack/core@2.0.0-beta.6(@swc/helpers@0.5.19)':
     dependencies:
-      '@module-federation/runtime-tools': 0.22.0
-      '@rspack/binding': 1.7.8
-      '@rspack/lite-tapable': 1.1.0
+      '@rspack/binding': 2.0.0-beta.6
     optionalDependencies:
       '@swc/helpers': 0.5.19
 
-  '@rspack/lite-tapable@1.1.0': {}
-
-  '@rushstack/node-core-library@5.20.3(@types/node@25.4.0)':
+  '@rushstack/node-core-library@5.20.3(@types/node@25.5.0)':
     dependencies:
       ajv: 8.18.0
       ajv-draft-04: 1.0.0(ajv@8.18.0)
@@ -4520,42 +4688,42 @@ snapshots:
       resolve: 1.22.11
       semver: 7.5.4
     optionalDependencies:
-      '@types/node': 25.4.0
+      '@types/node': 25.5.0
 
-  '@rushstack/problem-matcher@0.2.1(@types/node@25.4.0)':
+  '@rushstack/problem-matcher@0.2.1(@types/node@25.5.0)':
     optionalDependencies:
-      '@types/node': 25.4.0
+      '@types/node': 25.5.0
 
   '@rushstack/rig-package@0.7.2':
     dependencies:
       resolve: 1.22.11
       strip-json-comments: 3.1.1
 
-  '@rushstack/terminal@0.22.3(@types/node@25.4.0)':
+  '@rushstack/terminal@0.22.3(@types/node@25.5.0)':
     dependencies:
-      '@rushstack/node-core-library': 5.20.3(@types/node@25.4.0)
-      '@rushstack/problem-matcher': 0.2.1(@types/node@25.4.0)
+      '@rushstack/node-core-library': 5.20.3(@types/node@25.5.0)
+      '@rushstack/problem-matcher': 0.2.1(@types/node@25.5.0)
       supports-color: 8.1.1
     optionalDependencies:
-      '@types/node': 25.4.0
+      '@types/node': 25.5.0
 
-  '@rushstack/ts-command-line@5.3.3(@types/node@25.4.0)':
+  '@rushstack/ts-command-line@5.3.3(@types/node@25.5.0)':
     dependencies:
-      '@rushstack/terminal': 0.22.3(@types/node@25.4.0)
+      '@rushstack/terminal': 0.22.3(@types/node@25.5.0)
       '@types/argparse': 1.0.38
       argparse: 1.0.10
       string-argv: 0.3.2
     transitivePeerDependencies:
       - '@types/node'
 
-  '@savvy-web/changesets@0.5.1(0c118329066b697e68e825dd8709de22)':
+  '@savvy-web/changesets@0.6.0(@changesets/cli@2.30.0(@types/node@25.5.0))(@effect/cluster@0.58.0(@effect/platform@0.96.0(effect@3.21.0))(@effect/rpc@0.75.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/sql@0.51.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/workflow@0.18.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/platform@0.96.0(effect@3.21.0))(@effect/rpc@0.75.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(effect@3.21.0))(effect@3.21.0))(@effect/printer-ansi@0.49.0(@effect/typeclass@0.40.0(effect@3.21.0))(effect@3.21.0))(@effect/printer@0.49.0(@effect/typeclass@0.40.0(effect@3.21.0))(effect@3.21.0))(@effect/rpc@0.75.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/sql@0.51.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))':
     dependencies:
-      '@changesets/cli': 2.30.0(@types/node@25.4.0)
+      '@changesets/cli': 2.30.0(@types/node@25.5.0)
       '@changesets/get-github-info': 0.8.0
-      '@effect/cli': 0.73.2(@effect/platform@0.94.5(effect@3.19.19))(@effect/printer-ansi@0.47.0(@effect/typeclass@0.38.0(effect@3.19.19))(effect@3.19.19))(@effect/printer@0.47.0(@effect/typeclass@0.38.0(effect@3.19.19))(effect@3.19.19))(effect@3.19.19)
-      '@effect/platform': 0.94.5(effect@3.19.19)
-      '@effect/platform-node': 0.104.1(@effect/cluster@0.56.4(@effect/platform@0.94.5(effect@3.19.19))(@effect/rpc@0.73.2(@effect/platform@0.94.5(effect@3.19.19))(effect@3.19.19))(@effect/sql@0.49.0(@effect/experimental@0.58.0(@effect/platform@0.94.5(effect@3.19.19))(effect@3.19.19))(@effect/platform@0.94.5(effect@3.19.19))(effect@3.19.19))(@effect/workflow@0.16.0(@effect/experimental@0.58.0(@effect/platform@0.94.5(effect@3.19.19))(effect@3.19.19))(@effect/platform@0.94.5(effect@3.19.19))(@effect/rpc@0.73.2(@effect/platform@0.94.5(effect@3.19.19))(effect@3.19.19))(effect@3.19.19))(effect@3.19.19))(@effect/platform@0.94.5(effect@3.19.19))(@effect/rpc@0.73.2(@effect/platform@0.94.5(effect@3.19.19))(effect@3.19.19))(@effect/sql@0.49.0(@effect/experimental@0.58.0(@effect/platform@0.94.5(effect@3.19.19))(effect@3.19.19))(@effect/platform@0.94.5(effect@3.19.19))(effect@3.19.19))(effect@3.19.19)
-      effect: 3.19.19
+      '@effect/cli': 0.75.0(@effect/platform@0.96.0(effect@3.21.0))(@effect/printer-ansi@0.49.0(@effect/typeclass@0.40.0(effect@3.21.0))(effect@3.21.0))(@effect/printer@0.49.0(@effect/typeclass@0.40.0(effect@3.21.0))(effect@3.21.0))(effect@3.21.0)
+      '@effect/platform': 0.96.0(effect@3.21.0)
+      '@effect/platform-node': 0.106.0(@effect/cluster@0.58.0(@effect/platform@0.96.0(effect@3.21.0))(@effect/rpc@0.75.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/sql@0.51.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/workflow@0.18.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/platform@0.96.0(effect@3.21.0))(@effect/rpc@0.75.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(effect@3.21.0))(effect@3.21.0))(@effect/platform@0.96.0(effect@3.21.0))(@effect/rpc@0.75.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/sql@0.51.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(effect@3.21.0)
+      effect: 3.21.0
       jsonc-parser: 3.3.1
       mdast-util-heading-range: 4.0.0
       mdast-util-to-string: 4.0.0
@@ -4578,49 +4746,52 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@savvy-web/commitlint@0.4.1(7ad55c769ef6e03468ea280af116902e)':
+  '@savvy-web/commitlint@0.4.3(@commitlint/cli@20.5.0(@types/node@25.5.0)(conventional-commits-parser@6.3.0)(typescript@5.9.3))(@commitlint/config-conventional@20.5.0)(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/typeclass@0.40.0(effect@3.21.0))(@effect/workflow@0.18.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/platform@0.96.0(effect@3.21.0))(@effect/rpc@0.75.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(effect@3.21.0))(husky@9.1.7)':
     dependencies:
-      '@commitlint/cli': 20.4.3(@types/node@25.4.0)(conventional-commits-parser@6.3.0)(typescript@5.9.3)
-      '@commitlint/config-conventional': 20.4.3
-      '@effect/cli': 0.73.2(@effect/platform@0.94.5(effect@3.19.19))(@effect/printer-ansi@0.47.0(@effect/typeclass@0.38.0(effect@3.19.19))(effect@3.19.19))(@effect/printer@0.47.0(@effect/typeclass@0.38.0(effect@3.19.19))(effect@3.19.19))(effect@3.19.19)
-      '@effect/platform': 0.94.5(effect@3.19.19)
-      '@effect/platform-node': 0.104.1(@effect/cluster@0.56.4(@effect/platform@0.94.5(effect@3.19.19))(@effect/rpc@0.73.2(@effect/platform@0.94.5(effect@3.19.19))(effect@3.19.19))(@effect/sql@0.49.0(@effect/experimental@0.58.0(@effect/platform@0.94.5(effect@3.19.19))(effect@3.19.19))(@effect/platform@0.94.5(effect@3.19.19))(effect@3.19.19))(@effect/workflow@0.16.0(@effect/experimental@0.58.0(@effect/platform@0.94.5(effect@3.19.19))(effect@3.19.19))(@effect/platform@0.94.5(effect@3.19.19))(@effect/rpc@0.73.2(@effect/platform@0.94.5(effect@3.19.19))(effect@3.19.19))(effect@3.19.19))(effect@3.19.19))(@effect/platform@0.94.5(effect@3.19.19))(@effect/rpc@0.73.2(@effect/platform@0.94.5(effect@3.19.19))(effect@3.19.19))(@effect/sql@0.49.0(@effect/experimental@0.58.0(@effect/platform@0.94.5(effect@3.19.19))(effect@3.19.19))(@effect/platform@0.94.5(effect@3.19.19))(effect@3.19.19))(effect@3.19.19)
-      effect: 3.19.19
+      '@commitlint/cli': 20.5.0(@types/node@25.5.0)(conventional-commits-parser@6.3.0)(typescript@5.9.3)
+      '@commitlint/config-conventional': 20.5.0
+      '@effect/cli': 0.75.0(@effect/platform@0.96.0(effect@3.21.0))(@effect/printer-ansi@0.49.0(@effect/typeclass@0.40.0(effect@3.21.0))(effect@3.21.0))(@effect/printer@0.49.0(@effect/typeclass@0.40.0(effect@3.21.0))(effect@3.21.0))(effect@3.21.0)
+      '@effect/cluster': 0.58.0(@effect/platform@0.96.0(effect@3.21.0))(@effect/rpc@0.75.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/sql@0.51.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/workflow@0.18.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/platform@0.96.0(effect@3.21.0))(@effect/rpc@0.75.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(effect@3.21.0))(effect@3.21.0)
+      '@effect/platform': 0.96.0(effect@3.21.0)
+      '@effect/platform-node': 0.106.0(@effect/cluster@0.58.0(@effect/platform@0.96.0(effect@3.21.0))(@effect/rpc@0.75.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/sql@0.51.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/workflow@0.18.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/platform@0.96.0(effect@3.21.0))(@effect/rpc@0.75.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(effect@3.21.0))(effect@3.21.0))(@effect/platform@0.96.0(effect@3.21.0))(@effect/rpc@0.75.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/sql@0.51.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(effect@3.21.0)
+      '@effect/printer': 0.49.0(@effect/typeclass@0.40.0(effect@3.21.0))(effect@3.21.0)
+      '@effect/printer-ansi': 0.49.0(@effect/typeclass@0.40.0(effect@3.21.0))(effect@3.21.0)
+      '@effect/rpc': 0.75.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0)
+      '@effect/sql': 0.51.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0)
+      effect: 3.21.0
       husky: 9.1.7
       workspace-tools: 0.41.0
       zod: 4.3.6
     transitivePeerDependencies:
-      - '@effect/cluster'
-      - '@effect/printer'
-      - '@effect/printer-ansi'
-      - '@effect/rpc'
-      - '@effect/sql'
+      - '@effect/experimental'
+      - '@effect/typeclass'
+      - '@effect/workflow'
       - bufferutil
       - utf-8-validate
 
-  '@savvy-web/lint-staged@0.5.2(03929e76edcf99ee8580c27fcc711de5)':
+  '@savvy-web/lint-staged@0.6.2(4b8140fb90d3444252315ca2c86c4be4)':
     dependencies:
-      '@effect/cli': 0.73.2(@effect/platform@0.94.5(effect@3.19.19))(@effect/printer-ansi@0.47.0(@effect/typeclass@0.38.0(effect@3.19.19))(effect@3.19.19))(@effect/printer@0.47.0(@effect/typeclass@0.38.0(effect@3.19.19))(effect@3.19.19))(effect@3.19.19)
-      '@effect/platform': 0.94.5(effect@3.19.19)
-      '@effect/platform-node': 0.104.1(@effect/cluster@0.56.4(@effect/platform@0.94.5(effect@3.19.19))(@effect/rpc@0.73.2(@effect/platform@0.94.5(effect@3.19.19))(effect@3.19.19))(@effect/sql@0.49.0(@effect/experimental@0.58.0(@effect/platform@0.94.5(effect@3.19.19))(effect@3.19.19))(@effect/platform@0.94.5(effect@3.19.19))(effect@3.19.19))(@effect/workflow@0.16.0(@effect/experimental@0.58.0(@effect/platform@0.94.5(effect@3.19.19))(effect@3.19.19))(@effect/platform@0.94.5(effect@3.19.19))(@effect/rpc@0.73.2(@effect/platform@0.94.5(effect@3.19.19))(effect@3.19.19))(effect@3.19.19))(effect@3.19.19))(@effect/platform@0.94.5(effect@3.19.19))(@effect/rpc@0.73.2(@effect/platform@0.94.5(effect@3.19.19))(effect@3.19.19))(@effect/sql@0.49.0(@effect/experimental@0.58.0(@effect/platform@0.94.5(effect@3.19.19))(effect@3.19.19))(@effect/platform@0.94.5(effect@3.19.19))(effect@3.19.19))(effect@3.19.19)
-      '@types/node': 25.4.0
-      '@typescript-eslint/parser': 8.57.0(eslint@10.0.3(jiti@2.6.1))(typescript@5.9.3)
-      '@typescript/native-preview': 7.0.0-dev.20260311.1
+      '@effect/cli': 0.75.0(@effect/platform@0.96.0(effect@3.21.0))(@effect/printer-ansi@0.49.0(@effect/typeclass@0.40.0(effect@3.21.0))(effect@3.21.0))(@effect/printer@0.49.0(@effect/typeclass@0.40.0(effect@3.21.0))(effect@3.21.0))(effect@3.21.0)
+      '@effect/platform': 0.96.0(effect@3.21.0)
+      '@effect/platform-node': 0.106.0(@effect/cluster@0.58.0(@effect/platform@0.96.0(effect@3.21.0))(@effect/rpc@0.75.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/sql@0.51.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/workflow@0.18.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/platform@0.96.0(effect@3.21.0))(@effect/rpc@0.75.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(effect@3.21.0))(effect@3.21.0))(@effect/platform@0.96.0(effect@3.21.0))(@effect/rpc@0.75.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/sql@0.51.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(effect@3.21.0)
+      '@types/node': 25.5.0
+      '@typescript-eslint/parser': 8.57.2(eslint@10.1.0(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript/native-preview': 7.0.0-dev.20260324.1
       cosmiconfig: 9.0.1(typescript@5.9.3)
-      effect: 3.19.19
-      eslint: 10.0.3(jiti@2.6.1)
-      eslint-plugin-tsdoc: 0.5.2(eslint@10.0.3(jiti@2.6.1))(typescript@5.9.3)
+      effect: 3.21.0
+      eslint: 10.1.0(jiti@2.6.1)
+      eslint-plugin-tsdoc: 0.5.2(eslint@10.1.0(jiti@2.6.1))(typescript@5.9.3)
       husky: 9.1.7
-      jsonc-parser: 3.3.1
-      lint-staged: 16.3.3
-      markdownlint-cli2: 0.21.0
-      markdownlint-cli2-formatter-codequality: 0.0.7(markdownlint-cli2@0.21.0)
+      jsonc-effect: 0.2.0
+      lint-staged: 16.4.0
+      markdownlint-cli2: 0.22.0
+      markdownlint-cli2-formatter-codequality: 0.0.7(markdownlint-cli2@0.22.0)
       prettier: 3.8.1
       sort-package-json: 3.6.1
-      turbo: 2.8.16
+      turbo: 2.8.20
       typescript: 5.9.3
       workspace-tools: 0.41.0
-      yaml: 2.8.2
+      yaml: 2.8.3
       yaml-lint: 1.7.0
     transitivePeerDependencies:
       - '@effect/cluster'
@@ -4633,23 +4804,23 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@savvy-web/rslib-builder@0.18.1(@microsoft/api-extractor@7.57.7(@types/node@25.4.0))(@pnpm/logger@1001.0.1)(@rslib/core@0.19.6(@microsoft/api-extractor@7.57.7(@types/node@25.4.0))(@typescript/native-preview@7.0.0-dev.20260311.1)(typescript@5.9.3))(@types/node@25.4.0)(@typescript/native-preview@7.0.0-dev.20260311.1)(jiti@2.6.1)(typescript@5.9.3)':
+  '@savvy-web/rslib-builder@0.19.0(@microsoft/api-extractor@7.57.7(@types/node@25.5.0))(@pnpm/logger@1001.0.1)(@rslib/core@0.20.0(@microsoft/api-extractor@7.57.7(@types/node@25.5.0))(@typescript/native-preview@7.0.0-dev.20260324.1)(typescript@5.9.3))(@types/node@25.5.0)(@typescript/native-preview@7.0.0-dev.20260324.1)(jiti@2.6.1)(typescript@5.9.3)':
     dependencies:
-      '@microsoft/api-extractor': 7.57.7(@types/node@25.4.0)
+      '@microsoft/api-extractor': 7.57.7(@types/node@25.5.0)
       '@microsoft/tsdoc': 0.16.0
       '@microsoft/tsdoc-config': 0.18.1
-      '@pnpm/catalogs.config': 1000.0.5
+      '@pnpm/catalogs.config': 1000.0.6
       '@pnpm/catalogs.protocol-parser': 1001.0.0
-      '@pnpm/exportable-manifest': 1000.4.1(@pnpm/logger@1001.0.1)
-      '@pnpm/lockfile.fs': 1001.1.31(@pnpm/logger@1001.0.1)
-      '@pnpm/workspace.read-manifest': 1000.3.0
-      '@rslib/core': 0.19.6(@microsoft/api-extractor@7.57.7(@types/node@25.4.0))(@typescript/native-preview@7.0.0-dev.20260311.1)(typescript@5.9.3)
-      '@types/node': 25.4.0
-      '@typescript-eslint/parser': 8.57.0(eslint@10.0.3(jiti@2.6.1))(typescript@5.9.3)
-      '@typescript/native-preview': 7.0.0-dev.20260311.1
+      '@pnpm/exportable-manifest': 1000.4.2(@pnpm/logger@1001.0.1)
+      '@pnpm/lockfile.fs': 1001.1.32(@pnpm/logger@1001.0.1)
+      '@pnpm/workspace.read-manifest': 1000.3.1
+      '@rslib/core': 0.20.0(@microsoft/api-extractor@7.57.7(@types/node@25.5.0))(@typescript/native-preview@7.0.0-dev.20260324.1)(typescript@5.9.3)
+      '@types/node': 25.5.0
+      '@typescript-eslint/parser': 8.57.2(eslint@10.1.0(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript/native-preview': 7.0.0-dev.20260324.1
       deep-equal: 2.2.3
-      eslint: 10.0.3(jiti@2.6.1)
-      eslint-plugin-tsdoc: 0.5.2(eslint@10.0.3(jiti@2.6.1))(typescript@5.9.3)
+      eslint: 10.1.0(jiti@2.6.1)
+      eslint-plugin-tsdoc: 0.5.2(eslint@10.1.0(jiti@2.6.1))(typescript@5.9.3)
       glob: 13.0.6
       picocolors: 1.1.1
       sort-package-json: 3.6.1
@@ -4661,13 +4832,14 @@ snapshots:
       - jiti
       - supports-color
 
-  '@savvy-web/vitest@0.2.1(@types/node@25.4.0)(@typescript/native-preview@7.0.0-dev.20260311.1)(@vitest/coverage-v8@4.0.18(vitest@4.0.18(@types/node@25.4.0)(jiti@2.6.1)(yaml@2.8.2)))(typescript@5.9.3)(vitest@4.0.18(@types/node@25.4.0)(jiti@2.6.1)(yaml@2.8.2))':
+  '@savvy-web/vitest@1.0.0(f6bd36e22e00e000fe24ba2dfdd2d131)':
     dependencies:
-      '@types/node': 25.4.0
-      '@typescript/native-preview': 7.0.0-dev.20260311.1
-      '@vitest/coverage-v8': 4.0.18(vitest@4.0.18(@types/node@25.4.0)(jiti@2.6.1)(yaml@2.8.2))
+      '@types/node': 25.5.0
+      '@typescript/native-preview': 7.0.0-dev.20260324.1
+      '@vitest/coverage-v8': 4.1.1(vitest@4.1.1(@types/node@25.5.0)(vite@8.0.2(@types/node@25.5.0)(jiti@2.6.1)(yaml@2.8.3)))
       typescript: 5.9.3
-      vitest: 4.0.18(@types/node@25.4.0)(jiti@2.6.1)(yaml@2.8.2)
+      vitest: 4.1.1(@types/node@25.5.0)(vite@8.0.2(@types/node@25.5.0)(jiti@2.6.1)(yaml@2.8.3))
+      vitest-agent-reporter: 1.0.0(@effect/cluster@0.58.0(@effect/platform@0.96.0(effect@3.21.0))(@effect/rpc@0.75.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/sql@0.51.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/workflow@0.18.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/platform@0.96.0(effect@3.21.0))(@effect/rpc@0.75.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(effect@3.21.0))(effect@3.21.0))(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/printer-ansi@0.49.0(@effect/typeclass@0.40.0(effect@3.21.0))(effect@3.21.0))(@effect/printer@0.49.0(@effect/typeclass@0.40.0(effect@3.21.0))(effect@3.21.0))(@effect/rpc@0.75.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(typescript@5.9.3)(vitest@4.1.1(@types/node@25.5.0)(vite@8.0.2(@types/node@25.5.0)(jiti@2.6.1)(yaml@2.8.3)))
       workspace-tools: 0.41.0
 
   '@simple-libs/child-process-utils@1.0.2':
@@ -4684,6 +4856,28 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
+  '@trpc/server@11.15.0(typescript@5.9.3)':
+    dependencies:
+      typescript: 5.9.3
+
+  '@turbo/darwin-64@2.8.20':
+    optional: true
+
+  '@turbo/darwin-arm64@2.8.20':
+    optional: true
+
+  '@turbo/linux-64@2.8.20':
+    optional: true
+
+  '@turbo/linux-arm64@2.8.20':
+    optional: true
+
+  '@turbo/windows-64@2.8.20':
+    optional: true
+
+  '@turbo/windows-arm64@2.8.20':
+    optional: true
+
   '@tybys/wasm-util@0.10.1':
     dependencies:
       tslib: 2.8.1
@@ -4696,7 +4890,7 @@ snapshots:
       '@types/deep-eql': 4.0.2
       assertion-error: 2.0.1
 
-  '@types/debug@4.1.12':
+  '@types/debug@4.1.13':
     dependencies:
       '@types/ms': 2.1.0
 
@@ -4718,7 +4912,7 @@ snapshots:
 
   '@types/node@12.20.55': {}
 
-  '@types/node@25.4.0':
+  '@types/node@25.5.0':
     dependencies:
       undici-types: 7.18.2
 
@@ -4730,14 +4924,14 @@ snapshots:
 
   '@types/unist@3.0.3': {}
 
-  '@typescript-eslint/parser@8.57.0(eslint@10.0.3(jiti@2.6.1))(typescript@5.9.3)':
+  '@typescript-eslint/parser@8.57.2(eslint@10.1.0(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
-      '@typescript-eslint/scope-manager': 8.57.0
-      '@typescript-eslint/types': 8.57.0
-      '@typescript-eslint/typescript-estree': 8.57.0(typescript@5.9.3)
-      '@typescript-eslint/visitor-keys': 8.57.0
+      '@typescript-eslint/scope-manager': 8.57.2
+      '@typescript-eslint/types': 8.57.2
+      '@typescript-eslint/typescript-estree': 8.57.2(typescript@5.9.3)
+      '@typescript-eslint/visitor-keys': 8.57.2
       debug: 4.4.3
-      eslint: 10.0.3(jiti@2.6.1)
+      eslint: 10.1.0(jiti@2.6.1)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
@@ -4751,10 +4945,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/project-service@8.57.0(typescript@5.9.3)':
+  '@typescript-eslint/project-service@8.57.2(typescript@5.9.3)':
     dependencies:
-      '@typescript-eslint/tsconfig-utils': 8.57.0(typescript@5.9.3)
-      '@typescript-eslint/types': 8.57.0
+      '@typescript-eslint/tsconfig-utils': 8.57.2(typescript@5.9.3)
+      '@typescript-eslint/types': 8.57.2
       debug: 4.4.3
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -4765,22 +4959,22 @@ snapshots:
       '@typescript-eslint/types': 8.56.1
       '@typescript-eslint/visitor-keys': 8.56.1
 
-  '@typescript-eslint/scope-manager@8.57.0':
+  '@typescript-eslint/scope-manager@8.57.2':
     dependencies:
-      '@typescript-eslint/types': 8.57.0
-      '@typescript-eslint/visitor-keys': 8.57.0
+      '@typescript-eslint/types': 8.57.2
+      '@typescript-eslint/visitor-keys': 8.57.2
 
   '@typescript-eslint/tsconfig-utils@8.56.1(typescript@5.9.3)':
     dependencies:
       typescript: 5.9.3
 
-  '@typescript-eslint/tsconfig-utils@8.57.0(typescript@5.9.3)':
+  '@typescript-eslint/tsconfig-utils@8.57.2(typescript@5.9.3)':
     dependencies:
       typescript: 5.9.3
 
   '@typescript-eslint/types@8.56.1': {}
 
-  '@typescript-eslint/types@8.57.0': {}
+  '@typescript-eslint/types@8.57.2': {}
 
   '@typescript-eslint/typescript-estree@8.56.1(typescript@5.9.3)':
     dependencies:
@@ -4792,33 +4986,33 @@ snapshots:
       minimatch: 10.2.4
       semver: 7.7.4
       tinyglobby: 0.2.15
-      ts-api-utils: 2.4.0(typescript@5.9.3)
+      ts-api-utils: 2.5.0(typescript@5.9.3)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/typescript-estree@8.57.0(typescript@5.9.3)':
+  '@typescript-eslint/typescript-estree@8.57.2(typescript@5.9.3)':
     dependencies:
-      '@typescript-eslint/project-service': 8.57.0(typescript@5.9.3)
-      '@typescript-eslint/tsconfig-utils': 8.57.0(typescript@5.9.3)
-      '@typescript-eslint/types': 8.57.0
-      '@typescript-eslint/visitor-keys': 8.57.0
+      '@typescript-eslint/project-service': 8.57.2(typescript@5.9.3)
+      '@typescript-eslint/tsconfig-utils': 8.57.2(typescript@5.9.3)
+      '@typescript-eslint/types': 8.57.2
+      '@typescript-eslint/visitor-keys': 8.57.2
       debug: 4.4.3
       minimatch: 10.2.4
       semver: 7.7.4
       tinyglobby: 0.2.15
-      ts-api-utils: 2.4.0(typescript@5.9.3)
+      ts-api-utils: 2.5.0(typescript@5.9.3)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.56.1(eslint@10.0.3(jiti@2.6.1))(typescript@5.9.3)':
+  '@typescript-eslint/utils@8.56.1(eslint@10.1.0(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@10.0.3(jiti@2.6.1))
+      '@eslint-community/eslint-utils': 4.9.1(eslint@10.1.0(jiti@2.6.1))
       '@typescript-eslint/scope-manager': 8.56.1
       '@typescript-eslint/types': 8.56.1
       '@typescript-eslint/typescript-estree': 8.56.1(typescript@5.9.3)
-      eslint: 10.0.3(jiti@2.6.1)
+      eslint: 10.1.0(jiti@2.6.1)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
@@ -4828,93 +5022,95 @@ snapshots:
       '@typescript-eslint/types': 8.56.1
       eslint-visitor-keys: 5.0.1
 
-  '@typescript-eslint/visitor-keys@8.57.0':
+  '@typescript-eslint/visitor-keys@8.57.2':
     dependencies:
-      '@typescript-eslint/types': 8.57.0
+      '@typescript-eslint/types': 8.57.2
       eslint-visitor-keys: 5.0.1
 
-  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260311.1':
+  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260324.1':
     optional: true
 
-  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260311.1':
+  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260324.1':
     optional: true
 
-  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260311.1':
+  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260324.1':
     optional: true
 
-  '@typescript/native-preview-linux-arm@7.0.0-dev.20260311.1':
+  '@typescript/native-preview-linux-arm@7.0.0-dev.20260324.1':
     optional: true
 
-  '@typescript/native-preview-linux-x64@7.0.0-dev.20260311.1':
+  '@typescript/native-preview-linux-x64@7.0.0-dev.20260324.1':
     optional: true
 
-  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260311.1':
+  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260324.1':
     optional: true
 
-  '@typescript/native-preview-win32-x64@7.0.0-dev.20260311.1':
+  '@typescript/native-preview-win32-x64@7.0.0-dev.20260324.1':
     optional: true
 
-  '@typescript/native-preview@7.0.0-dev.20260311.1':
+  '@typescript/native-preview@7.0.0-dev.20260324.1':
     optionalDependencies:
-      '@typescript/native-preview-darwin-arm64': 7.0.0-dev.20260311.1
-      '@typescript/native-preview-darwin-x64': 7.0.0-dev.20260311.1
-      '@typescript/native-preview-linux-arm': 7.0.0-dev.20260311.1
-      '@typescript/native-preview-linux-arm64': 7.0.0-dev.20260311.1
-      '@typescript/native-preview-linux-x64': 7.0.0-dev.20260311.1
-      '@typescript/native-preview-win32-arm64': 7.0.0-dev.20260311.1
-      '@typescript/native-preview-win32-x64': 7.0.0-dev.20260311.1
+      '@typescript/native-preview-darwin-arm64': 7.0.0-dev.20260324.1
+      '@typescript/native-preview-darwin-x64': 7.0.0-dev.20260324.1
+      '@typescript/native-preview-linux-arm': 7.0.0-dev.20260324.1
+      '@typescript/native-preview-linux-arm64': 7.0.0-dev.20260324.1
+      '@typescript/native-preview-linux-x64': 7.0.0-dev.20260324.1
+      '@typescript/native-preview-win32-arm64': 7.0.0-dev.20260324.1
+      '@typescript/native-preview-win32-x64': 7.0.0-dev.20260324.1
 
-  '@vitest/coverage-v8@4.0.18(vitest@4.0.18(@types/node@25.4.0)(jiti@2.6.1)(yaml@2.8.2))':
+  '@vitest/coverage-v8@4.1.1(vitest@4.1.1(@types/node@25.5.0)(vite@8.0.2(@types/node@25.5.0)(jiti@2.6.1)(yaml@2.8.3)))':
     dependencies:
       '@bcoe/v8-coverage': 1.0.2
-      '@vitest/utils': 4.0.18
-      ast-v8-to-istanbul: 0.3.12
+      '@vitest/utils': 4.1.1
+      ast-v8-to-istanbul: 1.0.0
       istanbul-lib-coverage: 3.2.2
       istanbul-lib-report: 3.0.1
       istanbul-reports: 3.2.0
       magicast: 0.5.2
       obug: 2.1.1
-      std-env: 3.10.0
+      std-env: 4.0.0
       tinyrainbow: 3.1.0
-      vitest: 4.0.18(@types/node@25.4.0)(jiti@2.6.1)(yaml@2.8.2)
+      vitest: 4.1.1(@types/node@25.5.0)(vite@8.0.2(@types/node@25.5.0)(jiti@2.6.1)(yaml@2.8.3))
 
-  '@vitest/expect@4.0.18':
+  '@vitest/expect@4.1.1':
     dependencies:
       '@standard-schema/spec': 1.1.0
       '@types/chai': 5.2.3
-      '@vitest/spy': 4.0.18
-      '@vitest/utils': 4.0.18
+      '@vitest/spy': 4.1.1
+      '@vitest/utils': 4.1.1
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.0.18(vite@7.3.1(@types/node@25.4.0)(jiti@2.6.1)(yaml@2.8.2))':
+  '@vitest/mocker@4.1.1(vite@8.0.2(@types/node@25.5.0)(jiti@2.6.1)(yaml@2.8.3))':
     dependencies:
-      '@vitest/spy': 4.0.18
+      '@vitest/spy': 4.1.1
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.1(@types/node@25.4.0)(jiti@2.6.1)(yaml@2.8.2)
+      vite: 8.0.2(@types/node@25.5.0)(jiti@2.6.1)(yaml@2.8.3)
 
-  '@vitest/pretty-format@4.0.18':
+  '@vitest/pretty-format@4.1.1':
     dependencies:
       tinyrainbow: 3.1.0
 
-  '@vitest/runner@4.0.18':
+  '@vitest/runner@4.1.1':
     dependencies:
-      '@vitest/utils': 4.0.18
+      '@vitest/utils': 4.1.1
       pathe: 2.0.3
 
-  '@vitest/snapshot@4.0.18':
+  '@vitest/snapshot@4.1.1':
     dependencies:
-      '@vitest/pretty-format': 4.0.18
+      '@vitest/pretty-format': 4.1.1
+      '@vitest/utils': 4.1.1
       magic-string: 0.30.21
       pathe: 2.0.3
 
-  '@vitest/spy@4.0.18': {}
+  '@vitest/spy@4.1.1': {}
 
-  '@vitest/utils@4.0.18':
+  '@vitest/utils@4.1.1':
     dependencies:
-      '@vitest/pretty-format': 4.0.18
+      '@vitest/pretty-format': 4.1.1
+      convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
   '@yarnpkg/lockfile@1.1.0': {}
@@ -4928,6 +5124,11 @@ snapshots:
   '@zkochan/which@2.0.3':
     dependencies:
       isexe: 2.0.0
+
+  accepts@2.0.0:
+    dependencies:
+      mime-types: 3.0.2
+      negotiator: 1.0.0
 
   acorn-jsx@5.3.2(acorn@8.16.0):
     dependencies:
@@ -4990,7 +5191,7 @@ snapshots:
 
   assertion-error@2.0.1: {}
 
-  ast-v8-to-istanbul@0.3.12:
+  ast-v8-to-istanbul@1.0.0:
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       estree-walker: 3.0.3
@@ -5006,22 +5207,60 @@ snapshots:
 
   balanced-match@4.0.4: {}
 
+  base64-js@1.5.1: {}
+
   better-path-resolve@1.0.0:
     dependencies:
       is-windows: 1.0.2
+
+  better-sqlite3@12.8.0:
+    dependencies:
+      bindings: 1.5.0
+      prebuild-install: 7.1.3
+
+  bindings@1.5.0:
+    dependencies:
+      file-uri-to-path: 1.0.0
+
+  bl@4.1.0:
+    dependencies:
+      buffer: 5.7.1
+      inherits: 2.0.4
+      readable-stream: 3.6.2
+
+  body-parser@2.2.2:
+    dependencies:
+      bytes: 3.1.2
+      content-type: 1.0.5
+      debug: 4.4.3
+      http-errors: 2.0.1
+      iconv-lite: 0.7.2
+      on-finished: 2.4.1
+      qs: 6.15.0
+      raw-body: 3.0.2
+      type-is: 2.0.1
+    transitivePeerDependencies:
+      - supports-color
 
   bole@5.0.28:
     dependencies:
       fast-safe-stringify: 2.1.1
       individual: 3.0.0
 
-  brace-expansion@5.0.4:
+  brace-expansion@5.0.5:
     dependencies:
       balanced-match: 4.0.4
 
   braces@3.0.3:
     dependencies:
       fill-range: 7.1.1
+
+  buffer@5.7.1:
+    dependencies:
+      base64-js: 1.5.1
+      ieee754: 1.2.1
+
+  bytes@3.1.2: {}
 
   call-bind-apply-helpers@1.0.2:
     dependencies:
@@ -5053,6 +5292,8 @@ snapshots:
   character-reference-invalid@2.0.1: {}
 
   chardet@2.1.1: {}
+
+  chownr@1.1.4: {}
 
   cli-cursor@5.0.0:
     dependencies:
@@ -5096,6 +5337,10 @@ snapshots:
 
   consola@2.15.3: {}
 
+  content-disposition@1.0.1: {}
+
+  content-type@1.0.5: {}
+
   conventional-changelog-angular@8.3.0:
     dependencies:
       compare-func: 2.0.0
@@ -5109,11 +5354,20 @@ snapshots:
       '@simple-libs/stream-utils': 1.2.0
       meow: 13.2.0
 
-  core-js@3.47.0: {}
+  convert-source-map@2.0.0: {}
 
-  cosmiconfig-typescript-loader@6.2.0(@types/node@25.4.0)(cosmiconfig@9.0.1(typescript@5.9.3))(typescript@5.9.3):
+  cookie-signature@1.2.2: {}
+
+  cookie@0.7.2: {}
+
+  cors@2.8.6:
     dependencies:
-      '@types/node': 25.4.0
+      object-assign: 4.1.1
+      vary: 1.1.2
+
+  cosmiconfig-typescript-loader@6.2.0(@types/node@25.5.0)(cosmiconfig@9.0.1(typescript@5.9.3))(typescript@5.9.3):
+    dependencies:
+      '@types/node': 25.5.0
       cosmiconfig: 9.0.1(typescript@5.9.3)
       jiti: 2.6.1
       typescript: 5.9.3
@@ -5143,6 +5397,10 @@ snapshots:
     dependencies:
       character-entities: 2.0.2
 
+  decompress-response@6.0.0:
+    dependencies:
+      mimic-response: 3.1.0
+
   deep-equal@2.2.3:
     dependencies:
       array-buffer-byte-length: 1.0.2
@@ -5164,6 +5422,8 @@ snapshots:
       which-collection: 1.0.2
       which-typed-array: 1.1.20
 
+  deep-extend@0.6.0: {}
+
   deep-is@0.1.4: {}
 
   define-data-property@1.1.4:
@@ -5177,6 +5437,8 @@ snapshots:
       define-data-property: 1.1.4
       has-property-descriptors: 1.0.2
       object-keys: 1.1.1
+
+  depd@2.0.0: {}
 
   dequal@2.0.3: {}
 
@@ -5192,7 +5454,7 @@ snapshots:
     dependencies:
       dequal: 2.0.3
 
-  diff@8.0.3: {}
+  diff@8.0.4: {}
 
   dir-glob@3.0.1:
     dependencies:
@@ -5208,7 +5470,9 @@ snapshots:
       es-errors: 1.3.0
       gopd: 1.2.0
 
-  effect@3.19.19:
+  ee-first@1.1.1: {}
+
+  effect@3.21.0:
     dependencies:
       '@standard-schema/spec': 1.1.0
       fast-check: 3.23.2
@@ -5216,6 +5480,12 @@ snapshots:
   emoji-regex@10.6.0: {}
 
   emoji-regex@8.0.0: {}
+
+  encodeurl@2.0.0: {}
+
+  end-of-stream@1.4.5:
+    dependencies:
+      once: 1.4.0
 
   enquirer@2.4.1:
     dependencies:
@@ -5248,52 +5518,25 @@ snapshots:
       isarray: 2.0.5
       stop-iteration-iterator: 1.1.0
 
-  es-module-lexer@1.7.0: {}
+  es-module-lexer@2.0.0: {}
 
   es-object-atoms@1.1.1:
     dependencies:
       es-errors: 1.3.0
 
-  esbuild@0.27.4:
-    optionalDependencies:
-      '@esbuild/aix-ppc64': 0.27.4
-      '@esbuild/android-arm': 0.27.4
-      '@esbuild/android-arm64': 0.27.4
-      '@esbuild/android-x64': 0.27.4
-      '@esbuild/darwin-arm64': 0.27.4
-      '@esbuild/darwin-x64': 0.27.4
-      '@esbuild/freebsd-arm64': 0.27.4
-      '@esbuild/freebsd-x64': 0.27.4
-      '@esbuild/linux-arm': 0.27.4
-      '@esbuild/linux-arm64': 0.27.4
-      '@esbuild/linux-ia32': 0.27.4
-      '@esbuild/linux-loong64': 0.27.4
-      '@esbuild/linux-mips64el': 0.27.4
-      '@esbuild/linux-ppc64': 0.27.4
-      '@esbuild/linux-riscv64': 0.27.4
-      '@esbuild/linux-s390x': 0.27.4
-      '@esbuild/linux-x64': 0.27.4
-      '@esbuild/netbsd-arm64': 0.27.4
-      '@esbuild/netbsd-x64': 0.27.4
-      '@esbuild/openbsd-arm64': 0.27.4
-      '@esbuild/openbsd-x64': 0.27.4
-      '@esbuild/openharmony-arm64': 0.27.4
-      '@esbuild/sunos-x64': 0.27.4
-      '@esbuild/win32-arm64': 0.27.4
-      '@esbuild/win32-ia32': 0.27.4
-      '@esbuild/win32-x64': 0.27.4
-
   escalade@3.2.0: {}
+
+  escape-html@1.0.3: {}
 
   escape-string-regexp@4.0.0: {}
 
   escape-string-regexp@5.0.0: {}
 
-  eslint-plugin-tsdoc@0.5.2(eslint@10.0.3(jiti@2.6.1))(typescript@5.9.3):
+  eslint-plugin-tsdoc@0.5.2(eslint@10.1.0(jiti@2.6.1))(typescript@5.9.3):
     dependencies:
       '@microsoft/tsdoc': 0.16.0
       '@microsoft/tsdoc-config': 0.18.1
-      '@typescript-eslint/utils': 8.56.1(eslint@10.0.3(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.56.1(eslint@10.1.0(jiti@2.6.1))(typescript@5.9.3)
     transitivePeerDependencies:
       - eslint
       - supports-color
@@ -5310,9 +5553,9 @@ snapshots:
 
   eslint-visitor-keys@5.0.1: {}
 
-  eslint@10.0.3(jiti@2.6.1):
+  eslint@10.1.0(jiti@2.6.1):
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@10.0.3(jiti@2.6.1))
+      '@eslint-community/eslint-utils': 4.9.1(eslint@10.1.0(jiti@2.6.1))
       '@eslint-community/regexpp': 4.12.2
       '@eslint/config-array': 0.23.3
       '@eslint/config-helpers': 0.5.3
@@ -5371,7 +5614,15 @@ snapshots:
 
   esutils@2.0.3: {}
 
+  etag@1.8.1: {}
+
   eventemitter3@5.0.4: {}
+
+  eventsource-parser@3.0.6: {}
+
+  eventsource@3.0.7:
+    dependencies:
+      eventsource-parser: 3.0.6
 
   execa@5.1.1:
     dependencies:
@@ -5385,7 +5636,47 @@ snapshots:
       signal-exit: 3.0.7
       strip-final-newline: 2.0.0
 
+  expand-template@2.0.3: {}
+
   expect-type@1.3.0: {}
+
+  express-rate-limit@8.3.1(express@5.2.1):
+    dependencies:
+      express: 5.2.1
+      ip-address: 10.1.0
+
+  express@5.2.1:
+    dependencies:
+      accepts: 2.0.0
+      body-parser: 2.2.2
+      content-disposition: 1.0.1
+      content-type: 1.0.5
+      cookie: 0.7.2
+      cookie-signature: 1.2.2
+      debug: 4.4.3
+      depd: 2.0.0
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      finalhandler: 2.1.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      merge-descriptors: 2.0.0
+      mime-types: 3.0.2
+      on-finished: 2.4.1
+      once: 1.4.0
+      parseurl: 1.3.3
+      proxy-addr: 2.0.7
+      qs: 6.15.0
+      range-parser: 1.2.1
+      router: 2.2.0
+      send: 1.2.1
+      serve-static: 2.2.1
+      statuses: 2.0.2
+      type-is: 2.0.1
+      vary: 1.1.2
+    transitivePeerDependencies:
+      - supports-color
 
   extend@3.0.2: {}
 
@@ -5417,17 +5708,30 @@ snapshots:
     dependencies:
       reusify: 1.1.0
 
-  fdir@6.5.0(picomatch@4.0.3):
+  fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
-      picomatch: 4.0.3
+      picomatch: 4.0.4
 
   file-entry-cache@8.0.0:
     dependencies:
       flat-cache: 4.0.1
 
+  file-uri-to-path@1.0.0: {}
+
   fill-range@7.1.1:
     dependencies:
       to-regex-range: 5.0.1
+
+  finalhandler@2.1.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      on-finished: 2.4.1
+      parseurl: 1.3.3
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
 
   find-my-way-ts@0.1.6: {}
 
@@ -5443,14 +5747,20 @@ snapshots:
 
   flat-cache@4.0.1:
     dependencies:
-      flatted: 3.4.1
+      flatted: 3.4.2
       keyv: 4.5.4
 
-  flatted@3.4.1: {}
+  flatted@3.4.2: {}
 
   for-each@0.3.5:
     dependencies:
       is-callable: 1.2.7
+
+  forwarded@0.2.0: {}
+
+  fresh@2.0.0: {}
+
+  fs-constants@1.0.0: {}
 
   fs-extra@11.3.4:
     dependencies:
@@ -5522,6 +5832,8 @@ snapshots:
     dependencies:
       git-up: 8.1.1
 
+  github-from-package@0.0.0: {}
+
   glob-parent@5.1.2:
     dependencies:
       is-glob: 4.0.3
@@ -5549,7 +5861,7 @@ snapshots:
       merge2: 1.4.1
       slash: 3.0.0
 
-  globby@16.1.0:
+  globby@16.1.1:
     dependencies:
       '@sindresorhus/merge-streams': 4.0.0
       fast-glob: 3.3.3
@@ -5580,7 +5892,17 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
+  hono@4.12.9: {}
+
   html-escaper@2.0.2: {}
+
+  http-errors@2.0.1:
+    dependencies:
+      depd: 2.0.0
+      inherits: 2.0.4
+      setprototypeof: 1.2.0
+      statuses: 2.0.2
+      toidentifier: 1.0.1
 
   human-id@4.1.3: {}
 
@@ -5591,6 +5913,8 @@ snapshots:
   iconv-lite@0.7.2:
     dependencies:
       safer-buffer: 2.1.2
+
+  ieee754@1.2.1: {}
 
   ignore@5.3.2: {}
 
@@ -5609,6 +5933,10 @@ snapshots:
 
   individual@3.0.0: {}
 
+  inherits@2.0.4: {}
+
+  ini@1.3.8: {}
+
   ini@2.0.0: {}
 
   ini@4.1.1: {}
@@ -5620,6 +5948,10 @@ snapshots:
       es-errors: 1.3.0
       hasown: 2.0.2
       side-channel: 1.1.0
+
+  ip-address@10.1.0: {}
+
+  ipaddr.js@1.9.1: {}
 
   is-alphabetical@2.0.1: {}
 
@@ -5694,6 +6026,8 @@ snapshots:
 
   is-plain-obj@4.1.0: {}
 
+  is-promise@4.0.0: {}
+
   is-regex@1.2.1:
     dependencies:
       call-bound: 1.0.4
@@ -5758,6 +6092,8 @@ snapshots:
 
   jju@1.4.0: {}
 
+  jose@6.2.2: {}
+
   js-tokens@10.0.0: {}
 
   js-tokens@4.0.0: {}
@@ -5779,13 +6115,15 @@ snapshots:
 
   json-schema-traverse@1.0.0: {}
 
+  json-schema-typed@8.0.2: {}
+
   json-stable-stringify-without-jsonify@1.0.1: {}
 
   json5@2.2.3: {}
 
   jsonc-effect@0.2.0:
     dependencies:
-      effect: 3.19.19
+      effect: 3.21.0
 
   jsonc-parser@3.3.1: {}
 
@@ -5799,7 +6137,9 @@ snapshots:
     optionalDependencies:
       graceful-fs: 4.2.11
 
-  katex@0.16.38:
+  jsonpointer@5.0.1: {}
+
+  katex@0.16.42:
     dependencies:
       commander: 8.3.0
 
@@ -5814,20 +6154,69 @@ snapshots:
       prelude-ls: 1.2.1
       type-check: 0.4.0
 
+  lightningcss-android-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-x64@1.32.0:
+    optional: true
+
+  lightningcss-freebsd-x64@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-musl@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-musl@1.32.0:
+    optional: true
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    optional: true
+
+  lightningcss-win32-x64-msvc@1.32.0:
+    optional: true
+
+  lightningcss@1.32.0:
+    dependencies:
+      detect-libc: 2.1.2
+    optionalDependencies:
+      lightningcss-android-arm64: 1.32.0
+      lightningcss-darwin-arm64: 1.32.0
+      lightningcss-darwin-x64: 1.32.0
+      lightningcss-freebsd-x64: 1.32.0
+      lightningcss-linux-arm-gnueabihf: 1.32.0
+      lightningcss-linux-arm64-gnu: 1.32.0
+      lightningcss-linux-arm64-musl: 1.32.0
+      lightningcss-linux-x64-gnu: 1.32.0
+      lightningcss-linux-x64-musl: 1.32.0
+      lightningcss-win32-arm64-msvc: 1.32.0
+      lightningcss-win32-x64-msvc: 1.32.0
+
   lines-and-columns@1.2.4: {}
 
   linkify-it@5.0.0:
     dependencies:
       uc.micro: 2.1.0
 
-  lint-staged@16.3.3:
+  lint-staged@16.4.0:
     dependencies:
       commander: 14.0.3
       listr2: 9.0.5
-      micromatch: 4.0.8
+      picomatch: 4.0.4
       string-argv: 0.3.2
       tinyexec: 1.0.4
-      yaml: 2.8.2
+      yaml: 2.8.3
 
   listr2@9.0.5:
     dependencies:
@@ -5882,7 +6271,7 @@ snapshots:
 
   magicast@0.5.2:
     dependencies:
-      '@babel/parser': 7.29.0
+      '@babel/parser': 7.29.2
       '@babel/types': 7.29.0
       source-map-js: 1.2.1
 
@@ -5901,23 +6290,25 @@ snapshots:
 
   markdown-table@3.0.4: {}
 
-  markdownlint-cli2-formatter-codequality@0.0.7(markdownlint-cli2@0.21.0):
+  markdownlint-cli2-formatter-codequality@0.0.7(markdownlint-cli2@0.22.0):
     dependencies:
-      markdownlint-cli2: 0.21.0
+      markdownlint-cli2: 0.22.0
 
-  markdownlint-cli2-formatter-default@0.0.6(markdownlint-cli2@0.21.0):
+  markdownlint-cli2-formatter-default@0.0.6(markdownlint-cli2@0.22.0):
     dependencies:
-      markdownlint-cli2: 0.21.0
+      markdownlint-cli2: 0.22.0
 
-  markdownlint-cli2@0.21.0:
+  markdownlint-cli2@0.22.0:
     dependencies:
-      globby: 16.1.0
+      globby: 16.1.1
       js-yaml: 4.1.1
       jsonc-parser: 3.3.1
+      jsonpointer: 5.0.1
       markdown-it: 14.1.1
       markdownlint: 0.40.0
-      markdownlint-cli2-formatter-default: 0.0.6(markdownlint-cli2@0.21.0)
+      markdownlint-cli2-formatter-default: 0.0.6(markdownlint-cli2@0.22.0)
       micromatch: 4.0.8
+      smol-toml: 1.6.0
     transitivePeerDependencies:
       - supports-color
 
@@ -6048,7 +6439,11 @@ snapshots:
 
   mdurl@2.0.0: {}
 
+  media-typer@1.1.0: {}
+
   meow@13.2.0: {}
+
+  merge-descriptors@2.0.0: {}
 
   merge-stream@2.0.0: {}
 
@@ -6145,7 +6540,7 @@ snapshots:
     dependencies:
       '@types/katex': 0.16.8
       devlop: 1.1.0
-      katex: 0.16.38
+      katex: 0.16.42
       micromark-factory-space: 2.0.1
       micromark-util-character: 2.1.1
       micromark-util-symbol: 2.0.1
@@ -6245,7 +6640,7 @@ snapshots:
 
   micromark@4.0.2:
     dependencies:
-      '@types/debug': 4.1.12
+      '@types/debug': 4.1.13
       debug: 4.4.3
       decode-named-character-reference: 1.3.0
       devlop: 1.1.0
@@ -6268,7 +6663,13 @@ snapshots:
   micromatch@4.0.8:
     dependencies:
       braces: 3.0.3
-      picomatch: 2.3.1
+      picomatch: 2.3.2
+
+  mime-db@1.54.0: {}
+
+  mime-types@3.0.2:
+    dependencies:
+      mime-db: 1.54.0
 
   mime@3.0.0: {}
 
@@ -6276,13 +6677,17 @@ snapshots:
 
   mimic-function@5.0.1: {}
 
+  mimic-response@3.1.0: {}
+
   minimatch@10.2.4:
     dependencies:
-      brace-expansion: 5.0.4
+      brace-expansion: 5.0.5
 
   minimist@1.2.8: {}
 
   minipass@7.1.3: {}
+
+  mkdirp-classic@0.5.3: {}
 
   mri@1.2.0: {}
 
@@ -6308,6 +6713,8 @@ snapshots:
 
   nanoid@3.3.11: {}
 
+  napi-build-utils@2.0.0: {}
+
   natural-compare@1.4.0: {}
 
   nconf@0.12.1:
@@ -6316,6 +6723,12 @@ snapshots:
       ini: 2.0.0
       secure-keys: 1.0.0
       yargs: 16.2.0
+
+  negotiator@1.0.0: {}
+
+  node-abi@3.89.0:
+    dependencies:
+      semver: 7.7.4
 
   node-addon-api@7.1.1: {}
 
@@ -6333,6 +6746,8 @@ snapshots:
   npm-run-path@4.0.1:
     dependencies:
       path-key: 3.1.1
+
+  object-assign@4.1.1: {}
 
   object-inspect@1.13.4: {}
 
@@ -6353,6 +6768,14 @@ snapshots:
       object-keys: 1.1.1
 
   obug@2.1.1: {}
+
+  on-finished@2.4.1:
+    dependencies:
+      ee-first: 1.1.1
+
+  once@1.4.0:
+    dependencies:
+      wrappy: 1.0.2
 
   onetime@5.1.2:
     dependencies:
@@ -6433,6 +6856,8 @@ snapshots:
       '@types/parse-path': 7.1.0
       parse-path: 7.1.0
 
+  parseurl@1.3.3: {}
+
   path-exists@4.0.0: {}
 
   path-key@3.1.1: {}
@@ -6446,17 +6871,21 @@ snapshots:
       lru-cache: 11.2.7
       minipass: 7.1.3
 
+  path-to-regexp@8.3.0: {}
+
   path-type@4.0.0: {}
 
   pathe@2.0.3: {}
 
   picocolors@1.1.1: {}
 
-  picomatch@2.3.1: {}
+  picomatch@2.3.2: {}
 
-  picomatch@4.0.3: {}
+  picomatch@4.0.4: {}
 
   pify@4.0.1: {}
+
+  pkce-challenge@5.0.1: {}
 
   possible-typed-array-names@1.1.0: {}
 
@@ -6466,6 +6895,21 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
+  prebuild-install@7.1.3:
+    dependencies:
+      detect-libc: 2.1.2
+      expand-template: 2.0.3
+      github-from-package: 0.0.0
+      minimist: 1.2.8
+      mkdirp-classic: 0.5.3
+      napi-build-utils: 2.0.0
+      node-abi: 3.89.0
+      pump: 3.0.4
+      rc: 1.2.8
+      simple-get: 4.0.1
+      tar-fs: 2.1.4
+      tunnel-agent: 0.6.0
+
   prelude-ls@1.2.1: {}
 
   prettier@2.8.8: {}
@@ -6474,15 +6918,45 @@ snapshots:
 
   protocols@2.0.2: {}
 
+  proxy-addr@2.0.7:
+    dependencies:
+      forwarded: 0.2.0
+      ipaddr.js: 1.9.1
+
+  pump@3.0.4:
+    dependencies:
+      end-of-stream: 1.4.5
+      once: 1.4.0
+
   punycode.js@2.3.1: {}
 
   punycode@2.3.1: {}
 
   pure-rand@6.1.0: {}
 
+  qs@6.15.0:
+    dependencies:
+      side-channel: 1.1.0
+
   quansync@0.2.11: {}
 
   queue-microtask@1.2.3: {}
+
+  range-parser@1.2.1: {}
+
+  raw-body@3.0.2:
+    dependencies:
+      bytes: 3.1.2
+      http-errors: 2.0.1
+      iconv-lite: 0.7.2
+      unpipe: 1.0.0
+
+  rc@1.2.8:
+    dependencies:
+      deep-extend: 0.6.0
+      ini: 1.3.8
+      minimist: 1.2.8
+      strip-json-comments: 2.0.1
 
   read-yaml-file@1.1.0:
     dependencies:
@@ -6495,6 +6969,12 @@ snapshots:
     dependencies:
       js-yaml: 4.1.1
       strip-bom: 4.0.0
+
+  readable-stream@3.6.2:
+    dependencies:
+      inherits: 2.0.4
+      string_decoder: 1.3.0
+      util-deprecate: 1.0.2
 
   regexp.prototype.flags@1.5.4:
     dependencies:
@@ -6554,49 +7034,51 @@ snapshots:
 
   rfdc@1.4.1: {}
 
-  rollup@4.59.0:
+  rolldown@1.0.0-rc.11:
     dependencies:
-      '@types/estree': 1.0.8
+      '@oxc-project/types': 0.122.0
+      '@rolldown/pluginutils': 1.0.0-rc.11
     optionalDependencies:
-      '@rollup/rollup-android-arm-eabi': 4.59.0
-      '@rollup/rollup-android-arm64': 4.59.0
-      '@rollup/rollup-darwin-arm64': 4.59.0
-      '@rollup/rollup-darwin-x64': 4.59.0
-      '@rollup/rollup-freebsd-arm64': 4.59.0
-      '@rollup/rollup-freebsd-x64': 4.59.0
-      '@rollup/rollup-linux-arm-gnueabihf': 4.59.0
-      '@rollup/rollup-linux-arm-musleabihf': 4.59.0
-      '@rollup/rollup-linux-arm64-gnu': 4.59.0
-      '@rollup/rollup-linux-arm64-musl': 4.59.0
-      '@rollup/rollup-linux-loong64-gnu': 4.59.0
-      '@rollup/rollup-linux-loong64-musl': 4.59.0
-      '@rollup/rollup-linux-ppc64-gnu': 4.59.0
-      '@rollup/rollup-linux-ppc64-musl': 4.59.0
-      '@rollup/rollup-linux-riscv64-gnu': 4.59.0
-      '@rollup/rollup-linux-riscv64-musl': 4.59.0
-      '@rollup/rollup-linux-s390x-gnu': 4.59.0
-      '@rollup/rollup-linux-x64-gnu': 4.59.0
-      '@rollup/rollup-linux-x64-musl': 4.59.0
-      '@rollup/rollup-openbsd-x64': 4.59.0
-      '@rollup/rollup-openharmony-arm64': 4.59.0
-      '@rollup/rollup-win32-arm64-msvc': 4.59.0
-      '@rollup/rollup-win32-ia32-msvc': 4.59.0
-      '@rollup/rollup-win32-x64-gnu': 4.59.0
-      '@rollup/rollup-win32-x64-msvc': 4.59.0
-      fsevents: 2.3.3
+      '@rolldown/binding-android-arm64': 1.0.0-rc.11
+      '@rolldown/binding-darwin-arm64': 1.0.0-rc.11
+      '@rolldown/binding-darwin-x64': 1.0.0-rc.11
+      '@rolldown/binding-freebsd-x64': 1.0.0-rc.11
+      '@rolldown/binding-linux-arm-gnueabihf': 1.0.0-rc.11
+      '@rolldown/binding-linux-arm64-gnu': 1.0.0-rc.11
+      '@rolldown/binding-linux-arm64-musl': 1.0.0-rc.11
+      '@rolldown/binding-linux-ppc64-gnu': 1.0.0-rc.11
+      '@rolldown/binding-linux-s390x-gnu': 1.0.0-rc.11
+      '@rolldown/binding-linux-x64-gnu': 1.0.0-rc.11
+      '@rolldown/binding-linux-x64-musl': 1.0.0-rc.11
+      '@rolldown/binding-openharmony-arm64': 1.0.0-rc.11
+      '@rolldown/binding-wasm32-wasi': 1.0.0-rc.11
+      '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.11
+      '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.11
 
-  rsbuild-plugin-dts@0.19.6(@microsoft/api-extractor@7.57.7(@types/node@25.4.0))(@rsbuild/core@1.7.3)(@typescript/native-preview@7.0.0-dev.20260311.1)(typescript@5.9.3):
+  router@2.2.0:
+    dependencies:
+      debug: 4.4.3
+      depd: 2.0.0
+      is-promise: 4.0.0
+      parseurl: 1.3.3
+      path-to-regexp: 8.3.0
+    transitivePeerDependencies:
+      - supports-color
+
+  rsbuild-plugin-dts@0.20.0(@microsoft/api-extractor@7.57.7(@types/node@25.5.0))(@rsbuild/core@2.0.0-beta.8)(@typescript/native-preview@7.0.0-dev.20260324.1)(typescript@5.9.3):
     dependencies:
       '@ast-grep/napi': 0.37.0
-      '@rsbuild/core': 1.7.3
+      '@rsbuild/core': 2.0.0-beta.8
     optionalDependencies:
-      '@microsoft/api-extractor': 7.57.7(@types/node@25.4.0)
-      '@typescript/native-preview': 7.0.0-dev.20260311.1
+      '@microsoft/api-extractor': 7.57.7(@types/node@25.5.0)
+      '@typescript/native-preview': 7.0.0-dev.20260324.1
       typescript: 5.9.3
 
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
+
+  safe-buffer@5.2.1: {}
 
   safe-execa@0.1.2:
     dependencies:
@@ -6614,15 +7096,40 @@ snapshots:
 
   secure-keys@1.0.0: {}
 
-  semver-effect@0.1.0(effect@3.19.19):
+  semver-effect@0.2.0(effect@3.21.0):
     dependencies:
-      effect: 3.19.19
+      effect: 3.21.0
 
   semver@7.5.4:
     dependencies:
       lru-cache: 6.0.0
 
   semver@7.7.4: {}
+
+  send@1.2.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      mime-types: 3.0.2
+      ms: 2.1.3
+      on-finished: 2.4.1
+      range-parser: 1.2.1
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
+  serve-static@2.2.1:
+    dependencies:
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      parseurl: 1.3.3
+      send: 1.2.1
+    transitivePeerDependencies:
+      - supports-color
 
   set-function-length@1.2.2:
     dependencies:
@@ -6639,6 +7146,8 @@ snapshots:
       es-errors: 1.3.0
       functions-have-names: 1.2.3
       has-property-descriptors: 1.0.2
+
+  setprototypeof@1.2.0: {}
 
   shebang-command@2.0.0:
     dependencies:
@@ -6680,6 +7189,14 @@ snapshots:
 
   signal-exit@4.1.0: {}
 
+  simple-concat@1.0.1: {}
+
+  simple-get@4.0.1:
+    dependencies:
+      decompress-response: 6.0.0
+      once: 1.4.0
+      simple-concat: 1.0.1
+
   slash@3.0.0: {}
 
   slash@5.1.0: {}
@@ -6693,6 +7210,8 @@ snapshots:
     dependencies:
       ansi-styles: 6.2.3
       is-fullwidth-code-point: 5.1.0
+
+  smol-toml@1.6.0: {}
 
   sort-keys@4.2.0:
     dependencies:
@@ -6729,7 +7248,9 @@ snapshots:
 
   stackback@0.0.2: {}
 
-  std-env@3.10.0: {}
+  statuses@2.0.2: {}
+
+  std-env@4.0.0: {}
 
   stop-iteration-iterator@1.1.0:
     dependencies:
@@ -6760,6 +7281,10 @@ snapshots:
       get-east-asian-width: 1.5.0
       strip-ansi: 7.2.0
 
+  string_decoder@1.3.0:
+    dependencies:
+      safe-buffer: 5.2.1
+
   strip-ansi@6.0.1:
     dependencies:
       ansi-regex: 5.0.1
@@ -6776,6 +7301,8 @@ snapshots:
 
   strip-final-newline@2.0.0: {}
 
+  strip-json-comments@2.0.1: {}
+
   strip-json-comments@3.1.1: {}
 
   supports-color@7.2.0:
@@ -6788,6 +7315,21 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
+  tar-fs@2.1.4:
+    dependencies:
+      chownr: 1.1.4
+      mkdirp-classic: 0.5.3
+      pump: 3.0.4
+      tar-stream: 2.2.0
+
+  tar-stream@2.2.0:
+    dependencies:
+      bl: 4.1.0
+      end-of-stream: 1.4.5
+      fs-constants: 1.0.0
+      inherits: 2.0.4
+      readable-stream: 3.6.2
+
   term-size@2.2.1: {}
 
   tinybench@2.9.0: {}
@@ -6796,8 +7338,8 @@ snapshots:
 
   tinyglobby@0.2.15:
     dependencies:
-      fdir: 6.5.0(picomatch@4.0.3)
-      picomatch: 4.0.3
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
 
   tinyrainbow@3.1.0: {}
 
@@ -6807,48 +7349,42 @@ snapshots:
     dependencies:
       is-number: 7.0.0
 
+  toidentifier@1.0.1: {}
+
   toml@3.0.0: {}
 
   tr46@0.0.3: {}
 
   trough@2.2.0: {}
 
-  ts-api-utils@2.4.0(typescript@5.9.3):
+  ts-api-utils@2.5.0(typescript@5.9.3):
     dependencies:
       typescript: 5.9.3
 
   tslib@2.8.1: {}
 
-  turbo-darwin-64@2.8.16:
-    optional: true
+  tunnel-agent@0.6.0:
+    dependencies:
+      safe-buffer: 5.2.1
 
-  turbo-darwin-arm64@2.8.16:
-    optional: true
-
-  turbo-linux-64@2.8.16:
-    optional: true
-
-  turbo-linux-arm64@2.8.16:
-    optional: true
-
-  turbo-windows-64@2.8.16:
-    optional: true
-
-  turbo-windows-arm64@2.8.16:
-    optional: true
-
-  turbo@2.8.16:
+  turbo@2.8.20:
     optionalDependencies:
-      turbo-darwin-64: 2.8.16
-      turbo-darwin-arm64: 2.8.16
-      turbo-linux-64: 2.8.16
-      turbo-linux-arm64: 2.8.16
-      turbo-windows-64: 2.8.16
-      turbo-windows-arm64: 2.8.16
+      '@turbo/darwin-64': 2.8.20
+      '@turbo/darwin-arm64': 2.8.20
+      '@turbo/linux-64': 2.8.20
+      '@turbo/linux-arm64': 2.8.20
+      '@turbo/windows-64': 2.8.20
+      '@turbo/windows-arm64': 2.8.20
 
   type-check@0.4.0:
     dependencies:
       prelude-ls: 1.2.1
+
+  type-is@2.0.1:
+    dependencies:
+      content-type: 1.0.5
+      media-typer: 1.1.0
+      mime-types: 3.0.2
 
   typescript@5.8.2: {}
 
@@ -6858,7 +7394,7 @@ snapshots:
 
   undici-types@7.18.2: {}
 
-  undici@7.22.0: {}
+  undici@7.24.5: {}
 
   unicorn-magic@0.4.0: {}
 
@@ -6902,11 +7438,17 @@ snapshots:
 
   universalify@2.0.1: {}
 
+  unpipe@1.0.0: {}
+
   uri-js@4.4.1:
     dependencies:
       punycode: 2.3.1
 
+  util-deprecate@1.0.2: {}
+
   uuid@11.1.0: {}
+
+  vary@1.1.2: {}
 
   vfile-message@4.0.3:
     dependencies:
@@ -6918,56 +7460,70 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
-  vite@7.3.1(@types/node@25.4.0)(jiti@2.6.1)(yaml@2.8.2):
+  vite@8.0.2(@types/node@25.5.0)(jiti@2.6.1)(yaml@2.8.3):
     dependencies:
-      esbuild: 0.27.4
-      fdir: 6.5.0(picomatch@4.0.3)
-      picomatch: 4.0.3
+      lightningcss: 1.32.0
+      picomatch: 4.0.4
       postcss: 8.5.8
-      rollup: 4.59.0
+      rolldown: 1.0.0-rc.11
       tinyglobby: 0.2.15
     optionalDependencies:
-      '@types/node': 25.4.0
+      '@types/node': 25.5.0
       fsevents: 2.3.3
       jiti: 2.6.1
-      yaml: 2.8.2
+      yaml: 2.8.3
 
-  vitest@4.0.18(@types/node@25.4.0)(jiti@2.6.1)(yaml@2.8.2):
+  vitest-agent-reporter@1.0.0(@effect/cluster@0.58.0(@effect/platform@0.96.0(effect@3.21.0))(@effect/rpc@0.75.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/sql@0.51.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/workflow@0.18.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/platform@0.96.0(effect@3.21.0))(@effect/rpc@0.75.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(effect@3.21.0))(effect@3.21.0))(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/printer-ansi@0.49.0(@effect/typeclass@0.40.0(effect@3.21.0))(effect@3.21.0))(@effect/printer@0.49.0(@effect/typeclass@0.40.0(effect@3.21.0))(effect@3.21.0))(@effect/rpc@0.75.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(typescript@5.9.3)(vitest@4.1.1(@types/node@25.5.0)(vite@8.0.2(@types/node@25.5.0)(jiti@2.6.1)(yaml@2.8.3))):
     dependencies:
-      '@vitest/expect': 4.0.18
-      '@vitest/mocker': 4.0.18(vite@7.3.1(@types/node@25.4.0)(jiti@2.6.1)(yaml@2.8.2))
-      '@vitest/pretty-format': 4.0.18
-      '@vitest/runner': 4.0.18
-      '@vitest/snapshot': 4.0.18
-      '@vitest/spy': 4.0.18
-      '@vitest/utils': 4.0.18
-      es-module-lexer: 1.7.0
+      '@effect/cli': 0.75.0(@effect/platform@0.96.0(effect@3.21.0))(@effect/printer-ansi@0.49.0(@effect/typeclass@0.40.0(effect@3.21.0))(effect@3.21.0))(@effect/printer@0.49.0(@effect/typeclass@0.40.0(effect@3.21.0))(effect@3.21.0))(effect@3.21.0)
+      '@effect/platform': 0.96.0(effect@3.21.0)
+      '@effect/platform-node': 0.106.0(@effect/cluster@0.58.0(@effect/platform@0.96.0(effect@3.21.0))(@effect/rpc@0.75.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/sql@0.51.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/workflow@0.18.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/platform@0.96.0(effect@3.21.0))(@effect/rpc@0.75.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(effect@3.21.0))(effect@3.21.0))(@effect/platform@0.96.0(effect@3.21.0))(@effect/rpc@0.75.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/sql@0.51.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(effect@3.21.0)
+      '@effect/sql': 0.51.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0)
+      '@effect/sql-sqlite-node': 0.52.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/platform@0.96.0(effect@3.21.0))(@effect/sql@0.51.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(effect@3.21.0)
+      '@modelcontextprotocol/sdk': 1.27.1(zod@4.3.6)
+      '@trpc/server': 11.15.0(typescript@5.9.3)
+      effect: 3.21.0
+      std-env: 4.0.0
+      vitest: 4.1.1(@types/node@25.5.0)(vite@8.0.2(@types/node@25.5.0)(jiti@2.6.1)(yaml@2.8.3))
+      zod: 4.3.6
+    transitivePeerDependencies:
+      - '@cfworker/json-schema'
+      - '@effect/cluster'
+      - '@effect/experimental'
+      - '@effect/printer'
+      - '@effect/printer-ansi'
+      - '@effect/rpc'
+      - bufferutil
+      - supports-color
+      - typescript
+      - utf-8-validate
+
+  vitest@4.1.1(@types/node@25.5.0)(vite@8.0.2(@types/node@25.5.0)(jiti@2.6.1)(yaml@2.8.3)):
+    dependencies:
+      '@vitest/expect': 4.1.1
+      '@vitest/mocker': 4.1.1(vite@8.0.2(@types/node@25.5.0)(jiti@2.6.1)(yaml@2.8.3))
+      '@vitest/pretty-format': 4.1.1
+      '@vitest/runner': 4.1.1
+      '@vitest/snapshot': 4.1.1
+      '@vitest/spy': 4.1.1
+      '@vitest/utils': 4.1.1
+      es-module-lexer: 2.0.0
       expect-type: 1.3.0
       magic-string: 0.30.21
       obug: 2.1.1
       pathe: 2.0.3
-      picomatch: 4.0.3
-      std-env: 3.10.0
+      picomatch: 4.0.4
+      std-env: 4.0.0
       tinybench: 2.9.0
       tinyexec: 1.0.4
       tinyglobby: 0.2.15
       tinyrainbow: 3.1.0
-      vite: 7.3.1(@types/node@25.4.0)(jiti@2.6.1)(yaml@2.8.2)
+      vite: 8.0.2(@types/node@25.5.0)(jiti@2.6.1)(yaml@2.8.3)
       why-is-node-running: 2.3.0
     optionalDependencies:
-      '@types/node': 25.4.0
+      '@types/node': 25.5.0
     transitivePeerDependencies:
-      - jiti
-      - less
-      - lightningcss
       - msw
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - terser
-      - tsx
-      - yaml
 
   webidl-conversions@3.0.1: {}
 
@@ -7034,6 +7590,8 @@ snapshots:
       string-width: 7.2.0
       strip-ansi: 7.2.0
 
+  wrappy@1.0.2: {}
+
   write-file-atomic@5.0.1:
     dependencies:
       imurmurhash: 0.1.4
@@ -7044,15 +7602,15 @@ snapshots:
       js-yaml: 4.1.1
       write-file-atomic: 5.0.1
 
-  ws@8.19.0: {}
+  ws@8.20.0: {}
 
   y18n@5.0.8: {}
 
   yallist@4.0.0: {}
 
-  yaml-effect@0.1.0(effect@3.19.19):
+  yaml-effect@0.2.2(effect@3.21.0):
     dependencies:
-      effect: 3.19.19
+      effect: 3.21.0
 
   yaml-lint@1.7.0:
     dependencies:
@@ -7061,7 +7619,7 @@ snapshots:
       js-yaml: 4.1.1
       nconf: 0.12.1
 
-  yaml@2.8.2: {}
+  yaml@2.8.3: {}
 
   yargs-parser@20.2.9: {}
 
@@ -7088,6 +7646,10 @@ snapshots:
       yargs-parser: 21.1.1
 
   yocto-queue@0.1.0: {}
+
+  zod-to-json-schema@3.25.1(zod@4.3.6):
+    dependencies:
+      zod: 4.3.6
 
   zod@4.3.6: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,5 +2,5 @@ packages:
   - .
 autoInstallPeers: true
 configDependencies:
-  "@savvy-web/pnpm-plugin-silk": 0.8.0+sha512-KmEI1wt9YJkmaTdkpSQ829ZC/n6RBHuoijAco69s8flzTobym4CuS30CZ9PBBb5Jps4qEouY2zQU3BgU6LpJkw==
+  "@savvy-web/pnpm-plugin-silk": 0.10.0+sha512-Ow0XXEpYCJPYmxjpFfqww3m6ZhX1W5Fv+NRyGdXZfN7rZpQXXvoj6dPzWF+BIt0rcqCKQDWg01X5VeLjHunitA==
 loglevel: info

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -364,6 +364,7 @@ describe("Service tags", () => {
 		const testDiscovery = Layer.succeed(WorkspaceDiscovery, {
 			listPackages: () => Effect.succeed([]),
 			getPackage: (name: string) => Effect.fail(new PackageNotFoundError({ name, available: [] })),
+			importerMap: () => Effect.succeed(new Map() as ReadonlyMap<string, WorkspacePackage>),
 		});
 
 		const testLayer = Layer.mergeAll(testRoot, testDetector, testDiscovery);

--- a/src/index.ts
+++ b/src/index.ts
@@ -98,6 +98,7 @@ export { WorkspaceDiscoveryLive } from "./layers/WorkspaceDiscoveryLive.js";
 export { WorkspaceRootLive } from "./layers/WorkspaceRootLive.js";
 export { WorkspacesFullLive, WorkspacesLive } from "./layers/WorkspacesLive.js";
 export type {
+	DependencyDiff,
 	PackageJsonType,
 	PackageManagerType,
 	PackageNameType,
@@ -134,3 +135,41 @@ export { TopologicalSorter } from "./services/TopologicalSorter.js";
 export { WorkspaceDiscovery } from "./services/WorkspaceDiscovery.js";
 // ── Services ─────────────────────────────────────────────────────────
 export { WorkspaceRoot } from "./services/WorkspaceRoot.js";
+// ── Utils ────────────────────────────────────────────────────────────
+export {
+	dependencyDiff,
+	dependencyVersion,
+	hasAnyDependencyOn,
+	hasDependency,
+	hasDevDependency,
+	hasOptionalDependency,
+	hasPeerDependency,
+	matchesDependency,
+	readPackageJson,
+} from "./utils/workspace-package.js";
+
+// ── Wire cross-cutting static methods (avoids circular imports) ─────────
+
+import { WorkspacePackage as _WP } from "./schemas/core.js";
+import {
+	dependencyDiff as _dependencyDiff,
+	dependencyVersion as _dependencyVersion,
+	hasAnyDependencyOn as _hasAnyDependencyOn,
+	hasDependency as _hasDependency,
+	hasDevDependency as _hasDevDependency,
+	hasOptionalDependency as _hasOptionalDependency,
+	hasPeerDependency as _hasPeerDependency,
+	matchesDependency as _matchesDependency,
+	readPackageJson as _readPackageJson,
+} from "./utils/workspace-package.js";
+
+// WorkspacePackage statics
+_WP.hasDependency = _hasDependency;
+_WP.hasDevDependency = _hasDevDependency;
+_WP.hasPeerDependency = _hasPeerDependency;
+_WP.hasOptionalDependency = _hasOptionalDependency;
+_WP.hasAnyDependencyOn = _hasAnyDependencyOn;
+_WP.dependencyVersion = _dependencyVersion;
+_WP.matchesDependency = _matchesDependency;
+_WP.dependencyDiff = _dependencyDiff;
+_WP.readPackageJson = _readPackageJson;

--- a/src/layers/ChangeDetectorLive.test.ts
+++ b/src/layers/ChangeDetectorLive.test.ts
@@ -4,7 +4,7 @@
 
 import { Command, CommandExecutor } from "@effect/platform";
 import { SystemError } from "@effect/platform/Error";
-import { Effect, Layer, Option, Sink, Stream } from "effect";
+import { Effect, Layer, Logger, Option, Sink, Stream } from "effect";
 import { describe, expect, it } from "vitest";
 import { WorkspacePackage } from "../schemas/core.js";
 import { ChangeDetectionOptions, ChangeDetector } from "../services/ChangeDetector.js";
@@ -121,7 +121,12 @@ const buildLayer = (
 ) =>
 	ChangeDetectorLive.pipe(
 		Layer.provide(
-			Layer.mergeAll(mockResolver(packages), mockGraph(deps, reverseDeps), mockExecutor(gitResponses, executorOptions)),
+			Layer.mergeAll(
+				mockResolver(packages),
+				mockGraph(deps, reverseDeps),
+				mockExecutor(gitResponses, executorOptions),
+				Logger.replace(Logger.defaultLogger, Logger.none),
+			),
 		),
 	);
 

--- a/src/layers/DependencyGraphLive.test.ts
+++ b/src/layers/DependencyGraphLive.test.ts
@@ -2,7 +2,7 @@
  * Tests for DependencyGraphLive layer.
  */
 
-import { Effect, Layer } from "effect";
+import { Effect, Layer, Logger } from "effect";
 import { describe, expect, it } from "vitest";
 import { PackageNotFoundError } from "../errors/PackageNotFoundError.js";
 import { WorkspacePackage } from "../schemas/core.js";
@@ -20,6 +20,8 @@ const mockDiscovery = (packages: WorkspacePackage[]) =>
 				? Effect.succeed(found)
 				: Effect.fail(new PackageNotFoundError({ name, available: packages.map((p) => p.name) }));
 		},
+		importerMap: () =>
+			Effect.succeed(new Map(packages.map((p) => [p.relativePath, p])) as ReadonlyMap<string, WorkspacePackage>),
 	});
 
 /** Helper to create a WorkspacePackage. */
@@ -33,7 +35,10 @@ const pkg = (name: string, deps: Record<string, string> = {}, devDeps: Record<st
 		devDependencies: devDeps,
 	});
 
-const testLayer = (packages: WorkspacePackage[]) => DependencyGraphLive.pipe(Layer.provide(mockDiscovery(packages)));
+const testLayer = (packages: WorkspacePackage[]) =>
+	DependencyGraphLive.pipe(
+		Layer.provide(Layer.merge(mockDiscovery(packages), Logger.replace(Logger.defaultLogger, Logger.none))),
+	);
 
 describe("DependencyGraphLive", () => {
 	describe("dependenciesOf", () => {

--- a/src/layers/LockfileReaderLive.test.ts
+++ b/src/layers/LockfileReaderLive.test.ts
@@ -1,5 +1,5 @@
 import { FileSystem, Path, Error as PlatformError } from "@effect/platform";
-import { Effect, Exit, Layer, Option } from "effect";
+import { Effect, Exit, Layer, Logger, Option } from "effect";
 import { describe, expect, it } from "vitest";
 import { LockfileReader } from "../services/LockfileReader.js";
 import { PackageManagerDetector } from "../services/PackageManagerDetector.js";
@@ -115,6 +115,7 @@ const testLayer = (pm: "pnpm" | "npm" | "yarn" | "bun", lockfileContent: string)
 					},
 				}),
 				Path.layer,
+				Logger.replace(Logger.defaultLogger, Logger.none),
 			),
 		),
 	);

--- a/src/layers/PackageManagerDetectorLive.test.ts
+++ b/src/layers/PackageManagerDetectorLive.test.ts
@@ -1,5 +1,5 @@
 import { FileSystem, Path } from "@effect/platform";
-import { Effect, Layer } from "effect";
+import { Effect, Layer, Logger } from "effect";
 import { describe, expect, it } from "vitest";
 import { PackageManagerDetectionError } from "../errors/PackageManagerDetectionError.js";
 import { PackageManagerDetector } from "../services/PackageManagerDetector.js";
@@ -21,7 +21,9 @@ const mockFs = (files: Record<string, string | true>) =>
 	});
 
 const testLayer = (files: Record<string, string | true>) =>
-	PackageManagerDetectorLive.pipe(Layer.provide(Layer.mergeAll(mockFs(files), Path.layer)));
+	PackageManagerDetectorLive.pipe(
+		Layer.provide(Layer.mergeAll(mockFs(files), Path.layer, Logger.replace(Logger.defaultLogger, Logger.none))),
+	);
 
 describe("PackageManagerDetectorLive", () => {
 	it("detects pnpm from pnpm-workspace.yaml", async () => {

--- a/src/layers/PackageResolverLive.test.ts
+++ b/src/layers/PackageResolverLive.test.ts
@@ -31,6 +31,8 @@ const mockDiscovery = (packages: ReadonlyArray<WorkspacePackage>) =>
 			const found = packages.find((p) => p.name === name);
 			return found ? Effect.succeed(found) : Effect.die(`Package not found: ${name}`);
 		},
+		importerMap: () =>
+			Effect.succeed(new Map(packages.map((p) => [p.relativePath, p])) as ReadonlyMap<string, WorkspacePackage>),
 	});
 
 /** Build test layer with mock discovery. */

--- a/src/layers/TopologicalSorterLive.test.ts
+++ b/src/layers/TopologicalSorterLive.test.ts
@@ -31,6 +31,8 @@ const testLayer = (packages: WorkspacePackage[]) => {
 				? Effect.succeed(found)
 				: Effect.fail(new PackageNotFoundError({ name, available: packages.map((p) => p.name) }));
 		},
+		importerMap: () =>
+			Effect.succeed(new Map(packages.map((p) => [p.relativePath, p])) as ReadonlyMap<string, WorkspacePackage>),
 	});
 
 	return TopologicalSorterLive.pipe(Layer.provide(DependencyGraphLive), Layer.provide(mockDiscovery));

--- a/src/layers/WorkspaceDiscoveryLive.test.ts
+++ b/src/layers/WorkspaceDiscoveryLive.test.ts
@@ -3,7 +3,7 @@
  */
 
 import { FileSystem, Path } from "@effect/platform";
-import { Effect, Layer } from "effect";
+import { Effect, Layer, Logger } from "effect";
 import { describe, expect, it } from "vitest";
 import { WorkspaceDiscoveryError } from "../errors/WorkspaceDiscoveryError.js";
 import { WorkspaceDiscovery } from "../services/WorkspaceDiscovery.js";
@@ -43,7 +43,16 @@ const mockRoot = (rootPath: string) =>
 
 /** Build the discovery layer with mocked dependencies. */
 const testLayer = (rootPath: string, files: Record<string, string | true>, dirs: Record<string, string[]> = {}) =>
-	WorkspaceDiscoveryLive.pipe(Layer.provide(Layer.mergeAll(mockRoot(rootPath), mockFs(files, dirs), Path.layer)));
+	WorkspaceDiscoveryLive.pipe(
+		Layer.provide(
+			Layer.mergeAll(
+				mockRoot(rootPath),
+				mockFs(files, dirs),
+				Path.layer,
+				Logger.replace(Logger.defaultLogger, Logger.none),
+			),
+		),
+	);
 
 describe("WorkspaceDiscoveryLive", () => {
 	describe("listPackages", () => {
@@ -53,6 +62,11 @@ describe("WorkspaceDiscoveryLive", () => {
 				root,
 				{
 					[`${root}/pnpm-workspace.yaml`]: "packages:\n  - 'packages/*'",
+					[`${root}/package.json`]: JSON.stringify({
+						name: "my-monorepo",
+						version: "0.0.0",
+						private: true,
+					}),
 					[`${root}/packages/pkg-a/package.json`]: JSON.stringify({
 						name: "@scope/pkg-a",
 						version: "1.0.0",
@@ -75,12 +89,14 @@ describe("WorkspaceDiscoveryLive", () => {
 				}).pipe(Effect.provide(layer)),
 			);
 
-			expect(result).toHaveLength(2);
-			expect(result[0].name).toBe("@scope/pkg-a");
-			expect(result[0].version).toBe("1.0.0");
-			expect(result[0].relativePath).toBe("packages/pkg-a");
-			expect(result[1].name).toBe("@scope/pkg-b");
-			expect(result[1].private).toBe(true);
+			expect(result).toHaveLength(3);
+			expect(result[0].name).toBe("my-monorepo");
+			expect(result[0].relativePath).toBe(".");
+			expect(result[1].name).toBe("@scope/pkg-a");
+			expect(result[1].version).toBe("1.0.0");
+			expect(result[1].relativePath).toBe("packages/pkg-a");
+			expect(result[2].name).toBe("@scope/pkg-b");
+			expect(result[2].private).toBe(true);
 		});
 
 		it("discovers packages from package.json workspaces array", async () => {
@@ -109,8 +125,9 @@ describe("WorkspaceDiscoveryLive", () => {
 				}).pipe(Effect.provide(layer)),
 			);
 
-			expect(result).toHaveLength(1);
-			expect(result[0].name).toBe("pkg-a");
+			expect(result).toHaveLength(2);
+			expect(result[0].name).toBe("my-monorepo");
+			expect(result[1].name).toBe("pkg-a");
 		});
 
 		it("discovers packages from package.json workspaces object", async () => {
@@ -139,8 +156,9 @@ describe("WorkspaceDiscoveryLive", () => {
 				}).pipe(Effect.provide(layer)),
 			);
 
-			expect(result).toHaveLength(1);
-			expect(result[0].name).toBe("web-app");
+			expect(result).toHaveLength(2);
+			expect(result[0].name).toBe("my-monorepo");
+			expect(result[1].name).toBe("web-app");
 		});
 
 		it("handles multiple workspace patterns", async () => {
@@ -149,6 +167,11 @@ describe("WorkspaceDiscoveryLive", () => {
 				root,
 				{
 					[`${root}/pnpm-workspace.yaml`]: "packages:\n  - 'packages/*'\n  - 'apps/*'",
+					[`${root}/package.json`]: JSON.stringify({
+						name: "my-monorepo",
+						version: "0.0.0",
+						private: true,
+					}),
 					[`${root}/packages/lib/package.json`]: JSON.stringify({
 						name: "lib",
 						version: "1.0.0",
@@ -171,8 +194,9 @@ describe("WorkspaceDiscoveryLive", () => {
 				}).pipe(Effect.provide(layer)),
 			);
 
-			expect(result).toHaveLength(2);
+			expect(result).toHaveLength(3);
 			const names = result.map((p) => p.name);
+			expect(names).toContain("my-monorepo");
 			expect(names).toContain("lib");
 			expect(names).toContain("web");
 		});
@@ -183,6 +207,11 @@ describe("WorkspaceDiscoveryLive", () => {
 				root,
 				{
 					[`${root}/pnpm-workspace.yaml`]: "packages:\n  - 'packages/*'",
+					[`${root}/package.json`]: JSON.stringify({
+						name: "my-monorepo",
+						version: "0.0.0",
+						private: true,
+					}),
 					[`${root}/packages/real-pkg/package.json`]: JSON.stringify({
 						name: "real-pkg",
 						version: "1.0.0",
@@ -201,8 +230,9 @@ describe("WorkspaceDiscoveryLive", () => {
 				}).pipe(Effect.provide(layer)),
 			);
 
-			expect(result).toHaveLength(1);
-			expect(result[0].name).toBe("real-pkg");
+			expect(result).toHaveLength(2);
+			expect(result[0].name).toBe("my-monorepo");
+			expect(result[1].name).toBe("real-pkg");
 		});
 
 		it("includes dependencies in discovered packages", async () => {
@@ -211,6 +241,11 @@ describe("WorkspaceDiscoveryLive", () => {
 				root,
 				{
 					[`${root}/pnpm-workspace.yaml`]: "packages:\n  - 'packages/*'",
+					[`${root}/package.json`]: JSON.stringify({
+						name: "my-monorepo",
+						version: "0.0.0",
+						private: true,
+					}),
 					[`${root}/packages/pkg-a/package.json`]: JSON.stringify({
 						name: "pkg-a",
 						version: "1.0.0",
@@ -230,8 +265,8 @@ describe("WorkspaceDiscoveryLive", () => {
 				}).pipe(Effect.provide(layer)),
 			);
 
-			expect(result[0].dependencies).toEqual({ "pkg-b": "workspace:*" });
-			expect(result[0].devDependencies).toEqual({ vitest: "^3.0.0" });
+			expect(result[1].dependencies).toEqual({ "pkg-b": "workspace:*" });
+			expect(result[1].devDependencies).toEqual({ vitest: "^3.0.0" });
 		});
 
 		it("fails when no workspace patterns found", async () => {
@@ -251,6 +286,84 @@ describe("WorkspaceDiscoveryLive", () => {
 			expect(result._tag).toBe("WorkspaceDiscoveryError");
 			expect(result.message).toContain("Workspace discovery failed");
 		});
+
+		it("includes root workspace package as first entry", async () => {
+			const root = "/projects/monorepo";
+			const layer = testLayer(
+				root,
+				{
+					[`${root}/pnpm-workspace.yaml`]: "packages:\n  - 'packages/*'",
+					[`${root}/package.json`]: JSON.stringify({
+						name: "my-monorepo",
+						version: "0.0.0",
+						private: true,
+						dependencies: { typescript: "^5.0.0" },
+					}),
+					[`${root}/packages/pkg-a/package.json`]: JSON.stringify({
+						name: "@scope/pkg-a",
+						version: "1.0.0",
+					}),
+				},
+				{
+					[`${root}/packages`]: ["pkg-a"],
+				},
+			);
+
+			const result = await Effect.runPromise(
+				Effect.gen(function* () {
+					const discovery = yield* WorkspaceDiscovery;
+					return yield* discovery.listPackages();
+				}).pipe(Effect.provide(layer)),
+			);
+
+			expect(result).toHaveLength(2);
+			expect(result[0].name).toBe("my-monorepo");
+			expect(result[0].relativePath).toBe(".");
+			expect(result[0].path).toBe(root);
+			expect(result[0].isRootWorkspace).toBe(true);
+			expect(result[0].dependencies).toEqual({ typescript: "^5.0.0" });
+			expect(result[1].name).toBe("@scope/pkg-a");
+			expect(result[1].isRootWorkspace).toBe(false);
+		});
+	});
+
+	describe("importerMap", () => {
+		it("returns map keyed by relativePath", async () => {
+			const root = "/projects/monorepo";
+			const layer = testLayer(
+				root,
+				{
+					[`${root}/pnpm-workspace.yaml`]: "packages:\n  - 'packages/*'",
+					[`${root}/package.json`]: JSON.stringify({
+						name: "my-monorepo",
+						version: "0.0.0",
+					}),
+					[`${root}/packages/core/package.json`]: JSON.stringify({
+						name: "@scope/core",
+						version: "1.0.0",
+					}),
+					[`${root}/packages/utils/package.json`]: JSON.stringify({
+						name: "@scope/utils",
+						version: "1.0.0",
+					}),
+				},
+				{
+					[`${root}/packages`]: ["core", "utils"],
+				},
+			);
+
+			const result = await Effect.runPromise(
+				Effect.gen(function* () {
+					const discovery = yield* WorkspaceDiscovery;
+					return yield* discovery.importerMap();
+				}).pipe(Effect.provide(layer)),
+			);
+
+			expect(result.size).toBe(3);
+			expect(result.get(".")?.name).toBe("my-monorepo");
+			expect(result.get("packages/core")?.name).toBe("@scope/core");
+			expect(result.get("packages/utils")?.name).toBe("@scope/utils");
+		});
 	});
 
 	describe("getPackage", () => {
@@ -260,6 +373,11 @@ describe("WorkspaceDiscoveryLive", () => {
 				root,
 				{
 					[`${root}/pnpm-workspace.yaml`]: "packages:\n  - 'packages/*'",
+					[`${root}/package.json`]: JSON.stringify({
+						name: "my-monorepo",
+						version: "0.0.0",
+						private: true,
+					}),
 					[`${root}/packages/pkg-a/package.json`]: JSON.stringify({
 						name: "pkg-a",
 						version: "1.0.0",
@@ -291,6 +409,11 @@ describe("WorkspaceDiscoveryLive", () => {
 				root,
 				{
 					[`${root}/pnpm-workspace.yaml`]: "packages:\n  - 'packages/*'",
+					[`${root}/package.json`]: JSON.stringify({
+						name: "my-monorepo",
+						version: "0.0.0",
+						private: true,
+					}),
 					[`${root}/packages/pkg-a/package.json`]: JSON.stringify({
 						name: "pkg-a",
 						version: "1.0.0",
@@ -319,7 +442,7 @@ describe("WorkspaceDiscoveryLive", () => {
 			expect(result).toEqual({
 				caught: true,
 				name: "nonexistent",
-				available: ["pkg-a"],
+				available: ["my-monorepo", "pkg-a"],
 			});
 		});
 	});
@@ -331,6 +454,11 @@ describe("WorkspaceDiscoveryLive", () => {
 				root,
 				{
 					[`${root}/pnpm-workspace.yaml`]: "packages:\n  - packages/*",
+					[`${root}/package.json`]: JSON.stringify({
+						name: "my-monorepo",
+						version: "0.0.0",
+						private: true,
+					}),
 					[`${root}/packages/pkg/package.json`]: JSON.stringify({
 						name: "pkg",
 						version: "1.0.0",
@@ -348,7 +476,7 @@ describe("WorkspaceDiscoveryLive", () => {
 				}).pipe(Effect.provide(layer)),
 			);
 
-			expect(result).toHaveLength(1);
+			expect(result).toHaveLength(2);
 		});
 
 		it("handles double-quoted patterns", async () => {
@@ -357,6 +485,11 @@ describe("WorkspaceDiscoveryLive", () => {
 				root,
 				{
 					[`${root}/pnpm-workspace.yaml`]: 'packages:\n  - "packages/*"',
+					[`${root}/package.json`]: JSON.stringify({
+						name: "my-monorepo",
+						version: "0.0.0",
+						private: true,
+					}),
 					[`${root}/packages/pkg/package.json`]: JSON.stringify({
 						name: "pkg",
 						version: "1.0.0",
@@ -374,7 +507,7 @@ describe("WorkspaceDiscoveryLive", () => {
 				}).pipe(Effect.provide(layer)),
 			);
 
-			expect(result).toHaveLength(1);
+			expect(result).toHaveLength(2);
 		});
 	});
 });

--- a/src/layers/WorkspaceDiscoveryLive.ts
+++ b/src/layers/WorkspaceDiscoveryLive.ts
@@ -262,6 +262,8 @@ const readWorkspacePackage = (
 			private: decoded.private ?? false,
 			dependencies: (decoded.dependencies as Record<string, string>) ?? {},
 			devDependencies: (decoded.devDependencies as Record<string, string>) ?? {},
+			peerDependencies: (decoded.peerDependencies as Record<string, string>) ?? {},
+			optionalDependencies: (decoded.optionalDependencies as Record<string, string>) ?? {},
 			publishConfig: decoded.publishConfig,
 		});
 	});
@@ -340,9 +342,57 @@ export const WorkspaceDiscoveryLive: Layer.Layer<
 				const patterns = yield* readWorkspacePatterns(fs, path, resolvedRoot);
 				const dirs = yield* resolvePatterns(fs, path, resolvedRoot, patterns);
 
-				const packages = yield* Effect.forEach(dirs, (dir) => readWorkspacePackage(fs, path, resolvedRoot, dir), {
-					concurrency: 10,
+				const workspacePackages = yield* Effect.forEach(
+					dirs,
+					(dir) => readWorkspacePackage(fs, path, resolvedRoot, dir),
+					{
+						concurrency: 10,
+					},
+				);
+
+				// Read root package.json and prepend as first entry
+				const rootPkgJsonPath = path.join(resolvedRoot, "package.json");
+				const rootContent = yield* fs.readFileString(rootPkgJsonPath).pipe(
+					Effect.mapError(
+						() =>
+							new WorkspaceDiscoveryError({
+								root: resolvedRoot,
+								reason: `failed to read root ${rootPkgJsonPath}`,
+							}),
+					),
+				);
+				const rootRaw = yield* Effect.try({
+					try: () => JSON.parse(rootContent) as Record<string, unknown>,
+					catch: () =>
+						new WorkspaceDiscoveryError({
+							root: resolvedRoot,
+							reason: `invalid JSON in root ${rootPkgJsonPath}`,
+						}),
 				});
+				const rootDecoded = yield* Schema.decodeUnknown(PackageJsonSchema)(rootRaw).pipe(
+					Effect.mapError(
+						() =>
+							new WorkspaceDiscoveryError({
+								root: resolvedRoot,
+								reason: `failed to parse root ${rootPkgJsonPath}`,
+							}),
+					),
+				);
+
+				const rootPkg = new WorkspacePackage({
+					name: rootDecoded.name ?? path.basename(resolvedRoot),
+					version: rootDecoded.version ?? "0.0.0",
+					path: resolvedRoot,
+					relativePath: ".",
+					private: rootDecoded.private ?? false,
+					dependencies: (rootDecoded.dependencies as Record<string, string>) ?? {},
+					devDependencies: (rootDecoded.devDependencies as Record<string, string>) ?? {},
+					peerDependencies: (rootDecoded.peerDependencies as Record<string, string>) ?? {},
+					optionalDependencies: (rootDecoded.optionalDependencies as Record<string, string>) ?? {},
+					publishConfig: rootDecoded.publishConfig,
+				});
+
+				const packages = [rootPkg, ...workspacePackages];
 
 				cachedPackages = packages;
 				yield* Effect.logInfo("Workspace packages discovered").pipe(
@@ -353,6 +403,12 @@ export const WorkspaceDiscoveryLive: Layer.Layer<
 
 		return {
 			listPackages: discoverPackages,
+
+			importerMap: () =>
+				Effect.gen(function* () {
+					const packages = yield* discoverPackages();
+					return new Map(packages.map((p) => [p.relativePath, p])) as ReadonlyMap<string, WorkspacePackage>;
+				}).pipe(Effect.withSpan("WorkspaceDiscovery.importerMap")),
 
 			getPackage: (name: string) =>
 				Effect.gen(function* () {

--- a/src/layers/WorkspaceRootLive.test.ts
+++ b/src/layers/WorkspaceRootLive.test.ts
@@ -1,5 +1,5 @@
 import { FileSystem, Path } from "@effect/platform";
-import { Effect, Layer } from "effect";
+import { Effect, Layer, Logger } from "effect";
 import { describe, expect, it } from "vitest";
 import { WorkspaceRootNotFoundError } from "../errors/WorkspaceRootNotFoundError.js";
 import { WorkspaceRoot } from "../services/WorkspaceRoot.js";
@@ -22,7 +22,9 @@ const mockFs = (files: Record<string, string | true>) =>
 	});
 
 const testLayer = (files: Record<string, string | true>) =>
-	WorkspaceRootLive.pipe(Layer.provide(Layer.mergeAll(mockFs(files), Path.layer)));
+	WorkspaceRootLive.pipe(
+		Layer.provide(Layer.mergeAll(mockFs(files), Path.layer, Logger.replace(Logger.defaultLogger, Logger.none))),
+	);
 
 describe("WorkspaceRootLive", () => {
 	it("finds root with pnpm-workspace.yaml", async () => {

--- a/src/layers/WorkspacesLive.test.ts
+++ b/src/layers/WorkspacesLive.test.ts
@@ -13,7 +13,7 @@
  */
 
 import { CommandExecutor, FileSystem, Path } from "@effect/platform";
-import { Effect, Layer, Option } from "effect";
+import { Effect, Layer, Logger, Option } from "effect";
 import { describe, expect, it } from "vitest";
 import { ChangeDetector } from "../services/ChangeDetector.js";
 import { DependencyGraph } from "../services/DependencyGraph.js";
@@ -108,7 +108,7 @@ const mockExecutor = Layer.succeed(CommandExecutor.CommandExecutor, {
 } as unknown as CommandExecutor.CommandExecutor);
 
 /** Platform dependencies. */
-const platformDeps = Layer.mergeAll(mockFs(), Path.layer);
+const platformDeps = Layer.mergeAll(mockFs(), Path.layer, Logger.replace(Logger.defaultLogger, Logger.none));
 
 // ── WorkspacesLive — mirrored test layer ──────────────────────────────
 //
@@ -186,8 +186,10 @@ describe("WorkspacesLive", () => {
 			}).pipe(Effect.provide(workspacesTestLayer)),
 		);
 
-		expect(result).toHaveLength(1);
-		expect(result[0].name).toBe("pkg-a");
+		expect(result).toHaveLength(2);
+		expect(result[0].name).toBe("my-monorepo");
+		expect(result[0].relativePath).toBe(".");
+		expect(result[1].name).toBe("pkg-a");
 	});
 
 	it("provides DependencyGraph", async () => {
@@ -212,8 +214,9 @@ describe("WorkspacesLive", () => {
 
 		// sort() returns package names (strings), not WorkspacePackage objects
 		expect(Array.isArray(result)).toBe(true);
-		expect(result).toHaveLength(1);
-		expect(result[0]).toBe("pkg-a");
+		expect(result).toHaveLength(2);
+		expect(result).toContain("my-monorepo");
+		expect(result).toContain("pkg-a");
 	});
 
 	it("provides PublishabilityDetector", async () => {

--- a/src/layers/integration.test.ts
+++ b/src/layers/integration.test.ts
@@ -6,7 +6,7 @@
  */
 
 import { FileSystem, Path } from "@effect/platform";
-import { Effect, Layer } from "effect";
+import { Effect, Layer, Logger } from "effect";
 import { describe, expect, it } from "vitest";
 import { PackageManagerDetector } from "../services/PackageManagerDetector.js";
 import { WorkspaceDiscovery } from "../services/WorkspaceDiscovery.js";
@@ -46,7 +46,7 @@ describe("Discovery layers integration", () => {
 		};
 
 		const layer = Layer.mergeAll(WorkspaceRootLive, PackageManagerDetectorLive).pipe(
-			Layer.provide(Layer.mergeAll(mockFs(files), Path.layer)),
+			Layer.provide(Layer.mergeAll(mockFs(files), Path.layer, Logger.replace(Logger.defaultLogger, Logger.none))),
 		);
 
 		const result = await Effect.runPromise(
@@ -77,7 +77,7 @@ describe("Discovery layers integration", () => {
 		};
 
 		const layer = Layer.mergeAll(WorkspaceRootLive, PackageManagerDetectorLive).pipe(
-			Layer.provide(Layer.mergeAll(mockFs(files), Path.layer)),
+			Layer.provide(Layer.mergeAll(mockFs(files), Path.layer, Logger.replace(Logger.defaultLogger, Logger.none))),
 		);
 
 		const result = await Effect.runPromise(
@@ -108,7 +108,7 @@ describe("Discovery layers integration", () => {
 		};
 
 		const layer = Layer.mergeAll(WorkspaceRootLive, PackageManagerDetectorLive).pipe(
-			Layer.provide(Layer.mergeAll(mockFs(files), Path.layer)),
+			Layer.provide(Layer.mergeAll(mockFs(files), Path.layer, Logger.replace(Logger.defaultLogger, Logger.none))),
 		);
 
 		const result = await Effect.runPromise(
@@ -137,7 +137,7 @@ describe("Discovery layers integration", () => {
 		};
 
 		const layer = Layer.mergeAll(WorkspaceRootLive, PackageManagerDetectorLive).pipe(
-			Layer.provide(Layer.mergeAll(mockFs(files), Path.layer)),
+			Layer.provide(Layer.mergeAll(mockFs(files), Path.layer, Logger.replace(Logger.defaultLogger, Logger.none))),
 		);
 
 		const result = await Effect.runPromise(
@@ -158,7 +158,7 @@ describe("Discovery layers integration", () => {
 
 	it("handles error when root not found", async () => {
 		const layer = Layer.mergeAll(WorkspaceRootLive, PackageManagerDetectorLive).pipe(
-			Layer.provide(Layer.mergeAll(mockFs({}), Path.layer)),
+			Layer.provide(Layer.mergeAll(mockFs({}), Path.layer, Logger.replace(Logger.defaultLogger, Logger.none))),
 		);
 
 		const result = await Effect.runPromise(
@@ -194,7 +194,7 @@ describe("Workspace layers composition", () => {
 			mockRoot,
 			PackageManagerDetectorLive,
 			WorkspaceDiscoveryLive.pipe(Layer.provide(mockRoot)),
-		).pipe(Layer.provide(Layer.mergeAll(mockFs(files), Path.layer)));
+		).pipe(Layer.provide(Layer.mergeAll(mockFs(files), Path.layer, Logger.replace(Logger.defaultLogger, Logger.none))));
 
 		const result = await Effect.runPromise(
 			Effect.gen(function* () {
@@ -239,7 +239,9 @@ describe("Workspace layers composition", () => {
 			mockRoot,
 			PackageManagerDetectorLive,
 			WorkspaceDiscoveryLive.pipe(Layer.provide(mockRoot)),
-		).pipe(Layer.provide(Layer.mergeAll(mockFs(files, dirs), Path.layer)));
+		).pipe(
+			Layer.provide(Layer.mergeAll(mockFs(files, dirs), Path.layer, Logger.replace(Logger.defaultLogger, Logger.none))),
+		);
 
 		const result = await Effect.runPromise(
 			Effect.gen(function* () {
@@ -249,7 +251,9 @@ describe("Workspace layers composition", () => {
 			}).pipe(Effect.provide(layer)),
 		);
 
-		expect(result).toHaveLength(1);
-		expect(result[0].name).toBe("pkg-a");
+		expect(result).toHaveLength(2);
+		expect(result[0].name).toBe("my-monorepo");
+		expect(result[0].relativePath).toBe(".");
+		expect(result[1].name).toBe("pkg-a");
 	});
 });

--- a/src/layers/integrity.ts
+++ b/src/layers/integrity.ts
@@ -149,8 +149,8 @@ const checkConstraints = (
 					const resolved = resolvedIndex.get(depName);
 					if (!resolved) continue;
 
-					const rangeExit = yield* Effect.exit(Range.fromString(constraint));
-					const versionExit = yield* Effect.exit(SemVer.fromString(resolved));
+					const rangeExit = yield* Effect.exit(Range.parse(constraint));
+					const versionExit = yield* Effect.exit(SemVer.parse(resolved));
 
 					if (Exit.isFailure(rangeExit) || Exit.isFailure(versionExit)) {
 						yield* Effect.logTrace("Skipping unparseable constraint").pipe(
@@ -163,7 +163,7 @@ const checkConstraints = (
 						continue;
 					}
 
-					if (!Range.satisfies(versionExit.value, rangeExit.value)) {
+					if (!rangeExit.value.test(versionExit.value)) {
 						unsatisfied.push({
 							workspace: wsName,
 							dependency: depName,

--- a/src/schemas/core.test.ts
+++ b/src/schemas/core.test.ts
@@ -1,0 +1,192 @@
+import { Option } from "effect";
+import { describe, expect, it } from "vitest";
+import { WorkspacePackage } from "./core.js";
+
+const rootPkg = new WorkspacePackage({
+	name: "my-monorepo",
+	version: "1.0.0",
+	path: "/workspace",
+	relativePath: ".",
+});
+
+const scopedPkg = new WorkspacePackage({
+	name: "@scope/utils",
+	version: "2.0.0",
+	path: "/workspace/packages/utils",
+	relativePath: "packages/utils",
+	private: false,
+	dependencies: { effect: "^3.0.0" },
+	devDependencies: { vitest: "^3.0.0" },
+	peerDependencies: { react: "^18.0.0" },
+	optionalDependencies: { fsevents: "^2.3.0" },
+});
+
+const unscopedPkg = new WorkspacePackage({
+	name: "my-lib",
+	version: "1.0.0",
+	path: "/workspace/packages/my-lib",
+	relativePath: "packages/my-lib",
+	private: true,
+});
+
+describe("WorkspacePackage getters", () => {
+	it("isRootWorkspace returns true for root", () => {
+		expect(rootPkg.isRootWorkspace).toBe(true);
+		expect(scopedPkg.isRootWorkspace).toBe(false);
+	});
+
+	it("packageJsonPath appends package.json", () => {
+		expect(rootPkg.packageJsonPath).toBe("/workspace/package.json");
+		expect(scopedPkg.packageJsonPath).toBe("/workspace/packages/utils/package.json");
+	});
+
+	it("isPublic is inverse of private", () => {
+		expect(scopedPkg.isPublic).toBe(true);
+		expect(unscopedPkg.isPublic).toBe(false);
+	});
+
+	it("scope extracts @scope from scoped name", () => {
+		expect(scopedPkg.scope).toEqual(Option.some("@scope"));
+		expect(unscopedPkg.scope).toEqual(Option.none());
+	});
+
+	it("unscopedName strips scope prefix", () => {
+		expect(scopedPkg.unscopedName).toBe("utils");
+		expect(unscopedPkg.unscopedName).toBe("my-lib");
+	});
+
+	it("allDependencies merges all 4 dep types", () => {
+		expect(scopedPkg.allDependencies).toEqual({
+			effect: "^3.0.0",
+			vitest: "^3.0.0",
+			react: "^18.0.0",
+			fsevents: "^2.3.0",
+		});
+	});
+});
+
+describe("WorkspacePackage instance methods", () => {
+	it("hasDependency checks dependencies only", () => {
+		expect(scopedPkg.hasDependency("effect")).toBe(true);
+		expect(scopedPkg.hasDependency("vitest")).toBe(false);
+	});
+
+	it("hasDevDependency checks devDependencies only", () => {
+		expect(scopedPkg.hasDevDependency("vitest")).toBe(true);
+		expect(scopedPkg.hasDevDependency("effect")).toBe(false);
+	});
+
+	it("hasPeerDependency checks peerDependencies only", () => {
+		expect(scopedPkg.hasPeerDependency("react")).toBe(true);
+		expect(scopedPkg.hasPeerDependency("effect")).toBe(false);
+	});
+
+	it("hasOptionalDependency checks optionalDependencies only", () => {
+		expect(scopedPkg.hasOptionalDependency("fsevents")).toBe(true);
+		expect(scopedPkg.hasOptionalDependency("effect")).toBe(false);
+	});
+
+	it("hasAnyDependencyOn checks all 4 dep types", () => {
+		expect(scopedPkg.hasAnyDependencyOn("effect")).toBe(true);
+		expect(scopedPkg.hasAnyDependencyOn("vitest")).toBe(true);
+		expect(scopedPkg.hasAnyDependencyOn("react")).toBe(true);
+		expect(scopedPkg.hasAnyDependencyOn("fsevents")).toBe(true);
+		expect(scopedPkg.hasAnyDependencyOn("nonexistent")).toBe(false);
+	});
+
+	it("dependencyVersion returns version from any dep type", () => {
+		expect(scopedPkg.dependencyVersion("effect")).toEqual(Option.some("^3.0.0"));
+		expect(scopedPkg.dependencyVersion("react")).toEqual(Option.some("^18.0.0"));
+		expect(scopedPkg.dependencyVersion("nonexistent")).toEqual(Option.none());
+	});
+
+	it("matchesDependency matches glob patterns against dep names", () => {
+		expect(scopedPkg.matchesDependency("effect")).toBe(true);
+		expect(scopedPkg.matchesDependency("*test*")).toBe(true);
+		expect(scopedPkg.matchesDependency("@scope/*")).toBe(false);
+	});
+});
+
+describe("WorkspacePackage.dependencyDiff", () => {
+	it("detects added dependencies", () => {
+		const before = new WorkspacePackage({
+			name: "pkg",
+			version: "1.0.0",
+			path: "/workspace/pkg",
+			relativePath: "pkg",
+			dependencies: { a: "1.0.0" },
+		});
+		const after = new WorkspacePackage({
+			name: "pkg",
+			version: "1.0.0",
+			path: "/workspace/pkg",
+			relativePath: "pkg",
+			dependencies: { a: "1.0.0", b: "2.0.0" },
+		});
+		const diff = after.dependencyDiff(before);
+		expect(diff.added).toEqual({ b: "2.0.0" });
+		expect(diff.removed).toEqual({});
+		expect(diff.changed).toEqual({});
+	});
+
+	it("detects removed dependencies", () => {
+		const before = new WorkspacePackage({
+			name: "pkg",
+			version: "1.0.0",
+			path: "/workspace/pkg",
+			relativePath: "pkg",
+			dependencies: { a: "1.0.0", b: "2.0.0" },
+		});
+		const after = new WorkspacePackage({
+			name: "pkg",
+			version: "1.0.0",
+			path: "/workspace/pkg",
+			relativePath: "pkg",
+			dependencies: { a: "1.0.0" },
+		});
+		const diff = after.dependencyDiff(before);
+		expect(diff.added).toEqual({});
+		expect(diff.removed).toEqual({ b: "2.0.0" });
+		expect(diff.changed).toEqual({});
+	});
+
+	it("detects changed versions", () => {
+		const before = new WorkspacePackage({
+			name: "pkg",
+			version: "1.0.0",
+			path: "/workspace/pkg",
+			relativePath: "pkg",
+			dependencies: { a: "1.0.0" },
+		});
+		const after = new WorkspacePackage({
+			name: "pkg",
+			version: "1.0.0",
+			path: "/workspace/pkg",
+			relativePath: "pkg",
+			dependencies: { a: "2.0.0" },
+		});
+		const diff = after.dependencyDiff(before);
+		expect(diff.added).toEqual({});
+		expect(diff.removed).toEqual({});
+		expect(diff.changed).toEqual({ a: { from: "1.0.0", to: "2.0.0" } });
+	});
+
+	it("compares across all dep types", () => {
+		const before = new WorkspacePackage({
+			name: "pkg",
+			version: "1.0.0",
+			path: "/workspace/pkg",
+			relativePath: "pkg",
+			peerDependencies: { react: "^17.0.0" },
+		});
+		const after = new WorkspacePackage({
+			name: "pkg",
+			version: "1.0.0",
+			path: "/workspace/pkg",
+			relativePath: "pkg",
+			peerDependencies: { react: "^18.0.0" },
+		});
+		const diff = after.dependencyDiff(before);
+		expect(diff.changed).toEqual({ react: { from: "^17.0.0", to: "^18.0.0" } });
+	});
+});

--- a/src/schemas/core.ts
+++ b/src/schemas/core.ts
@@ -4,7 +4,11 @@
  * @packageDocumentation
  */
 
-import { Schema } from "effect";
+import type { FileSystem } from "@effect/platform";
+import type { Effect } from "effect";
+import { Option, Schema } from "effect";
+import { minimatch } from "minimatch";
+import type { PackageJsonParseError } from "../errors/PackageJsonParseError.js";
 
 // ── Branded Primitives ───────────────────────────────────────────────
 
@@ -200,6 +204,7 @@ export const PackageJsonSchema = Schema.Struct({
 	dependencies: Schema.optional(Schema.Record({ key: Schema.String, value: Schema.String })),
 	devDependencies: Schema.optional(Schema.Record({ key: Schema.String, value: Schema.String })),
 	peerDependencies: Schema.optional(Schema.Record({ key: Schema.String, value: Schema.String })),
+	optionalDependencies: Schema.optional(Schema.Record({ key: Schema.String, value: Schema.String })),
 	packageManager: Schema.optional(Schema.String),
 	publishConfig: Schema.optional(PublishConfigSchema),
 });
@@ -212,6 +217,16 @@ export const PackageJsonSchema = Schema.Struct({
 export type PackageJsonType = Schema.Schema.Type<typeof PackageJsonSchema>;
 
 // ── Workspace Data Types ─────────────────────────────────────────────
+
+/**
+ * Result of comparing two WorkspacePackage dependency snapshots.
+ * @public
+ */
+export interface DependencyDiff {
+	readonly added: Record<string, string>;
+	readonly removed: Record<string, string>;
+	readonly changed: Record<string, { readonly from: string; readonly to: string }>;
+}
 
 /**
  * A single workspace package within a monorepo.
@@ -229,6 +244,8 @@ export type PackageJsonType = Schema.Schema.Type<typeof PackageJsonSchema>;
  * - `private` — whether the package is marked private (defaults to `false`).
  * - `dependencies` — production dependency map (defaults to `{}`).
  * - `devDependencies` — development dependency map (defaults to `{}`).
+ * - `peerDependencies` — peer dependency map (defaults to `{}`).
+ * - `optionalDependencies` — optional dependency map (defaults to `{}`).
  * - `publishConfig` — optional publishing configuration overrides.
  *
  * @example Creating a WorkspacePackage
@@ -257,8 +274,150 @@ export class WorkspacePackage extends Schema.Class<WorkspacePackage>("WorkspaceP
 	devDependencies: Schema.optionalWith(Schema.Record({ key: Schema.String, value: Schema.String }), {
 		default: () => ({}),
 	}),
+	peerDependencies: Schema.optionalWith(Schema.Record({ key: Schema.String, value: Schema.String }), {
+		default: () => ({}),
+	}),
+	optionalDependencies: Schema.optionalWith(Schema.Record({ key: Schema.String, value: Schema.String }), {
+		default: () => ({}),
+	}),
 	publishConfig: Schema.optional(PublishConfigSchema),
-}) {}
+}) {
+	get isRootWorkspace(): boolean {
+		return this.relativePath === ".";
+	}
+
+	get packageJsonPath(): string {
+		return `${this.path}/package.json`;
+	}
+
+	get isPublic(): boolean {
+		return !this.private;
+	}
+
+	get scope(): Option.Option<string> {
+		const match = this.name.match(/^(@[^/]+)\//);
+		return match ? Option.some(match[1]) : Option.none();
+	}
+
+	get unscopedName(): string {
+		const slashIndex = this.name.indexOf("/");
+		return this.name.startsWith("@") && slashIndex !== -1 ? this.name.slice(slashIndex + 1) : this.name;
+	}
+
+	get allDependencies(): Record<string, string> {
+		return {
+			...this.optionalDependencies,
+			...this.peerDependencies,
+			...this.devDependencies,
+			...this.dependencies,
+		};
+	}
+
+	hasDependency(name: string): boolean {
+		return name in this.dependencies;
+	}
+
+	hasDevDependency(name: string): boolean {
+		return name in this.devDependencies;
+	}
+
+	hasPeerDependency(name: string): boolean {
+		return name in this.peerDependencies;
+	}
+
+	hasOptionalDependency(name: string): boolean {
+		return name in this.optionalDependencies;
+	}
+
+	hasAnyDependencyOn(name: string): boolean {
+		return (
+			this.hasDependency(name) ||
+			this.hasDevDependency(name) ||
+			this.hasPeerDependency(name) ||
+			this.hasOptionalDependency(name)
+		);
+	}
+
+	dependencyVersion(name: string): Option.Option<string> {
+		const version =
+			this.dependencies[name] ??
+			this.devDependencies[name] ??
+			this.peerDependencies[name] ??
+			this.optionalDependencies[name];
+		return version !== undefined ? Option.some(version) : Option.none();
+	}
+
+	matchesDependency(pattern: string): boolean {
+		return Object.keys(this.allDependencies).some((dep) => minimatch(dep, pattern));
+	}
+
+	/**
+	 * Compare two WorkspacePackage dependency snapshots.
+	 *
+	 * Compares across all dependency types combined. A dependency that moves
+	 * between categories (e.g. from `dependencies` to `peerDependencies`) at
+	 * the same version will not appear in the diff.
+	 */
+	dependencyDiff(other: WorkspacePackage): DependencyDiff {
+		const selfDeps = this.allDependencies;
+		const otherDeps = other.allDependencies;
+		const added: Record<string, string> = {};
+		const removed: Record<string, string> = {};
+		const changed: Record<string, { from: string; to: string }> = {};
+
+		for (const [name, version] of Object.entries(selfDeps)) {
+			if (!(name in otherDeps)) {
+				added[name] = version;
+			} else if (otherDeps[name] !== version) {
+				changed[name] = { from: otherDeps[name], to: version };
+			}
+		}
+		for (const [name, version] of Object.entries(otherDeps)) {
+			if (!(name in selfDeps)) {
+				removed[name] = version;
+			}
+		}
+
+		return { added, removed, changed };
+	}
+
+	// ── Cross-cutting statics (wired in index.ts) ───────────────────────
+	declare static hasDependency: {
+		(name: string): (self: WorkspacePackage) => boolean;
+		(self: WorkspacePackage, name: string): boolean;
+	};
+	declare static hasDevDependency: {
+		(name: string): (self: WorkspacePackage) => boolean;
+		(self: WorkspacePackage, name: string): boolean;
+	};
+	declare static hasPeerDependency: {
+		(name: string): (self: WorkspacePackage) => boolean;
+		(self: WorkspacePackage, name: string): boolean;
+	};
+	declare static hasOptionalDependency: {
+		(name: string): (self: WorkspacePackage) => boolean;
+		(self: WorkspacePackage, name: string): boolean;
+	};
+	declare static hasAnyDependencyOn: {
+		(name: string): (self: WorkspacePackage) => boolean;
+		(self: WorkspacePackage, name: string): boolean;
+	};
+	declare static dependencyVersion: {
+		(name: string): (self: WorkspacePackage) => Option.Option<string>;
+		(self: WorkspacePackage, name: string): Option.Option<string>;
+	};
+	declare static matchesDependency: {
+		(pattern: string): (self: WorkspacePackage) => boolean;
+		(self: WorkspacePackage, pattern: string): boolean;
+	};
+	declare static dependencyDiff: {
+		(other: WorkspacePackage): (self: WorkspacePackage) => DependencyDiff;
+		(self: WorkspacePackage, other: WorkspacePackage): DependencyDiff;
+	};
+	declare static readPackageJson: (
+		self: WorkspacePackage,
+	) => Effect.Effect<PackageJsonType, PackageJsonParseError, FileSystem.FileSystem>;
+}
 
 /**
  * Top-level workspace info for a monorepo.

--- a/src/services/WorkspaceDiscovery.ts
+++ b/src/services/WorkspaceDiscovery.ts
@@ -82,5 +82,15 @@ export class WorkspaceDiscovery extends Context.Tag("@spencerbeggs/workspaces-ef
 		readonly getPackage: (
 			name: string,
 		) => Effect.Effect<WorkspacePackage, PackageNotFoundError | WorkspaceDiscoveryError>;
+
+		/**
+		 * Get a map of workspace-relative directory paths to packages.
+		 *
+		 * Useful for mapping lockfile importer keys to their workspace packages.
+		 * Built from `listPackages()` output and inherits its caching.
+		 *
+		 * @returns An Effect that succeeds with a ReadonlyMap keyed by relativePath.
+		 */
+		readonly importerMap: () => Effect.Effect<ReadonlyMap<string, WorkspacePackage>, WorkspaceDiscoveryError>;
 	}
 >() {}

--- a/src/utils/workspace-package.test.ts
+++ b/src/utils/workspace-package.test.ts
@@ -1,0 +1,148 @@
+import { FileSystem } from "@effect/platform";
+import { Effect, Option, pipe } from "effect";
+import { describe, expect, it } from "vitest";
+import { WorkspacePackage } from "../schemas/core.js";
+import {
+	dependencyDiff,
+	dependencyVersion,
+	hasAnyDependencyOn,
+	hasDependency,
+	hasDevDependency,
+	hasOptionalDependency,
+	hasPeerDependency,
+	matchesDependency,
+	readPackageJson,
+} from "./workspace-package.js";
+
+const pkg = new WorkspacePackage({
+	name: "@scope/utils",
+	version: "1.0.0",
+	path: "/workspace/packages/utils",
+	relativePath: "packages/utils",
+	dependencies: { effect: "^3.0.0" },
+	devDependencies: { vitest: "^3.0.0" },
+	peerDependencies: { react: "^18.0.0" },
+	optionalDependencies: { fsevents: "^2.3.0" },
+});
+
+describe("standalone dual functions", () => {
+	describe("data-first calling style", () => {
+		it("hasDependency", () => {
+			expect(hasDependency(pkg, "effect")).toBe(true);
+			expect(hasDependency(pkg, "vitest")).toBe(false);
+		});
+
+		it("hasDevDependency", () => {
+			expect(hasDevDependency(pkg, "vitest")).toBe(true);
+		});
+
+		it("hasPeerDependency", () => {
+			expect(hasPeerDependency(pkg, "react")).toBe(true);
+		});
+
+		it("hasOptionalDependency", () => {
+			expect(hasOptionalDependency(pkg, "fsevents")).toBe(true);
+		});
+
+		it("hasAnyDependencyOn", () => {
+			expect(hasAnyDependencyOn(pkg, "effect")).toBe(true);
+			expect(hasAnyDependencyOn(pkg, "nonexistent")).toBe(false);
+		});
+
+		it("dependencyVersion", () => {
+			expect(dependencyVersion(pkg, "effect")).toEqual(Option.some("^3.0.0"));
+			expect(dependencyVersion(pkg, "nonexistent")).toEqual(Option.none());
+		});
+
+		it("matchesDependency", () => {
+			expect(matchesDependency(pkg, "*test*")).toBe(true);
+		});
+	});
+
+	describe("data-last (pipeable) calling style", () => {
+		it("hasDependency", () => {
+			expect(pipe(pkg, hasDependency("effect"))).toBe(true);
+		});
+
+		it("dependencyVersion", () => {
+			expect(pipe(pkg, dependencyVersion("effect"))).toEqual(Option.some("^3.0.0"));
+		});
+
+		it("matchesDependency", () => {
+			expect(pipe(pkg, matchesDependency("*test*"))).toBe(true);
+		});
+	});
+
+	describe("dependencyDiff standalone", () => {
+		it("data-first", () => {
+			const before = new WorkspacePackage({
+				name: "pkg",
+				version: "1.0.0",
+				path: "/workspace/pkg",
+				relativePath: "pkg",
+				dependencies: { a: "1.0.0" },
+			});
+			const after = new WorkspacePackage({
+				name: "pkg",
+				version: "1.0.0",
+				path: "/workspace/pkg",
+				relativePath: "pkg",
+				dependencies: { a: "2.0.0", b: "1.0.0" },
+			});
+			const diff = dependencyDiff(after, before);
+			expect(diff.added).toEqual({ b: "1.0.0" });
+			expect(diff.changed).toEqual({ a: { from: "1.0.0", to: "2.0.0" } });
+		});
+
+		it("data-last (pipeable)", () => {
+			const before = new WorkspacePackage({
+				name: "pkg",
+				version: "1.0.0",
+				path: "/workspace/pkg",
+				relativePath: "pkg",
+				dependencies: { a: "1.0.0" },
+			});
+			const after = new WorkspacePackage({
+				name: "pkg",
+				version: "1.0.0",
+				path: "/workspace/pkg",
+				relativePath: "pkg",
+				dependencies: { b: "1.0.0" },
+			});
+			const diff = pipe(after, dependencyDiff(before));
+			expect(diff.added).toEqual({ b: "1.0.0" });
+			expect(diff.removed).toEqual({ a: "1.0.0" });
+		});
+	});
+});
+
+describe("readPackageJson", () => {
+	it("reads and parses a package.json from the filesystem", async () => {
+		const testPkg = new WorkspacePackage({
+			name: "test-pkg",
+			version: "1.0.0",
+			path: "/workspace/packages/test",
+			relativePath: "packages/test",
+		});
+
+		const mockFsLayer = FileSystem.layerNoop({
+			readFileString: (path) => {
+				if (path === "/workspace/packages/test/package.json") {
+					return Effect.succeed(
+						JSON.stringify({
+							name: "test-pkg",
+							version: "1.0.0",
+							dependencies: { effect: "^3.0.0" },
+						}),
+					);
+				}
+				return Effect.die(new Error(`ENOENT: ${path}`));
+			},
+		});
+
+		const result = await Effect.runPromise(readPackageJson(testPkg).pipe(Effect.provide(mockFsLayer)));
+
+		expect(result.name).toBe("test-pkg");
+		expect(result.dependencies).toEqual({ effect: "^3.0.0" });
+	});
+});

--- a/src/utils/workspace-package.ts
+++ b/src/utils/workspace-package.ts
@@ -1,0 +1,95 @@
+/**
+ * Standalone dual-API functions for WorkspacePackage.
+ *
+ * Each function supports both data-first and data-last (pipeable) calling styles
+ * via `Function.dual()`.
+ *
+ * @packageDocumentation
+ */
+
+import { FileSystem } from "@effect/platform";
+import type { Option } from "effect";
+import { Effect, Function as Fn, Schema } from "effect";
+import { PackageJsonParseError } from "../errors/PackageJsonParseError.js";
+import type { DependencyDiff, WorkspacePackage } from "../schemas/core.js";
+import { PackageJsonSchema } from "../schemas/core.js";
+
+/** Check if a package has a production dependency. Dual API. */
+export const hasDependency: {
+	(name: string): (self: WorkspacePackage) => boolean;
+	(self: WorkspacePackage, name: string): boolean;
+} = Fn.dual(2, (self: WorkspacePackage, name: string): boolean => self.hasDependency(name));
+
+/** Check if a package has a dev dependency. Dual API. */
+export const hasDevDependency: {
+	(name: string): (self: WorkspacePackage) => boolean;
+	(self: WorkspacePackage, name: string): boolean;
+} = Fn.dual(2, (self: WorkspacePackage, name: string): boolean => self.hasDevDependency(name));
+
+/** Check if a package has a peer dependency. Dual API. */
+export const hasPeerDependency: {
+	(name: string): (self: WorkspacePackage) => boolean;
+	(self: WorkspacePackage, name: string): boolean;
+} = Fn.dual(2, (self: WorkspacePackage, name: string): boolean => self.hasPeerDependency(name));
+
+/** Check if a package has an optional dependency. Dual API. */
+export const hasOptionalDependency: {
+	(name: string): (self: WorkspacePackage) => boolean;
+	(self: WorkspacePackage, name: string): boolean;
+} = Fn.dual(2, (self: WorkspacePackage, name: string): boolean => self.hasOptionalDependency(name));
+
+/** Check if a package depends on a name in any dep type. Dual API. */
+export const hasAnyDependencyOn: {
+	(name: string): (self: WorkspacePackage) => boolean;
+	(self: WorkspacePackage, name: string): boolean;
+} = Fn.dual(2, (self: WorkspacePackage, name: string): boolean => self.hasAnyDependencyOn(name));
+
+/** Look up version across all dep types. Dual API. */
+export const dependencyVersion: {
+	(name: string): (self: WorkspacePackage) => Option.Option<string>;
+	(self: WorkspacePackage, name: string): Option.Option<string>;
+} = Fn.dual(2, (self: WorkspacePackage, name: string): Option.Option<string> => self.dependencyVersion(name));
+
+/** Check if any dep name matches a glob pattern. Dual API. */
+export const matchesDependency: {
+	(pattern: string): (self: WorkspacePackage) => boolean;
+	(self: WorkspacePackage, pattern: string): boolean;
+} = Fn.dual(2, (self: WorkspacePackage, pattern: string): boolean => self.matchesDependency(pattern));
+
+/** Compare two WorkspacePackage dependency snapshots. Dual API. */
+export const dependencyDiff: {
+	(other: WorkspacePackage): (self: WorkspacePackage) => DependencyDiff;
+	(self: WorkspacePackage, other: WorkspacePackage): DependencyDiff;
+} = Fn.dual(2, (self: WorkspacePackage, other: WorkspacePackage): DependencyDiff => self.dependencyDiff(other));
+
+/**
+ * Read and parse a package's package.json from disk.
+ *
+ * Returns the minimal `PackageJsonType` schema fields. For full raw
+ * package.json access, read `pkg.packageJsonPath` directly.
+ *
+ * Not a dual function — takes a single WorkspacePackage argument.
+ * Pipeable via `pipe(pkg, readPackageJson)`.
+ */
+export const readPackageJson = (
+	self: WorkspacePackage,
+): Effect.Effect<Schema.Schema.Type<typeof PackageJsonSchema>, PackageJsonParseError, FileSystem.FileSystem> =>
+	Effect.gen(function* () {
+		const fs = yield* FileSystem.FileSystem;
+		const content = yield* fs
+			.readFileString(self.packageJsonPath)
+			.pipe(
+				Effect.mapError(
+					() => new PackageJsonParseError({ filePath: self.packageJsonPath, cause: "failed to read file" }),
+				),
+			);
+		const raw = yield* Effect.try({
+			try: () => JSON.parse(content) as Record<string, unknown>,
+			catch: () => new PackageJsonParseError({ filePath: self.packageJsonPath, cause: "invalid JSON" }),
+		});
+		return yield* Schema.decodeUnknown(PackageJsonSchema)(raw).pipe(
+			Effect.mapError(
+				() => new PackageJsonParseError({ filePath: self.packageJsonPath, cause: "schema decode failed" }),
+			),
+		);
+	});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,9 +1,3 @@
 import { VitestConfig } from "@savvy-web/vitest";
 
-export default VitestConfig.create(({ projects, coverage, reporters }) => ({
-	test: {
-		reporters,
-		projects: projects.map((p) => p.toConfig()),
-		coverage: { provider: "v8", ...coverage },
-	},
-}));
+export default VitestConfig.create();


### PR DESCRIPTION
## Summary

- Enrich `WorkspacePackage` with `peerDependencies`/`optionalDependencies` fields, computed getters (`isRootWorkspace`, `packageJsonPath`, `isPublic`, `scope`, `unscopedName`, `allDependencies`), and dependency query methods (`hasDependency`, `hasAnyDependencyOn`, `dependencyVersion`, `matchesDependency`, `dependencyDiff`)
- Add standalone `Function.dual()` functions for pipeable/curried use, wired as static methods on `WorkspacePackage` (semver-effect pattern)
- Add `readPackageJson` utility and `WorkspaceDiscovery.importerMap()` service method for lockfile importer mapping
- **Breaking:** `listPackages()` now always includes the root workspace package as the first entry

## Test plan

- [x] 206 tests passing (30 new tests for getters, instance methods, dual functions, root inclusion, importerMap)
- [x] Typecheck clean
- [x] Lint clean (Biome + markdownlint)
- [ ] CI passes

Closes #12.

Signed-off-by: C. Spencer Beggs <spencer@beggs.codes>