### PR TITLE
docs: daily routine improvements 2026-04-30

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,7 +82,7 @@ pnpm run test:watch
 pnpm run test:coverage
 
 # Run a specific test file
-pnpm vitest run src/layers/DependencyGraphLive.test.ts
+pnpm vitest run __test__/layers/DependencyGraphLive.test.ts
 ```
 
 ## TypeScript

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![npm version](https://img.shields.io/npm/v/workspaces-effect)](https://www.npmjs.com/package/workspaces-effect)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
-[![TypeScript](https://img.shields.io/badge/TypeScript-5.9-blue.svg)](https://www.typescriptlang.org/)
+[![TypeScript](https://img.shields.io/badge/TypeScript-6.0-blue.svg)](https://www.typescriptlang.org/)
 
 An [Effect](https://effect.website) library for monorepo workspace tooling. Discover workspaces, analyze dependency graphs, detect changes, parse lockfiles, and check publishability across npm, pnpm, yarn Berry and Bun through composable Effect services with typed errors and platform independence.
 


### PR DESCRIPTION
## Summary

Two small, high-confidence fixes to user-facing documentation:

- **`CONTRIBUTING.md`**: Fix stale test file path in the "Run a specific test file" example. The path `src/layers/DependencyGraphLive.test.ts` is wrong — tests have always lived in `__test__/layers/`, not co-located with source. Correct path: `__test__/layers/DependencyGraphLive.test.ts`.
- **`README.md`**: Update the TypeScript badge from `5.9` to `6.0`. The lockfile (`pnpm-lock.yaml`) shows `typescript@6.0.3` is installed; the badge was never updated when the project upgraded.

## Related issues

These are the user-doc counterparts to the design-doc issues filed separately:
- #49 (CLAUDE.md stale `pkgs/` references) covers the broader stale-path theme; this PR fixes the user-visible instance in CONTRIBUTING.md.

## Test plan

- [ ] Verify `__test__/layers/DependencyGraphLive.test.ts` exists (it does — confirmed in audit)
- [ ] Verify `typescript@6.0.3` in `pnpm-lock.yaml` (confirmed)
- [ ] No logic changes; markdown-only edits

Filed automatically by daily routine. Close if not wanted — no follow-up needed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pz59kyTHt2gouuyXt4opD6)_