### PR TITLE
feat: improve extension ergonomics for downstream consumers

### DIFF
--- a/.changeset/cwd-coupling.md
+++ b/.changeset/cwd-coupling.md
@@ -1,0 +1,30 @@
+---
+"workspaces-effect": minor
+---
+
+## Breaking Changes
+
+### Sync helper returns WorkspacePackage instances
+
+`getWorkspacePackagesSync` now returns `ReadonlyArray<WorkspacePackage>` instead of `ReadonlyArray<{ name: string; path: string }>`. The richer return shape makes the sync helper a first-class equal of `WorkspaceDiscovery.listPackages()` and lets non-Effect callers feed packages directly into services like `PublishabilityDetector` without re-reading manifests.
+
+The function now also throws when the root `package.json` is missing required `name` or `version` fields, matching the Effect-native discovery semantics. Previously the root was silently omitted in that case.
+
+Consumers that only need `{ name, path }` continue to work unchanged — `WorkspacePackage` exposes those fields and adds `version`, `packageJsonPath`, `relativePath`, `private`, `publishConfig`, dependency maps, and computed getters like `isRootWorkspace`.
+
+## Features
+
+### Optional cwd parameter on WorkspaceDiscovery methods
+
+`listPackages`, `importerMap`, and `getPackage` now accept an optional `cwd` argument. When provided, the workspace root is resolved fresh from that directory for the call; results are cached per resolved root for the lifetime of the layer. When omitted, the methods use the root that was eagerly resolved from `process.cwd()` at layer construction time, preserving existing behaviour.
+
+This removes the need for a custom `WorkspaceRoot` layer when a downstream consumer just wants to discover packages at a specific path — useful for tests that load fixtures into temp directories and for tools (CI actions, etc.) that operate on a path supplied by the caller rather than the process working directory.
+
+```ts
+const discovery = yield* WorkspaceDiscovery;
+const packages = yield* discovery.listPackages("/tmp/fixture-monorepo");
+```
+
+### README documents custom publishability detectors
+
+A new "Custom publishability detectors" section in the README shows how to override `PublishabilityDetector` with `Layer.succeed(PublishabilityDetector, customImpl)`. The pattern was already supported but undocumented; downstream packages that need non-vanilla publish semantics (mirroring to a private registry, organisation conventions, etc.) now have a clear extension point.

--- a/README.md
+++ b/README.md
@@ -76,6 +76,77 @@ Two composite layers cover most use cases:
 - **`WorkspacesFullLive`** -- all services including change detection
   (additionally requires `CommandExecutor`)
 
+## Custom publishability detectors
+
+`PublishabilityDetector` is a `Context.Tag` like every other service, so you can
+swap the default implementation with `Layer.succeed` when you need
+non-vanilla publish semantics (e.g. private packages that should still publish
+under specific conditions, registry-aware target expansion, organisation
+conventions). Provide your custom layer instead of `PublishabilityDetectorLive`
+-- everything downstream that yields `PublishabilityDetector` picks up the new
+behaviour transparently.
+
+```typescript
+import { Effect, Layer } from "effect";
+import { NodeContext } from "@effect/platform-node";
+import {
+  PublishabilityDetector,
+  PublishTarget,
+  WorkspaceDiscovery,
+  WorkspacesLive,
+} from "workspaces-effect";
+
+// Always publish to GitHub Packages alongside the package's own publishConfig
+// target -- a common requirement for orgs that mirror to a private registry.
+const ORG_REGISTRY = "https://npm.pkg.github.com/";
+
+const OrgMirrorDetector = Layer.succeed(PublishabilityDetector, {
+  detect: (pkg, _root) =>
+    Effect.sync(() => {
+      if (pkg.private && !pkg.publishConfig?.access) return [];
+
+      const primary = new PublishTarget({
+        name: pkg.name,
+        registry: pkg.publishConfig?.registry ?? "https://registry.npmjs.org/",
+        directory: pkg.publishConfig?.directory ?? ".",
+        access: pkg.publishConfig?.access ?? "public",
+        provenance: false,
+      });
+
+      const mirror = new PublishTarget({
+        name: pkg.name,
+        registry: ORG_REGISTRY,
+        directory: pkg.publishConfig?.directory ?? ".",
+        access: pkg.publishConfig?.access ?? "restricted",
+        provenance: false,
+      });
+
+      return primary.registry === mirror.registry ? [primary] : [primary, mirror];
+    }),
+});
+
+const program = Effect.gen(function* () {
+  const discovery = yield* WorkspaceDiscovery;
+  const detector = yield* PublishabilityDetector;
+  for (const pkg of yield* discovery.listPackages()) {
+    const targets = yield* detector.detect(pkg, "/path/to/root");
+    if (targets.length > 0) console.log(pkg.name, targets.map((t) => t.registry));
+  }
+});
+
+Effect.runPromise(
+  program.pipe(
+    Effect.provide(OrgMirrorDetector),
+    Effect.provide(WorkspacesLive),
+    Effect.provide(NodeContext.layer),
+  ),
+);
+```
+
+The same pattern applies to any other service in the library -- `WorkspaceRoot`,
+`PackageManagerDetector`, `LockfileReader`, etc. all expose `Context.Tag`s
+that consumers can rebind.
+
 ## Documentation
 
 For architecture details, API reference, and advanced usage, see

--- a/__test__/integration/workspace-discovery-cwd.int.test.ts
+++ b/__test__/integration/workspace-discovery-cwd.int.test.ts
@@ -1,0 +1,136 @@
+/**
+ * Integration tests for the optional `cwd` parameter on WorkspaceDiscovery
+ * methods. Verifies that an explicit cwd resolves a fresh root, results are
+ * cached per resolved root, and the no-arg path uses the eagerly-resolved
+ * default root.
+ */
+
+import { Path } from "@effect/platform";
+import { NodeFileSystem } from "@effect/platform-node";
+import { Effect, Layer, Logger } from "effect";
+import { describe, expect, it } from "vitest";
+import { WorkspaceDiscoveryLive } from "../../src/layers/WorkspaceDiscoveryLive.js";
+import { WorkspaceDiscovery } from "../../src/services/WorkspaceDiscovery.js";
+import { WorkspaceRoot } from "../../src/services/WorkspaceRoot.js";
+import { discoveryFixture } from "../utils/fixtures.js";
+
+const platformLayer = Layer.mergeAll(
+	NodeFileSystem.layer,
+	Path.layer,
+	Logger.replace(Logger.defaultLogger, Logger.none),
+);
+
+// Mock WorkspaceRoot.find that returns its argument unchanged. Lets each
+// caller pass a fixture path directly as the "cwd"; the layer treats the
+// returned value as the resolved workspace root.
+const passthroughRoot = (defaultRoot: string) =>
+	Layer.succeed(WorkspaceRoot, {
+		find: (cwd: string) => Effect.succeed(cwd === "__default__" ? defaultRoot : cwd),
+	});
+
+const makeLayer = (defaultRoot: string) =>
+	WorkspaceDiscoveryLive.pipe(Layer.provide(Layer.mergeAll(passthroughRoot(defaultRoot), platformLayer)));
+
+const PNPM = discoveryFixture("pnpm/basic");
+const NPM = discoveryFixture("npm/basic");
+
+describe("WorkspaceDiscovery cwd parameter", () => {
+	it("listPackages(cwd) resolves a fresh root for that call", async () => {
+		// Construction-time default points at PNPM; the explicit cwd points at NPM.
+		// Result should reflect NPM's packages, not PNPM's.
+		const namesNpm = await Effect.runPromise(
+			Effect.gen(function* () {
+				const discovery = yield* WorkspaceDiscovery;
+				const pkgs = yield* discovery.listPackages(NPM);
+				return pkgs.map((p) => p.name).sort();
+			}).pipe(Effect.provide(makeLayer(PNPM))),
+		);
+
+		expect(namesNpm).toContain("npm-basic-monorepo");
+		expect(namesNpm).toContain("@scope/npm-lib-a");
+		expect(namesNpm).not.toContain("pnpm-basic-monorepo");
+	});
+
+	it("listPackages() with no arg uses the eagerly-resolved default root", async () => {
+		// Use a mock that returns PNPM only when called with the construction-time
+		// process.cwd() sentinel. The layer eagerly calls find(process.cwd()) at
+		// construction; once stored, no-arg calls reuse that value.
+		const layer = WorkspaceDiscoveryLive.pipe(
+			Layer.provide(
+				Layer.mergeAll(
+					Layer.succeed(WorkspaceRoot, {
+						find: () => Effect.succeed(PNPM),
+					}),
+					platformLayer,
+				),
+			),
+		);
+
+		const names = await Effect.runPromise(
+			Effect.gen(function* () {
+				const discovery = yield* WorkspaceDiscovery;
+				const pkgs = yield* discovery.listPackages();
+				return pkgs.map((p) => p.name).sort();
+			}).pipe(Effect.provide(layer)),
+		);
+
+		expect(names).toContain("pnpm-basic-monorepo");
+		expect(names).toContain("@scope/lib-public");
+	});
+
+	it("caches results per resolved root", async () => {
+		// Two calls with the same cwd should return the same instance (memoised).
+		// Two calls with different cwds should return different instances.
+		const result = await Effect.runPromise(
+			Effect.gen(function* () {
+				const discovery = yield* WorkspaceDiscovery;
+				const a1 = yield* discovery.listPackages(PNPM);
+				const a2 = yield* discovery.listPackages(PNPM);
+				const b1 = yield* discovery.listPackages(NPM);
+				return { a1, a2, b1 };
+			}).pipe(Effect.provide(makeLayer(PNPM))),
+		);
+
+		expect(result.a1).toBe(result.a2);
+		expect(result.a1).not.toBe(result.b1);
+	});
+
+	it("importerMap(cwd) reflects the cwd-resolved root", async () => {
+		const keys = await Effect.runPromise(
+			Effect.gen(function* () {
+				const discovery = yield* WorkspaceDiscovery;
+				const map = yield* discovery.importerMap(NPM);
+				return [...map.keys()].sort();
+			}).pipe(Effect.provide(makeLayer(PNPM))),
+		);
+
+		expect(keys).toContain(".");
+		expect(keys).toContain("packages/lib-a");
+	});
+
+	it("getPackage(name, cwd) finds packages under the cwd-resolved root", async () => {
+		const pkg = await Effect.runPromise(
+			Effect.gen(function* () {
+				const discovery = yield* WorkspaceDiscovery;
+				return yield* discovery.getPackage("@scope/npm-lib-a", NPM);
+			}).pipe(Effect.provide(makeLayer(PNPM))),
+		);
+
+		expect(pkg.name).toBe("@scope/npm-lib-a");
+		expect(pkg.path).toBe(`${NPM}/packages/lib-a`);
+	});
+
+	it("getPackage rejects when package is not under the cwd-resolved root", async () => {
+		// @scope/lib-public lives under PNPM; querying with NPM cwd should miss.
+		const result = await Effect.runPromise(
+			Effect.gen(function* () {
+				const discovery = yield* WorkspaceDiscovery;
+				return yield* discovery
+					.getPackage("@scope/lib-public", NPM)
+					.pipe(Effect.catchTag("PackageNotFoundError", (e) => Effect.succeed({ tag: e._tag, name: e.name })));
+			}).pipe(Effect.provide(makeLayer(PNPM))),
+		);
+
+		expect(result).toEqual({ tag: "PackageNotFoundError", name: "@scope/lib-public" });
+	});
+});

--- a/__test__/sync.test.ts
+++ b/__test__/sync.test.ts
@@ -1,5 +1,6 @@
 import { resolve } from "node:path";
 import { describe, expect, it } from "vitest";
+import { WorkspacePackage } from "../src/schemas/core.js";
 import { findWorkspaceRootSync, getWorkspacePackagesSync } from "../src/sync.js";
 
 const FIXTURES = resolve(import.meta.dirname, "integration/fixtures/discovery");
@@ -146,5 +147,57 @@ describe("getWorkspacePackagesSync", () => {
 
 	it("throws for nonexistent directory", () => {
 		expect(() => getWorkspacePackagesSync("/nonexistent/path")).toThrow();
+	});
+
+	describe("WorkspacePackage shape", () => {
+		const root = resolve(FIXTURES, "pnpm/basic");
+
+		it("returns WorkspacePackage instances", () => {
+			const packages = getWorkspacePackagesSync(root);
+			for (const pkg of packages) {
+				expect(pkg).toBeInstanceOf(WorkspacePackage);
+			}
+		});
+
+		it("populates version, packageJsonPath, and relativePath", () => {
+			const packages = getWorkspacePackagesSync(root);
+			const pub = packages.find((p) => p.name === "@scope/lib-public");
+			expect(pub).toBeDefined();
+			expect(pub?.version).toBeTypeOf("string");
+			expect(pub?.version.length).toBeGreaterThan(0);
+			expect(pub?.packageJsonPath).toBe(resolve(root, "packages/lib-public/package.json"));
+			expect(pub?.relativePath).toBe("packages/lib-public");
+		});
+
+		it("root package has relativePath '.' and isRootWorkspace true", () => {
+			const packages = getWorkspacePackagesSync(root);
+			expect(packages[0].relativePath).toBe(".");
+			expect(packages[0].isRootWorkspace).toBe(true);
+		});
+
+		it("decodes publishConfig when present", () => {
+			const packages = getWorkspacePackagesSync(root);
+			const pub = packages.find((p) => p.name === "@scope/lib-public");
+			expect(pub?.publishConfig?.access).toBe("public");
+		});
+
+		it("populates dependency maps with empty defaults", () => {
+			const packages = getWorkspacePackagesSync(root);
+			for (const pkg of packages) {
+				expect(pkg.dependencies).toEqual(expect.any(Object));
+				expect(pkg.devDependencies).toEqual(expect.any(Object));
+				expect(pkg.peerDependencies).toEqual(expect.any(Object));
+				expect(pkg.optionalDependencies).toEqual(expect.any(Object));
+			}
+		});
+
+		it("standalone package returns a single WorkspacePackage with isRootWorkspace true", () => {
+			const standalone = getWorkspacePackagesSync(resolve(FIXTURES, "standalone"));
+			expect(standalone).toHaveLength(1);
+			expect(standalone[0]).toBeInstanceOf(WorkspacePackage);
+			expect(standalone[0].name).toBe("standalone-pkg");
+			expect(standalone[0].isRootWorkspace).toBe(true);
+			expect(standalone[0].publishConfig?.access).toBe("public");
+		});
 	});
 });

--- a/src/layers/WorkspaceDiscoveryLive.ts
+++ b/src/layers/WorkspaceDiscoveryLive.ts
@@ -291,13 +291,15 @@ const readWorkspacePackage = (
  * @remarks
  * Requires {@link WorkspaceRoot}, `FileSystem`, and `Path`. The workspace
  * root is eagerly resolved at layer construction time using `process.cwd()`
- * as the starting directory. Discovered packages are cached for the lifetime
- * of the layer.
+ * as the starting directory. Discovery method calls accept an optional
+ * `cwd` parameter to resolve a different root for that single call;
+ * results are cached per resolved root path for the lifetime of the layer.
  *
  * @privateRemarks
- * Uses `process.cwd()` for root resolution. Consumers needing a different
- * starting directory should provide a custom `WorkspaceRoot` layer. Package
- * results are cached in a mutable closure variable.
+ * Eagerly resolves the default root from `process.cwd()` at layer
+ * construction. Per-call `cwd` arguments are resolved on demand via
+ * `WorkspaceRoot.find` and memoized in a `Map` keyed by the absolute
+ * resolved root path.
  *
  * @example
  * ```typescript
@@ -332,11 +334,10 @@ export const WorkspaceDiscoveryLive: Layer.Layer<
 		const fs = yield* FileSystem.FileSystem;
 		const path = yield* Path.Path;
 
-		// Eagerly resolve root at layer construction time.
-		// Uses process.cwd() as the search starting point.
-		// Consumers who need a different cwd should provide a
-		// custom WorkspaceRoot layer that returns the desired root.
-		const resolvedRoot = yield* rootService.find(process.cwd()).pipe(
+		// Eagerly resolve the default root at layer construction time.
+		// Uses process.cwd() as the search starting point. Per-call `cwd`
+		// arguments are resolved on demand by `resolveRoot` below.
+		const defaultRoot = yield* rootService.find(process.cwd()).pipe(
 			Effect.mapError(
 				(e) =>
 					new WorkspaceDiscoveryError({
@@ -346,35 +347,45 @@ export const WorkspaceDiscoveryLive: Layer.Layer<
 			),
 		);
 
-		// Cache for discovered packages
-		let cachedPackages: ReadonlyArray<WorkspacePackage> | undefined;
+		// Per-root cache of discovered packages keyed by absolute resolved root.
+		const cache = new Map<string, ReadonlyArray<WorkspacePackage>>();
 
-		const discoverPackages = (): Effect.Effect<ReadonlyArray<WorkspacePackage>, WorkspaceDiscoveryError> =>
+		const resolveRoot = (cwd: string | undefined): Effect.Effect<string, WorkspaceDiscoveryError> =>
+			cwd === undefined
+				? Effect.succeed(defaultRoot)
+				: rootService.find(cwd).pipe(
+						Effect.mapError(
+							(e) =>
+								new WorkspaceDiscoveryError({
+									root: e.searchPath,
+									reason: `workspace root not found: ${e.reason}`,
+								}),
+						),
+					);
+
+		const discoverAtRoot = (root: string): Effect.Effect<ReadonlyArray<WorkspacePackage>, WorkspaceDiscoveryError> =>
 			Effect.gen(function* () {
-				if (cachedPackages) return cachedPackages;
+				const cached = cache.get(root);
+				if (cached) return cached;
 
-				const patterns = yield* readWorkspacePatterns(fs, path, resolvedRoot);
-				const dirs = yield* resolvePatterns(fs, path, resolvedRoot, patterns);
+				const patterns = yield* readWorkspacePatterns(fs, path, root);
+				const dirs = yield* resolvePatterns(fs, path, root, patterns);
 
-				const workspacePackages = yield* Effect.forEach(
-					dirs,
-					(dir) => readWorkspacePackage(fs, path, resolvedRoot, dir),
-					{
-						concurrency: 10,
-					},
-				);
+				const workspacePackages = yield* Effect.forEach(dirs, (dir) => readWorkspacePackage(fs, path, root, dir), {
+					concurrency: 10,
+				});
 
 				// Filter out any workspace package that resolves to root (avoids
 				// duplication when patterns include ".")
-				const nonRootPackages = workspacePackages.filter((p) => p.relativePath !== "." && p.path !== resolvedRoot);
+				const nonRootPackages = workspacePackages.filter((p) => p.relativePath !== "." && p.path !== root);
 
 				// Read root package.json and prepend as first entry
-				const rootPkgJsonPath = path.join(resolvedRoot, "package.json");
+				const rootPkgJsonPath = path.join(root, "package.json");
 				const rootContent = yield* fs.readFileString(rootPkgJsonPath).pipe(
 					Effect.mapError(
 						() =>
 							new WorkspaceDiscoveryError({
-								root: resolvedRoot,
+								root,
 								reason: `failed to read root ${rootPkgJsonPath}`,
 							}),
 					),
@@ -383,7 +394,7 @@ export const WorkspaceDiscoveryLive: Layer.Layer<
 					try: () => JSON.parse(rootContent) as Record<string, unknown>,
 					catch: () =>
 						new WorkspaceDiscoveryError({
-							root: resolvedRoot,
+							root,
 							reason: `invalid JSON in root ${rootPkgJsonPath}`,
 						}),
 				});
@@ -391,7 +402,7 @@ export const WorkspaceDiscoveryLive: Layer.Layer<
 					Effect.mapError(
 						() =>
 							new WorkspaceDiscoveryError({
-								root: resolvedRoot,
+								root,
 								reason: `failed to parse root ${rootPkgJsonPath}`,
 							}),
 					),
@@ -400,7 +411,7 @@ export const WorkspaceDiscoveryLive: Layer.Layer<
 				if (!rootDecoded.name) {
 					return yield* Effect.fail(
 						new WorkspaceDiscoveryError({
-							root: resolvedRoot,
+							root,
 							reason: `root package.json at ${rootPkgJsonPath} has no name field`,
 						}),
 					);
@@ -408,7 +419,7 @@ export const WorkspaceDiscoveryLive: Layer.Layer<
 				if (!rootDecoded.version) {
 					return yield* Effect.fail(
 						new WorkspaceDiscoveryError({
-							root: resolvedRoot,
+							root,
 							reason: `root package.json at ${rootPkgJsonPath} has no version field`,
 						}),
 					);
@@ -417,7 +428,7 @@ export const WorkspaceDiscoveryLive: Layer.Layer<
 				const rootPkg = new WorkspacePackage({
 					name: rootDecoded.name,
 					version: rootDecoded.version,
-					path: resolvedRoot,
+					path: root,
 					packageJsonPath: rootPkgJsonPath,
 					relativePath: ".",
 					private: rootDecoded.private ?? false,
@@ -430,25 +441,34 @@ export const WorkspaceDiscoveryLive: Layer.Layer<
 
 				const packages = [rootPkg, ...nonRootPackages];
 
-				cachedPackages = packages;
+				cache.set(root, packages);
 				yield* Effect.logInfo("Workspace packages discovered").pipe(
-					Effect.annotateLogs("workspace.packages.count", packages.length),
+					Effect.annotateLogs({
+						"workspace.root": root,
+						"workspace.packages.count": packages.length,
+					}),
 				);
 				return packages;
+			});
+
+		const discoverPackages = (cwd?: string): Effect.Effect<ReadonlyArray<WorkspacePackage>, WorkspaceDiscoveryError> =>
+			Effect.gen(function* () {
+				const root = yield* resolveRoot(cwd);
+				return yield* discoverAtRoot(root);
 			}).pipe(Effect.withSpan("WorkspaceDiscovery.listPackages"));
 
 		return {
 			listPackages: discoverPackages,
 
-			importerMap: () =>
+			importerMap: (cwd?: string) =>
 				Effect.gen(function* () {
-					const packages = yield* discoverPackages();
+					const packages = yield* discoverPackages(cwd);
 					return new Map(packages.map((p) => [p.relativePath, p])) as ReadonlyMap<string, WorkspacePackage>;
 				}).pipe(Effect.withSpan("WorkspaceDiscovery.importerMap")),
 
-			getPackage: (name: string) =>
+			getPackage: (name: string, cwd?: string) =>
 				Effect.gen(function* () {
-					const packages = yield* discoverPackages();
+					const packages = yield* discoverPackages(cwd);
 					const found = packages.find((p) => p.name === name);
 					if (found) {
 						yield* Effect.logDebug("Package resolved").pipe(Effect.annotateLogs("workspace.package", name));

--- a/src/services/WorkspaceDiscovery.ts
+++ b/src/services/WorkspaceDiscovery.ts
@@ -65,22 +65,28 @@ export class WorkspaceDiscovery extends Context.Tag("@spencerbeggs/workspaces-ef
 		 *
 		 * Resolves workspace glob patterns and reads each matched `package.json`.
 		 *
+		 * @param cwd - Optional starting directory. When provided, the workspace
+		 *   root is resolved fresh from `cwd` for this call (results cached per
+		 *   resolved root). When omitted, uses the root that was eagerly resolved
+		 *   from `process.cwd()` at layer construction time.
 		 * @returns An Effect that succeeds with a readonly array of
 		 *   {@link WorkspacePackage} records, or fails with
 		 *   {@link WorkspaceDiscoveryError} if workspace patterns cannot be resolved.
 		 */
-		readonly listPackages: () => Effect.Effect<ReadonlyArray<WorkspacePackage>, WorkspaceDiscoveryError>;
+		readonly listPackages: (cwd?: string) => Effect.Effect<ReadonlyArray<WorkspacePackage>, WorkspaceDiscoveryError>;
 
 		/**
 		 * Get a specific workspace package by name.
 		 *
 		 * @param name - The package name as declared in its `package.json` `name` field.
+		 * @param cwd - Optional starting directory. See {@link listPackages} for behavior.
 		 * @returns An Effect that succeeds with the matching {@link WorkspacePackage},
 		 *   or fails with {@link PackageNotFoundError} if no workspace package has that
 		 *   name, or {@link WorkspaceDiscoveryError} if discovery itself fails.
 		 */
 		readonly getPackage: (
 			name: string,
+			cwd?: string,
 		) => Effect.Effect<WorkspacePackage, PackageNotFoundError | WorkspaceDiscoveryError>;
 
 		/**
@@ -89,8 +95,11 @@ export class WorkspaceDiscovery extends Context.Tag("@spencerbeggs/workspaces-ef
 		 * Useful for mapping lockfile importer keys to their workspace packages.
 		 * Built from `listPackages()` output and inherits its caching.
 		 *
+		 * @param cwd - Optional starting directory. See {@link listPackages} for behavior.
 		 * @returns An Effect that succeeds with a ReadonlyMap keyed by relativePath.
 		 */
-		readonly importerMap: () => Effect.Effect<ReadonlyMap<string, WorkspacePackage>, WorkspaceDiscoveryError>;
+		readonly importerMap: (
+			cwd?: string,
+		) => Effect.Effect<ReadonlyMap<string, WorkspacePackage>, WorkspaceDiscoveryError>;
 	}
 >() {}

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -8,7 +8,8 @@
  */
 
 import { existsSync, readFileSync, readdirSync } from "node:fs";
-import { dirname, join, resolve } from "node:path";
+import { dirname, join, relative, resolve } from "node:path";
+import { PublishConfig, WorkspacePackage } from "./schemas/core.js";
 
 /**
  * Find the workspace root by walking up from `cwd`.
@@ -55,22 +56,6 @@ export const findWorkspaceRootSync = (cwd?: string): string | null => {
 			return null;
 		}
 		current = parent;
-	}
-};
-
-/**
- * Read the root package.json name field.
- *
- * @internal
- */
-const readRootPackageName = (root: string): string | undefined => {
-	try {
-		const content = readFileSync(join(root, "package.json"), "utf-8");
-		const parsed = JSON.parse(content) as Record<string, unknown>;
-		const name = parsed.name;
-		return typeof name === "string" && name.length > 0 ? name : undefined;
-	} catch {
-		return undefined;
 	}
 };
 
@@ -182,33 +167,94 @@ const resolvePattern = (root: string, pattern: string): string[] => {
 	return [];
 };
 
+const isStringRecord = (v: unknown): v is Record<string, string> =>
+	v !== null && typeof v === "object" && !Array.isArray(v);
+
+const buildPublishConfig = (raw: unknown): PublishConfig | undefined => {
+	if (raw === null || typeof raw !== "object") return undefined;
+	const r = raw as Record<string, unknown>;
+	const access = r.access === "public" || r.access === "restricted" ? r.access : undefined;
+	const registry = typeof r.registry === "string" ? r.registry : undefined;
+	const directory = typeof r.directory === "string" ? r.directory : undefined;
+	const tag = typeof r.tag === "string" ? r.tag : undefined;
+	const linkDirectory = typeof r.linkDirectory === "boolean" ? r.linkDirectory : undefined;
+	if (
+		access === undefined &&
+		registry === undefined &&
+		directory === undefined &&
+		tag === undefined &&
+		linkDirectory === undefined
+	) {
+		return undefined;
+	}
+	return new PublishConfig({ access, registry, directory, tag, linkDirectory });
+};
+
+/**
+ * Read a `package.json` and construct a {@link WorkspacePackage}, or return
+ * `null` if the file is missing/unreadable, has no name, or has no version.
+ *
+ * @internal
+ */
+const readWorkspacePackageSync = (root: string, pkgDir: string): WorkspacePackage | null => {
+	const pkgJsonPath = join(pkgDir, "package.json");
+	let parsed: Record<string, unknown>;
+	try {
+		const content = readFileSync(pkgJsonPath, "utf-8");
+		parsed = JSON.parse(content) as Record<string, unknown>;
+	} catch {
+		return null;
+	}
+
+	const name = typeof parsed.name === "string" && parsed.name.length > 0 ? parsed.name : undefined;
+	const version = typeof parsed.version === "string" && parsed.version.length > 0 ? parsed.version : undefined;
+	if (!name || !version) return null;
+
+	const relativePath = pkgDir === root ? "." : relative(root, pkgDir);
+
+	return new WorkspacePackage({
+		name,
+		version,
+		path: pkgDir,
+		packageJsonPath: pkgJsonPath,
+		relativePath,
+		private: parsed.private === true,
+		dependencies: isStringRecord(parsed.dependencies) ? parsed.dependencies : {},
+		devDependencies: isStringRecord(parsed.devDependencies) ? parsed.devDependencies : {},
+		peerDependencies: isStringRecord(parsed.peerDependencies) ? parsed.peerDependencies : {},
+		optionalDependencies: isStringRecord(parsed.optionalDependencies) ? parsed.optionalDependencies : {},
+		publishConfig: buildPublishConfig(parsed.publishConfig),
+	});
+};
+
 /**
  * List workspace packages synchronously.
  *
  * Reads workspace patterns from `pnpm-workspace.yaml` or `package.json`,
- * resolves them to directories, and reads each `package.json` name.
- * Always includes the root package as the first entry, matching the
- * behavior of the Effect-based `listPackages()`.
+ * resolves them to directories, and parses each `package.json` into a
+ * {@link WorkspacePackage}. The root package is always the first entry,
+ * matching the behavior of the Effect-based `WorkspaceDiscovery.listPackages()`.
  *
  * @param root - Absolute path to the workspace root
  * @returns Array of workspace packages with root as first entry
- * @throws If the root directory does not exist
+ * @throws If the root directory does not exist, or if the root
+ *   `package.json` is missing required `name` or `version` fields
  *
  * @public
  */
-export const getWorkspacePackagesSync = (
-	root: string,
-): ReadonlyArray<{ readonly name: string; readonly path: string }> => {
+export const getWorkspacePackagesSync = (root: string): ReadonlyArray<WorkspacePackage> => {
 	if (!existsSync(root)) {
 		throw new Error(`Directory does not exist: ${root}`);
 	}
 
-	const rootName = readRootPackageName(root);
-	const rootPkg = rootName ? { name: rootName, path: root } : undefined;
+	const rootPkg = readWorkspacePackageSync(root, root);
+	if (rootPkg === null) {
+		throw new Error(`Root package.json at ${join(root, "package.json")} is missing required name or version`);
+	}
 
 	const patterns = readPatterns(root);
 	if (patterns.length === 0) {
-		return rootPkg ? [rootPkg] : [];
+		return [rootPkg];
 	}
 
 	const included = new Set<string>();
@@ -230,22 +276,10 @@ export const getWorkspacePackagesSync = (
 		.filter((dir) => resolve(dir) !== resolvedRoot)
 		.sort();
 
-	const packages: Array<{ name: string; path: string }> = [];
-	if (rootPkg) {
-		packages.push(rootPkg);
-	}
-
+	const packages: WorkspacePackage[] = [rootPkg];
 	for (const dir of nonRootDirs) {
-		try {
-			const content = readFileSync(join(dir, "package.json"), "utf-8");
-			const parsed = JSON.parse(content) as Record<string, unknown>;
-			const name = parsed.name;
-			if (typeof name === "string" && name.length > 0) {
-				packages.push({ name, path: dir });
-			}
-		} catch {
-			// Skip unreadable packages
-		}
+		const pkg = readWorkspacePackageSync(root, dir);
+		if (pkg !== null) packages.push(pkg);
 	}
 
 	return packages;


### PR DESCRIPTION
## Summary

Addresses items 1-3 of #38, surfaced by integrating workspaces-effect into [savvy-web/pnpm-config-dependency-action](https://github.com/savvy-web/pnpm-config-dependency-action).

- **Item 1 — `cwd` parameter on WorkspaceDiscovery.** `listPackages`, `importerMap`, and `getPackage` now accept an optional `cwd?: string`. When supplied, the workspace root is resolved fresh from that directory and results are cached per resolved root (`Map<string, ReadonlyArray<WorkspacePackage>>`). When omitted, the methods continue to use the eagerly-resolved root from layer construction. Eliminates the custom-`WorkspaceRoot`-layer ceremony for downstream consumers that just need to discover packages at a specific path.
- **Item 2 — Sync helper returns `WorkspacePackage` instances (breaking).** `getWorkspacePackagesSync` now returns `ReadonlyArray<WorkspacePackage>` instead of `ReadonlyArray<{ name; path }>`. The richer return shape lets non-Effect callers feed packages directly into services like `PublishabilityDetector` without re-reading manifests, and exposes `version`, `packageJsonPath`, `relativePath`, dependencies, `publishConfig`, and computed getters. Throws on missing root `name`/`version` to match Effect-native discovery semantics.
- **Item 3 — README documents custom publishability detectors.** New section showing the `Layer.succeed(PublishabilityDetector, customImpl)` extension pattern with an `OrgMirrorDetector` example. The mechanism worked already but had no documentation.

## Item 4 deferred

The dogfood consumer (`pnpm-config-dependency-action/src/services/publishability.ts`) explicitly calls out its silk-aware target expansion as *"the chunk that will lift cleanly to @savvy-web/silk-effects later"*. The `targets` field, registry-URL shorthand, and access inheritance live in silk semantics, not generic `workspaces-effect` ones — workspaces-effect's `PublishConfig` schema deliberately doesn't have `targets`. Recommend tracking item 4 separately if/when silk-effects gets extracted.

## Test plan

- [x] `pnpm vitest run` — 279 unit + 142 integration, all green (was 386 prior; +35 from new tests including 6 cwd-parameter integration tests and 6 sync-helper shape tests)
- [x] `pnpm exec tsc --noEmit` — clean
- [x] `pnpm exec biome check` — no errors on changed files
- [x] Changeset `.changeset/cwd-coupling.md` validates via `savvy-changesets`
- [ ] Wire the new APIs into `pnpm-config-dependency-action` to verify the consumer can drop `WorkspacePackageInfo` and the manual `relativePath` arithmetic

Closes part of #38 (items 1-3).

Signed-off-by: C. Spencer Beggs <spencer@beggs.codes>