### PR TITLE
docs: daily routine improvements 2026-05-02

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,7 +82,7 @@ pnpm run test:watch
 pnpm run test:coverage
 
 # Run a specific test file
-pnpm vitest run src/layers/DependencyGraphLive.test.ts
+pnpm vitest run __test__/layers/DependencyGraphLive.test.ts
 ```
 
 ## TypeScript

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -33,7 +33,7 @@ You choose the Effect and platform versions. workspaces-effect requires
 ## Prerequisites
 
 - A monorepo using npm, pnpm, yarn Berry, or Bun workspaces
-- Node.js 22+ or Bun 1.0+
+- Node.js 24+ or Bun 1.0+
 - Effect 3.x
 
 Workspace configuration is recommended but not required:


### PR DESCRIPTION
## Changes

- **`CONTRIBUTING.md`**: Fix stale example test path from `src/layers/DependencyGraphLive.test.ts` to `__test__/layers/DependencyGraphLive.test.ts`. Tests live in the top-level `__test__/` directory per project convention (not co-located in `src/`); the old path would send contributors to a file that does not exist.

- **`docs/guides/getting-started.md`**: Update Node.js prerequisite from "Node.js 22+" to "Node.js 24+". This matches `CONTRIBUTING.md` (which already says 24+) and the `devEngines.runtime` entry in `package.json` (`"version": "24.11.0"`).

## Track 1 note

Design-docs audit found 10 open issues already covering all detectable problems — all filed by runs on 2026-04-30 and 2026-05-01 (#47–#51, #54–#58). No new design-doc issues were filed today.

Filed automatically by daily Routine. Close if not wanted — no follow-up needed.

https://claude.ai/code/session_01RtpE8FsYwgeySLvSbJa9Ns

---
_Generated by [Claude Code](https://claude.ai/code/session_01RtpE8FsYwgeySLvSbJa9Ns)_