### PR TITLE
fix: silence library logs by default

### DIFF
--- a/.changeset/bump-yaml-effect.md
+++ b/.changeset/bump-yaml-effect.md
@@ -1,0 +1,9 @@
+---
+"workspaces-effect": patch
+---
+
+## Dependencies
+
+| Dependency | Type | Action | From | To |
+| :--- | :--- | :--- | :--- | :--- |
+| yaml-effect | dependency | updated | ^0.4.0 | ^0.5.0 |

--- a/.changeset/silent-by-default-logging.md
+++ b/.changeset/silent-by-default-logging.md
@@ -1,0 +1,11 @@
+---
+"workspaces-effect": patch
+---
+
+## Refactoring
+
+- Internal observability events now emit at `Debug` level instead of `Info`. The library is silent under Effect's default logger; consumers who want to see workspace-root discovery, package-manager detection, lockfile reads, and change-detection events can opt in via `Logger.withMinimumLogLevel(LogLevel.Debug)` or by attaching a custom logger. Affects `WorkspaceRootLive`, `PackageManagerDetectorLive`, `LockfileReaderLive`, `WorkspaceDiscoveryLive`, and `ChangeDetectorLive`. Log annotations (`workspace.root`, `workspace.pm`, `workspace.packages.count`, etc.) are unchanged.
+
+## Documentation
+
+- New "Observability" section in the README documenting how to subscribe to internal events by lowering the log level or replacing the logger.

--- a/.claude/design/architecture.md
+++ b/.claude/design/architecture.md
@@ -5,8 +5,8 @@ category: architecture
 status: current
 completeness: 100
 created: 2026-03-12
-updated: 2026-04-15
-last-synced: 2026-04-15
+updated: 2026-04-28
+last-synced: 2026-04-28
 related:
   - phase2-dependency-graph.md
   - phase3-change-detection.md
@@ -65,7 +65,12 @@ services.
 - **Internal patterns**: Request/RequestResolver with per-layer caching for
   DependencyGraph and LockfileReader lookups
 - **Observability**: Effect.withSpan on all service methods and layer
-  construction; structured logging at Info/Debug/Trace levels
+  construction; structured logging at Debug/Trace levels only -- the library
+  is silent under Effect's default logger. Consumers opt in via
+  `Logger.withMinimumLogLevel(LogLevel.Debug)` (or lower) or by attaching a
+  custom logger. Log annotations (`workspace.root`, `workspace.pm`,
+  `workspace.packages.count`, etc.) are unchanged. See the README
+  "Observability" section for subscription examples.
 - **Test organization**: Tests in top-level `__test__/` directory (not
   co-located in `src/`), following the `@savvy-web/vitest` discovery
   convention. Shared test utilities in `__test__/utils/`. Integration tests

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,10 @@ tooling. Supports npm, pnpm, yarn Berry, and Bun workspaces.
 
 All phases complete plus WorkspacePackage enrichment (Issue #12). 386 tests
 passing (250 unit + 136 integration). Full observability (spans + structured
-logging) across all services. Request/RequestResolver with per-layer caching
+logging at Debug level) across all services -- library is silent under
+Effect's default logger; consumers opt in via
+`Logger.withMinimumLogLevel(LogLevel.Debug)`. See README "Observability"
+section. Request/RequestResolver with per-layer caching
 for DependencyGraph and LockfileReader lookups. Integrity check works for all
 4 package managers. Composite layers: WorkspacesLive (no git),
 WorkspacesFullLive (with git). WorkspacePackage has peerDependencies,
@@ -55,6 +58,7 @@ Load these when working on the corresponding area:
 - `Data.TaggedError` with exported Base constants
 - CommandExecutor resolved at layer construction for R=never methods
 - Eager data construction in `Layer.effect`
+- Internal service events use `Effect.logDebug` (not `logInfo`); library stays silent under the default logger
 - Request/RequestResolver with per-layer `Request.makeCache` for deduplication
 - `Schema.transformOrFail` + `Schema.compose` for parsing pipelines
 - PublishConfig is a `Schema.Class` (not Schema.Struct); no PublishConfigSchema alias

--- a/README.md
+++ b/README.md
@@ -173,14 +173,18 @@ To route events somewhere other than the console (a collector,
 OpenTelemetry, a test sink, etc.), replace or add a logger:
 
 ```typescript
-import { Logger } from "effect";
+import { Effect, Logger } from "effect";
 
-const collectingLogger = Logger.make(({ message, annotations }) => {
-  // ship to your destination of choice
+const collectingLogger = Logger.make(({ logLevel, message, annotations }) => {
+  // ship to your destination of choice; logLevel is usually what you route on
 });
 
-program.pipe(
-  Effect.provide(Logger.replace(Logger.defaultLogger, collectingLogger)),
+Effect.runPromise(
+  program.pipe(
+    Effect.provide(WorkspacesLive),
+    Effect.provide(NodeContext.layer),
+    Effect.provide(Logger.replace(Logger.defaultLogger, collectingLogger)),
+  ),
 );
 ```
 

--- a/README.md
+++ b/README.md
@@ -147,6 +147,47 @@ The same pattern applies to any other service in the library -- `WorkspaceRoot`,
 `PackageManagerDetector`, `LockfileReader`, etc. all expose `Context.Tag`s
 that consumers can rebind.
 
+## Observability
+
+`workspaces-effect` is silent at the default log level. Internal
+events (workspace root discovery, package manager detection, lockfile
+reads, change detection, etc.) are emitted via Effect's structured
+logger at `Debug` level with annotations like `workspace.root`,
+`workspace.pm`, and `workspace.packages.count`.
+
+To see those events, lower the minimum log level:
+
+```typescript
+import { Effect, Logger, LogLevel } from "effect";
+
+Effect.runPromise(
+  program.pipe(
+    Effect.provide(WorkspacesLive),
+    Effect.provide(NodeContext.layer),
+    Logger.withMinimumLogLevel(LogLevel.Debug),
+  ),
+);
+```
+
+To route events somewhere other than the console (a collector,
+OpenTelemetry, a test sink, etc.), replace or add a logger:
+
+```typescript
+import { Logger } from "effect";
+
+const collectingLogger = Logger.make(({ message, annotations }) => {
+  // ship to your destination of choice
+});
+
+program.pipe(
+  Effect.provide(Logger.replace(Logger.defaultLogger, collectingLogger)),
+);
+```
+
+Errors are still raised through the typed error channel
+(`WorkspaceRootNotFoundError`, `LockfileReadError`, etc.) -- the
+logger only carries informational events.
+
 ## Documentation
 
 For architecture details, API reference, and advanced usage, see

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
 		"jsonc-effect": "^0.2.1",
 		"minimatch": ">=10.2.3",
 		"semver-effect": "^0.2.1",
-		"yaml-effect": "^0.4.0"
+		"yaml-effect": "^0.5.0"
 	},
 	"devDependencies": {
 		"@effect/platform": "catalog:silk",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,8 +41,8 @@ importers:
         specifier: ^0.2.1
         version: 0.2.1(effect@3.21.2)
       yaml-effect:
-        specifier: ^0.4.0
-        version: 0.4.0(effect@3.21.2)
+        specifier: ^0.5.0
+        version: 0.5.0(effect@3.21.2)
     devDependencies:
       '@effect/platform':
         specifier: catalog:silk
@@ -914,18 +914,8 @@ packages:
   '@rolldown/pluginutils@1.0.0-rc.17':
     resolution: {integrity: sha512-n8iosDOt6Ig1UhJ2AYqoIhHWh/isz0xpicHTzpKBeotdVsTEcxsSA/i3EVM7gQAj0rU27OLAxCjzlj15IWY7bg==}
 
-  '@rsbuild/core@2.0.1':
-    resolution: {integrity: sha512-5TwUpb10Y+VYaYH8oLL/rfJGrhxrk16BiGzv101kzaMPT60MtOXgjEUTxztbjRuq0ifbtRJ/w7rsIZQ4VziWYg==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    hasBin: true
-    peerDependencies:
-      core-js: '>= 3.0.0'
-    peerDependenciesMeta:
-      core-js:
-        optional: true
-
-  '@rsbuild/core@2.0.2':
-    resolution: {integrity: sha512-0Vo1W0ZekQ6jTIaSqiG/dgMrYXcKP/eUDNad87NhxfMfu/S5xZT8fk0AEMMk49IyvIIE56uw2Ua6rw8mnZtM+Q==}
+  '@rsbuild/core@2.0.3':
+    resolution: {integrity: sha512-2myp7jUgGen50saxW8OJD/eMVKp7HnuBN5MUzwRb6mDbRZZVpoorfI4LQqiGSBNjGLB6jltvx/R2yHmcmnchwg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
@@ -947,64 +937,64 @@ packages:
       typescript:
         optional: true
 
-  '@rspack/binding-darwin-arm64@2.0.0':
-    resolution: {integrity: sha512-ICBHDKYyndFqljLhjxvKfWWZu39RJSH2jkSmbceXl0kmptLSE0cLWpvk+eGSzLqtxKN0jVchwCw+5P5mWCzwAw==}
+  '@rspack/binding-darwin-arm64@2.0.1':
+    resolution: {integrity: sha512-CGFO5zmajD1Itch1lxAI7+gvKiagzyqXopHv/jHG9Su2WWQ2/Nhn2/rkSpdp6ptE9ri6+6tCOOahf099/v/Xog==}
     cpu: [arm64]
     os: [darwin]
 
-  '@rspack/binding-darwin-x64@2.0.0':
-    resolution: {integrity: sha512-YQ96LMmzIzhZt9cZWUDWXSxS9UWWHWoLxJyZ5f42DSaVPVelBg5ThbVORDwOP5QDA2xFXj60rVnmmcZLzg/aDA==}
+  '@rspack/binding-darwin-x64@2.0.1':
+    resolution: {integrity: sha512-2vvBNBoS09/PurupBwSrlTZd8283o00B8v20ncsNUdEff41uCR/hzIrYoTIVWnVST+Gt5O1+cfcfORp397lajg==}
     cpu: [x64]
     os: [darwin]
 
-  '@rspack/binding-linux-arm64-gnu@2.0.0':
-    resolution: {integrity: sha512-Ufn33gzkIV7JY69k6vJQEdOzRvBqThIgH46pwXksHSMwRZp8IbJhXfyYIAVsRWCk8fXpr9t1nAvCDvJXT2EeyA==}
+  '@rspack/binding-linux-arm64-gnu@2.0.1':
+    resolution: {integrity: sha512-uvNXk6ahE3AH3h2avnd1Mgno68YQpS4cfX1OkOGWIC/roL+NrOP2XVXV4yfVAoydPALDO7AfbIfN0QdmBK3rsA==}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@rspack/binding-linux-arm64-musl@2.0.0':
-    resolution: {integrity: sha512-CZbvFKlNY9UC0C+Czz6i8JFCzGpuL9oX8gEqcJA1+84Y6eEEBH50UiTzeCewxKW3dOofkZdvT5vgNMXz6aMUmg==}
+  '@rspack/binding-linux-arm64-musl@2.0.1':
+    resolution: {integrity: sha512-S/a6uN9PiZ5O/PjSqyIXhuRC1lVzeJkJV69NeLk5sIEUiDQ/aQGZG97uN+tluwpbo1tPbLJkdHYETfjspOX4Pg==}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@rspack/binding-linux-x64-gnu@2.0.0':
-    resolution: {integrity: sha512-dPjFGpoCvZfFpJBsWAUR+PR7mWYxpou6L026qIOpAVkz7WiTzErwKD3P1jVrpP4dM9yLb3fVE+PHHjTglhTJ4g==}
+  '@rspack/binding-linux-x64-gnu@2.0.1':
+    resolution: {integrity: sha512-C13Kk0OkZiocZVj187Sf753UH6pDXnuEu6vzUvi3qv9ltibG1ki0H2Y8isXBYL2cHQOV+hk0g1S6/4z3TTB97A==}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@rspack/binding-linux-x64-musl@2.0.0':
-    resolution: {integrity: sha512-4fgDTMWt0mJDiugdia2mdOjTbnm7yM1Drzl1JpPqlUlOr113byOhc+qgN57LURSGypz2yz/h/Zad7/UnVAxYJw==}
+  '@rspack/binding-linux-x64-musl@2.0.1':
+    resolution: {integrity: sha512-TQsiBFpEDGkuvK9tNdGj/Uc+AIytzqhxXH/1jKU6M24cWB1DTw/Cx7DdrkCBDyq3129K3POLdujvbWCGqBzQUw==}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@rspack/binding-wasm32-wasi@2.0.0':
-    resolution: {integrity: sha512-ANk73ZKtPrZf9gdtyRK2nQUfhi1uXoC5P2KF89pyVAE8+zcoLBnYtZGYpWa/cmNi5BcO5g4Z+v2l1UA3bUPLQQ==}
+  '@rspack/binding-wasm32-wasi@2.0.1':
+    resolution: {integrity: sha512-wk3gyUgBW/ayP49bI54bkY8+EQnfBHxdoe9dz3oobSTZQc8AOWwmUUDEPltW8rUvPOM6dfHECTOUMnfaf2f5yA==}
     cpu: [wasm32]
 
-  '@rspack/binding-win32-arm64-msvc@2.0.0':
-    resolution: {integrity: sha512-IHZFRtJ85ONbM+BCtF4TeYXS2Fu9X0IJS2phX1rPibYq9iEtHGfBt4cNlnsJPhbPAXVvi4Oli/yiLRJ1zxtCIg==}
+  '@rspack/binding-win32-arm64-msvc@2.0.1':
+    resolution: {integrity: sha512-rHjLcy3VcAC3+x+PxH+gwhwv6tPe0JdXTNT5eAOs9wgZIM6T9p4wre49+K4Qy98+Fb7TTbLX0ObUitlOkGwTSA==}
     cpu: [arm64]
     os: [win32]
 
-  '@rspack/binding-win32-ia32-msvc@2.0.0':
-    resolution: {integrity: sha512-n4tbIqacq/FhNJflMlgZV50AeQFTLh5hnDS3v4W+rJWa3IW1VfgB0+XppdeW+Dqhw7QcMIsCmro01kwNdlXZDQ==}
+  '@rspack/binding-win32-ia32-msvc@2.0.1':
+    resolution: {integrity: sha512-Ad1vVqMBBnd4T8rsORngu9sl2kyRTlS4kMlvFudjzl1X2UFArEDBe0YVGNN7ZvahM12CErUx2WiN8Sd8pb+qXQ==}
     cpu: [ia32]
     os: [win32]
 
-  '@rspack/binding-win32-x64-msvc@2.0.0':
-    resolution: {integrity: sha512-cJOgikIW2t3S+42TQZsv+DJriJt2m6lnUk+pUFu/fO93rrMvNrx8gfMxR8W5zDTreBX0cfMx2pw6EVmyi/YzsQ==}
+  '@rspack/binding-win32-x64-msvc@2.0.1':
+    resolution: {integrity: sha512-oPM2Jtm7HOlmxl/aBfleAVlL6t9VeHx6WvEets7BBJMInemFXAQd4CErRqybf7rXutACzLeUWBOue4Jpd1/ykw==}
     cpu: [x64]
     os: [win32]
 
-  '@rspack/binding@2.0.0':
-    resolution: {integrity: sha512-WA2f9eQpejkvf5Vrnf6wNCn1m8RT1p08NjgOZpKhsCzr0uBjWeRvGduawlrFFHZh/jPnWZTVaVdQ08FEAWbwGw==}
+  '@rspack/binding@2.0.1':
+    resolution: {integrity: sha512-ynV1gw4KqFtQ0P+ZZh76SUj49wBb2FuHW3zSmHverHWuxBhzvrZS6/dZ+fCFQG8bTTPtrPz0RQUTN3uEDbPVBQ==}
 
-  '@rspack/core@2.0.0':
-    resolution: {integrity: sha512-WD1mJM9LbZ7Z399Rbv9dE3BNEV0+3sE5OzDdzV8hOxUb3mX++ynK5n9kil8w60B6nGdcKeV9ly5aN4PgqiwWUg==}
+  '@rspack/core@2.0.1':
+    resolution: {integrity: sha512-lgfZiExh8kDR/3obgi3RQKwKG5av1Xf5qDN1aVde777W9pbmx0Pqvrww1qtNvJ+gobEjbrrn5HEZWYGe0VLmcA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     peerDependencies:
       '@module-federation/runtime-tools': ^0.24.1 || ^2.0.0
@@ -1145,8 +1135,8 @@ packages:
   '@swc/helpers@0.5.21':
     resolution: {integrity: sha512-jI/VAmtdjB/RnI8GTnokyX7Ug8c+g+ffD6QRLa6XQewtnGyukKkKSk3wLTM3b5cjt1jNh9x0jfVlagdN2gDKQg==}
 
-  '@trpc/server@11.16.0':
-    resolution: {integrity: sha512-XgGuUMddrUTd04+za/WE5GFuZ1/YU9XQG0t3VL5WOIu2JspkOlq6k4RYEiqS6HSJt+S0RXaPdIoE2anIP/BBRQ==}
+  '@trpc/server@11.17.0':
+    resolution: {integrity: sha512-jbAOUe0PpUTCYqziyu+8vYXZdDXPudZgnEhWCQ2NjKnVEjfE93RqHTt1oycZJv/HNf51YlRXfEEwSIAbb161rw==}
     hasBin: true
     peerDependencies:
       typescript: ^6.0.3
@@ -1265,12 +1255,6 @@ packages:
     peerDependencies:
       typescript: ^6.0.3
 
-  '@typescript-eslint/tsconfig-utils@8.59.0':
-    resolution: {integrity: sha512-91Sbl3s4Kb3SybliIY6muFBmHVv+pYXfybC4Oolp3dvk8BvIE3wOPc+403CWIT7mJNkfQRGtdqghzs2+Z91Tqg==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      typescript: ^6.0.3
-
   '@typescript-eslint/tsconfig-utils@8.59.1':
     resolution: {integrity: sha512-/0nEyPbX7gRsk0Uwfe4ALwwgxuA66d/l2mhRDNlAvaj4U3juhUtJNq0DsY8M2AYwwb9rEq2hrC3IcIcEt++iJA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -1279,10 +1263,6 @@ packages:
 
   '@typescript-eslint/types@8.56.1':
     resolution: {integrity: sha512-dbMkdIUkIkchgGDIv7KLUpa0Mda4IYjo4IAMJUZ+3xNoUXxMsk9YtKpTHSChRS85o+H9ftm51gsK1dZReY9CVw==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
-  '@typescript-eslint/types@8.59.0':
-    resolution: {integrity: sha512-nLzdsT1gdOgFxxxwrlNVUBzSNBEEHJ86bblmk4QAS6stfig7rcJzWKqCyxFy3YRRHXDWEkb2NralA1nOYkkm/A==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@typescript-eslint/types@8.59.1':
@@ -1551,8 +1531,8 @@ packages:
     resolution: {integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==}
     engines: {node: '>=18'}
 
-  bole@5.0.28:
-    resolution: {integrity: sha512-l+yybyZLV7zTD6EuGxoXsilpER1ctMCpdOqjSYNigJJma39ha85fzCtYccPx06oR1u7uCQLOcUAFFzvfXVBmuQ==}
+  bole@5.0.29:
+    resolution: {integrity: sha512-eYR9i2ubLv5/4TFGyZsQ1cVH4jF9+qLJA72Aow+E7ZZQfqHqQNUZeX3w+pVWF76PQyjl5eDKf2xylyOOX76ozA==}
 
   brace-expansion@5.0.5:
     resolution: {integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==}
@@ -2540,8 +2520,8 @@ packages:
   jju@1.4.0:
     resolution: {integrity: sha512-8wb9Yw966OSxApiCt0K3yNJL8pnNeIv+OEq2YMidz4FKP6nonSRoOXc80iXY4JaN2FC11B9qsNmDsm+ZOfMROA==}
 
-  jose@6.2.2:
-    resolution: {integrity: sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==}
+  jose@6.2.3:
+    resolution: {integrity: sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==}
 
   js-tokens@10.0.0:
     resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
@@ -3567,8 +3547,8 @@ packages:
     resolution: {integrity: sha512-Kxl3KJGb/gxkaUMOjRsQ8IrXiGW75O4E3RPjFIINOVH8AMl2SQ/yWdTzWwF3FevIX9LcMAjJW+GRwAlAbTSXdg==}
     engines: {node: '>=20'}
 
-  string-width@8.2.0:
-    resolution: {integrity: sha512-6hJPQ8N0V0P3SNmP6h2J99RLuzrWz2gvT7VnK5tKvrNqJoyS9W4/Fb8mo31UiPvy00z7DQXkP2hnKBVav76thw==}
+  string-width@8.2.1:
+    resolution: {integrity: sha512-IIaP0g3iy9Cyy18w3M9YcaDudujEAVHKt3a3QJg1+sr/oX96TbaGUubG0hJyCjCBThFH+tFpcIyoUHUn1ogaLA==}
     engines: {node: '>=20'}
 
   string_decoder@1.3.0:
@@ -3974,8 +3954,8 @@ packages:
     peerDependencies:
       effect: '>=3.21.0'
 
-  yaml-effect@0.4.0:
-    resolution: {integrity: sha512-WHco6UeMCFnnKv+Zw442uUgUbJOtIjP2AYRG8JIcFLHaF0lHE35qF0brTOD4fKxhi0QSXi5jywR2lF33CKOytw==}
+  yaml-effect@0.5.0:
+    resolution: {integrity: sha512-gDqPqryW0BeP5OMfCUZdIAbKGxC4iRJuRRHxEbkHByZRGBCxf0IVgkDEAnwjyRSsIybpK8N3pZodePWmRvNq5g==}
     peerDependencies:
       effect: '>=3.21.0'
 
@@ -4611,7 +4591,7 @@ snapshots:
       express: 5.2.1
       express-rate-limit: 8.4.1(express@5.2.1)
       hono: 4.12.15
-      jose: 6.2.2
+      jose: 6.2.3
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
       raw-body: 3.0.2
@@ -4851,7 +4831,7 @@ snapshots:
 
   '@pnpm/logger@1001.0.1':
     dependencies:
-      bole: 5.0.28
+      bole: 5.0.29
       split2: 4.2.0
 
   '@pnpm/manifest-utils@1002.0.5(@pnpm/logger@1001.0.1)':
@@ -4983,24 +4963,17 @@ snapshots:
 
   '@rolldown/pluginutils@1.0.0-rc.17': {}
 
-  '@rsbuild/core@2.0.1':
+  '@rsbuild/core@2.0.3':
     dependencies:
-      '@rspack/core': 2.0.0(@swc/helpers@0.5.21)
-      '@swc/helpers': 0.5.21
-    transitivePeerDependencies:
-      - '@module-federation/runtime-tools'
-
-  '@rsbuild/core@2.0.2':
-    dependencies:
-      '@rspack/core': 2.0.0(@swc/helpers@0.5.21)
+      '@rspack/core': 2.0.1(@swc/helpers@0.5.21)
       '@swc/helpers': 0.5.21
     transitivePeerDependencies:
       - '@module-federation/runtime-tools'
 
   '@rslib/core@0.21.3(@microsoft/api-extractor@7.58.7(@types/node@25.6.0))(@typescript/native-preview@7.0.0-dev.20260426.1)(typescript@6.0.3)':
     dependencies:
-      '@rsbuild/core': 2.0.1
-      rsbuild-plugin-dts: 0.21.3(@microsoft/api-extractor@7.58.7(@types/node@25.6.0))(@rsbuild/core@2.0.1)(@typescript/native-preview@7.0.0-dev.20260426.1)(typescript@6.0.3)
+      '@rsbuild/core': 2.0.3
+      rsbuild-plugin-dts: 0.21.3(@microsoft/api-extractor@7.58.7(@types/node@25.6.0))(@rsbuild/core@2.0.3)(@typescript/native-preview@7.0.0-dev.20260426.1)(typescript@6.0.3)
     optionalDependencies:
       '@microsoft/api-extractor': 7.58.7(@types/node@25.6.0)
       typescript: 6.0.3
@@ -5009,56 +4982,56 @@ snapshots:
       - '@typescript/native-preview'
       - core-js
 
-  '@rspack/binding-darwin-arm64@2.0.0':
+  '@rspack/binding-darwin-arm64@2.0.1':
     optional: true
 
-  '@rspack/binding-darwin-x64@2.0.0':
+  '@rspack/binding-darwin-x64@2.0.1':
     optional: true
 
-  '@rspack/binding-linux-arm64-gnu@2.0.0':
+  '@rspack/binding-linux-arm64-gnu@2.0.1':
     optional: true
 
-  '@rspack/binding-linux-arm64-musl@2.0.0':
+  '@rspack/binding-linux-arm64-musl@2.0.1':
     optional: true
 
-  '@rspack/binding-linux-x64-gnu@2.0.0':
+  '@rspack/binding-linux-x64-gnu@2.0.1':
     optional: true
 
-  '@rspack/binding-linux-x64-musl@2.0.0':
+  '@rspack/binding-linux-x64-musl@2.0.1':
     optional: true
 
-  '@rspack/binding-wasm32-wasi@2.0.0':
+  '@rspack/binding-wasm32-wasi@2.0.1':
     dependencies:
       '@emnapi/core': 1.10.0
       '@emnapi/runtime': 1.10.0
       '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
     optional: true
 
-  '@rspack/binding-win32-arm64-msvc@2.0.0':
+  '@rspack/binding-win32-arm64-msvc@2.0.1':
     optional: true
 
-  '@rspack/binding-win32-ia32-msvc@2.0.0':
+  '@rspack/binding-win32-ia32-msvc@2.0.1':
     optional: true
 
-  '@rspack/binding-win32-x64-msvc@2.0.0':
+  '@rspack/binding-win32-x64-msvc@2.0.1':
     optional: true
 
-  '@rspack/binding@2.0.0':
+  '@rspack/binding@2.0.1':
     optionalDependencies:
-      '@rspack/binding-darwin-arm64': 2.0.0
-      '@rspack/binding-darwin-x64': 2.0.0
-      '@rspack/binding-linux-arm64-gnu': 2.0.0
-      '@rspack/binding-linux-arm64-musl': 2.0.0
-      '@rspack/binding-linux-x64-gnu': 2.0.0
-      '@rspack/binding-linux-x64-musl': 2.0.0
-      '@rspack/binding-wasm32-wasi': 2.0.0
-      '@rspack/binding-win32-arm64-msvc': 2.0.0
-      '@rspack/binding-win32-ia32-msvc': 2.0.0
-      '@rspack/binding-win32-x64-msvc': 2.0.0
+      '@rspack/binding-darwin-arm64': 2.0.1
+      '@rspack/binding-darwin-x64': 2.0.1
+      '@rspack/binding-linux-arm64-gnu': 2.0.1
+      '@rspack/binding-linux-arm64-musl': 2.0.1
+      '@rspack/binding-linux-x64-gnu': 2.0.1
+      '@rspack/binding-linux-x64-musl': 2.0.1
+      '@rspack/binding-wasm32-wasi': 2.0.1
+      '@rspack/binding-win32-arm64-msvc': 2.0.1
+      '@rspack/binding-win32-ia32-msvc': 2.0.1
+      '@rspack/binding-win32-x64-msvc': 2.0.1
 
-  '@rspack/core@2.0.0(@swc/helpers@0.5.21)':
+  '@rspack/core@2.0.1(@swc/helpers@0.5.21)':
     dependencies:
-      '@rspack/binding': 2.0.0
+      '@rspack/binding': 2.0.1
     optionalDependencies:
       '@swc/helpers': 0.5.21
 
@@ -5197,7 +5170,7 @@ snapshots:
       '@pnpm/exportable-manifest': 1000.4.2(@pnpm/logger@1001.0.1)
       '@pnpm/lockfile.fs': 1100.0.3(@pnpm/logger@1001.0.1)
       '@pnpm/workspace.read-manifest': 1000.3.1
-      '@rsbuild/core': 2.0.2
+      '@rsbuild/core': 2.0.3
       '@rslib/core': 0.21.3(@microsoft/api-extractor@7.58.7(@types/node@25.6.0))(@typescript/native-preview@7.0.0-dev.20260426.1)(typescript@6.0.3)
       '@types/node': 25.6.0
       '@typescript-eslint/parser': 8.59.1(eslint@10.2.1(jiti@2.6.1))(typescript@6.0.3)
@@ -5262,7 +5235,7 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  '@trpc/server@11.16.0(typescript@6.0.3)':
+  '@trpc/server@11.17.0(typescript@6.0.3)':
     dependencies:
       typescript: 6.0.3
 
@@ -5348,8 +5321,8 @@ snapshots:
 
   '@typescript-eslint/project-service@8.56.1(typescript@6.0.3)':
     dependencies:
-      '@typescript-eslint/tsconfig-utils': 8.59.0(typescript@6.0.3)
-      '@typescript-eslint/types': 8.59.0
+      '@typescript-eslint/tsconfig-utils': 8.56.1(typescript@6.0.3)
+      '@typescript-eslint/types': 8.56.1
       debug: 4.4.3
       typescript: 6.0.3
     transitivePeerDependencies:
@@ -5378,17 +5351,11 @@ snapshots:
     dependencies:
       typescript: 6.0.3
 
-  '@typescript-eslint/tsconfig-utils@8.59.0(typescript@6.0.3)':
-    dependencies:
-      typescript: 6.0.3
-
   '@typescript-eslint/tsconfig-utils@8.59.1(typescript@6.0.3)':
     dependencies:
       typescript: 6.0.3
 
   '@typescript-eslint/types@8.56.1': {}
-
-  '@typescript-eslint/types@8.59.0': {}
 
   '@typescript-eslint/types@8.59.1': {}
 
@@ -5679,7 +5646,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  bole@5.0.28:
+  bole@5.0.29:
     dependencies:
       fast-safe-stringify: 2.1.1
       individual: 3.0.0
@@ -5760,7 +5727,7 @@ snapshots:
   cli-truncate@5.2.0:
     dependencies:
       slice-ansi: 8.0.0
-      string-width: 8.2.0
+      string-width: 8.2.1
 
   cli-width@3.0.0: {}
 
@@ -6715,7 +6682,7 @@ snapshots:
 
   jju@1.4.0: {}
 
-  jose@6.2.2: {}
+  jose@6.2.3: {}
 
   js-tokens@10.0.0: {}
 
@@ -7733,10 +7700,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  rsbuild-plugin-dts@0.21.3(@microsoft/api-extractor@7.58.7(@types/node@25.6.0))(@rsbuild/core@2.0.1)(@typescript/native-preview@7.0.0-dev.20260426.1)(typescript@6.0.3):
+  rsbuild-plugin-dts@0.21.3(@microsoft/api-extractor@7.58.7(@types/node@25.6.0))(@rsbuild/core@2.0.3)(@typescript/native-preview@7.0.0-dev.20260426.1)(typescript@6.0.3):
     dependencies:
       '@ast-grep/napi': 0.37.0
-      '@rsbuild/core': 2.0.1
+      '@rsbuild/core': 2.0.3
     optionalDependencies:
       '@microsoft/api-extractor': 7.58.7(@types/node@25.6.0)
       '@typescript/native-preview': 7.0.0-dev.20260426.1
@@ -7946,7 +7913,7 @@ snapshots:
       get-east-asian-width: 1.5.0
       strip-ansi: 7.2.0
 
-  string-width@8.2.0:
+  string-width@8.2.1:
     dependencies:
       get-east-asian-width: 1.5.0
       strip-ansi: 7.2.0
@@ -8161,7 +8128,7 @@ snapshots:
       '@effect/sql': 0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2)
       '@effect/sql-sqlite-node': 0.52.0(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(effect@3.21.2)
       '@modelcontextprotocol/sdk': 1.29.0(zod@4.3.6)
-      '@trpc/server': 11.16.0(typescript@6.0.3)
+      '@trpc/server': 11.17.0(typescript@6.0.3)
       effect: 3.21.2
       std-env: 4.1.0
       vitest: 4.1.5(@types/node@25.6.0)(@vitest/coverage-v8@4.1.5)(vite@8.0.10(@types/node@25.6.0)(jiti@2.6.1)(yaml@2.8.3))
@@ -8331,7 +8298,7 @@ snapshots:
     dependencies:
       effect: 3.21.2
 
-  yaml-effect@0.4.0(effect@3.21.2):
+  yaml-effect@0.5.0(effect@3.21.2):
     dependencies:
       effect: 3.21.2
 

--- a/src/layers/ChangeDetectorLive.ts
+++ b/src/layers/ChangeDetectorLive.ts
@@ -136,7 +136,7 @@ export const ChangeDetectorLive = Layer.effect(
 					const committedFiles = yield* runGitLines(cwd, "diff", "--name-only", `${options.base}...${options.head}`);
 
 					if (!options.includeUncommitted) {
-						yield* Effect.logInfo("Changed files detected").pipe(
+						yield* Effect.logDebug("Changed files detected").pipe(
 							Effect.annotateLogs("workspace.files.count", committedFiles.length),
 						);
 						return committedFiles;
@@ -148,7 +148,7 @@ export const ChangeDetectorLive = Layer.effect(
 
 					const allFiles = new Set([...committedFiles, ...unstagedFiles, ...stagedFiles, ...untrackedFiles]);
 					const sorted = Array.from(allFiles).sort();
-					yield* Effect.logInfo("Changed files detected").pipe(
+					yield* Effect.logDebug("Changed files detected").pipe(
 						Effect.annotateLogs("workspace.files.count", sorted.length),
 					);
 					return sorted;
@@ -187,7 +187,7 @@ export const ChangeDetectorLive = Layer.effect(
 						}
 					}
 					const sorted = packages.sort((a, b) => a.name.localeCompare(b.name));
-					yield* Effect.logInfo("Changed packages detected").pipe(
+					yield* Effect.logDebug("Changed packages detected").pipe(
 						Effect.annotateLogs("workspace.packages.count", sorted.length),
 					);
 					return sorted;
@@ -241,7 +241,7 @@ export const ChangeDetectorLive = Layer.effect(
 						.map((name) => packageMap.get(name))
 						.filter((pkg): pkg is WorkspacePackage => pkg !== undefined)
 						.sort((a, b) => a.name.localeCompare(b.name));
-					yield* Effect.logInfo("Affected packages detected").pipe(
+					yield* Effect.logDebug("Affected packages detected").pipe(
 						Effect.annotateLogs("workspace.packages.count", result.length),
 					);
 					return result;

--- a/src/layers/LockfileReaderLive.ts
+++ b/src/layers/LockfileReaderLive.ts
@@ -209,7 +209,7 @@ export const LockfileReaderLive = Layer.effect(
 			packageIndex.set(pkg.name, existing);
 		}
 
-		yield* Effect.logInfo("Lockfile reader initialized").pipe(
+		yield* Effect.logDebug("Lockfile reader initialized").pipe(
 			Effect.annotateLogs({
 				"workspace.pm": pm,
 				"workspace.packages.count": lockfileData.packages.length,
@@ -248,7 +248,7 @@ export const LockfileReaderLive = Layer.effect(
 			checkIntegrity: () =>
 				Effect.gen(function* () {
 					const result = yield* checkLockfileIntegrity(lockfileData, root, fs, path);
-					yield* Effect.logInfo("Lockfile integrity check complete").pipe(
+					yield* Effect.logDebug("Lockfile integrity check complete").pipe(
 						Effect.annotateLogs({
 							"workspace.integrity.valid": result.valid,
 							"workspace.integrity.issues":

--- a/src/layers/PackageManagerDetectorLive.ts
+++ b/src/layers/PackageManagerDetectorLive.ts
@@ -95,7 +95,7 @@ const detectPackageManager = (
 				version: pmInfo?.name === "pnpm" ? pmInfo.version : undefined,
 				runtime: "node" as const,
 			};
-			yield* Effect.logInfo("Package manager detected").pipe(Effect.annotateLogs("workspace.pm", result.type));
+			yield* Effect.logDebug("Package manager detected").pipe(Effect.annotateLogs("workspace.pm", result.type));
 			return result;
 		}
 
@@ -108,7 +108,7 @@ const detectPackageManager = (
 				version: pmInfo.version,
 				runtime: "bun" as const,
 			};
-			yield* Effect.logInfo("Package manager detected").pipe(Effect.annotateLogs("workspace.pm", result.type));
+			yield* Effect.logDebug("Package manager detected").pipe(Effect.annotateLogs("workspace.pm", result.type));
 			return result;
 		}
 
@@ -120,7 +120,7 @@ const detectPackageManager = (
 				version: pmInfo.version,
 				runtime: "node" as const,
 			};
-			yield* Effect.logInfo("Package manager detected").pipe(Effect.annotateLogs("workspace.pm", result.type));
+			yield* Effect.logDebug("Package manager detected").pipe(Effect.annotateLogs("workspace.pm", result.type));
 			return result;
 		}
 
@@ -136,7 +136,7 @@ const detectPackageManager = (
 					version: pmInfo?.name === "npm" ? pmInfo.version : undefined,
 					runtime: "node" as const,
 				};
-				yield* Effect.logInfo("Package manager detected").pipe(Effect.annotateLogs("workspace.pm", result.type));
+				yield* Effect.logDebug("Package manager detected").pipe(Effect.annotateLogs("workspace.pm", result.type));
 				return result;
 			}
 		}

--- a/src/layers/WorkspaceDiscoveryLive.ts
+++ b/src/layers/WorkspaceDiscoveryLive.ts
@@ -442,7 +442,7 @@ export const WorkspaceDiscoveryLive: Layer.Layer<
 				const packages = [rootPkg, ...nonRootPackages];
 
 				cache.set(root, packages);
-				yield* Effect.logInfo("Workspace packages discovered").pipe(
+				yield* Effect.logDebug("Workspace packages discovered").pipe(
 					Effect.annotateLogs({
 						"workspace.root": root,
 						"workspace.packages.count": packages.length,

--- a/src/layers/WorkspaceRootLive.ts
+++ b/src/layers/WorkspaceRootLive.ts
@@ -83,7 +83,7 @@ const findWorkspaceRoot = (
 			const result = yield* checkForWorkspaceRoot(fs, path, current).pipe(Effect.option);
 
 			if (result._tag === "Some") {
-				yield* Effect.logInfo("Workspace root found").pipe(Effect.annotateLogs("workspace.root", result.value));
+				yield* Effect.logDebug("Workspace root found").pipe(Effect.annotateLogs("workspace.root", result.value));
 				return result.value;
 			}
 


### PR DESCRIPTION
## Summary

- Downgrades 12 internal `Effect.logInfo` sites in `WorkspaceRootLive`, `PackageManagerDetectorLive`, `LockfileReaderLive`, `WorkspaceDiscoveryLive`, and `ChangeDetectorLive` to `Effect.logDebug`. The library is now silent under Effect's default logger; consumers opt in via `Logger.withMinimumLogLevel(LogLevel.Debug)` or by attaching a custom logger. Annotations (`workspace.root`, `workspace.pm`, `workspace.packages.count`, etc.) are unchanged.
- Adds a README "Observability" section documenting the subscription patterns (lower the log level, replace/add a logger).
- Updates internal docs (`CLAUDE.md`, `.claude/design/architecture.md`) to record the convention shift.
- Bumps `yaml-effect` to `^0.5.0` (runtime dep).

## Why

Reported during downstream usage: `workspaces-effect` is a utility library, but it was emitting "Workspace root found" and similar messages on stdout because internal observability events were at Info level. The right model is "events users can subscribe to, not logs printed by default" — Effect's logger already provides this; the fix is to lower the level so consumers opt in.

## Changesets

- `.changeset/silent-by-default-logging.md` — patch, Refactoring + Documentation
- `.changeset/bump-yaml-effect.md` — patch, Dependencies

## Test plan

- [x] `pnpm run typecheck` — clean
- [x] `pnpm run test` — 279 unit + 142 integration, all green
- [x] `pnpm exec savvy-changesets validate-file` — both changesets valid
- [x] `pnpm exec markdownlint-cli2` — clean
- [ ] Verify default-logger output is empty when consumers run library code (observed via downstream consumer)
- [ ] Verify `Logger.withMinimumLogLevel(LogLevel.Debug)` surfaces the events as documented

Signed-off-by: C. Spencer Beggs <spencer@beggs.codes>