### PR TITLE
perf(layers): defer I/O in LockfileReaderLive and WorkspaceDiscoveryLive

### DIFF
--- a/.changeset/doc-debt-sweep.md
+++ b/.changeset/doc-debt-sweep.md
@@ -1,0 +1,28 @@
+---
+"workspaces-effect": patch
+---
+
+## Documentation
+
+Address eight stale design-doc audit issues (#47, #48, #49, #50, #51, #54,
+#55, #57). No code changes.
+
+- `architecture.md`: corrected error-type count from 11 to 12 (missing
+  `LockfileIntegrityError`); added the optional `cwd` parameter to the
+  documented `WorkspaceDiscovery` method signatures.
+- `CLAUDE.md`: removed two stale references to a non-existent `pkgs/`
+  directory and replaced the example test command with a single-package
+  equivalent; updated the code-review summary from "5/10 fixed" to
+  "6/10 fixed".
+- `code-review-findings.md`: replaced the open-ended "Should fix soon"
+  marker on Issue 3 (`/**` glob) with a reference to the new GitHub issue
+  #62 that tracks the fix.
+- `phase4-configuration-lockfiles.md`: replaced the stale, self-referential
+  composite layer example with the real `Layer.mergeAll` shape from
+  `src/layers/WorkspacesLive.ts`.
+- `phase3-change-detection.md`: corrected the false claim that
+  `ChangeDetectorLive` does not resolve `CommandExecutor`; the layer does
+  yield it inside `Layer.effect` so service methods have `R = never`.
+- `research-notes.md`: promoted from `draft`/60 % to `current`/100 % and
+  added a header marking the document as historical reference material that
+  informed the architecture rather than a prescriptive spec.

--- a/.changeset/lazy-layer-init.md
+++ b/.changeset/lazy-layer-init.md
@@ -1,0 +1,44 @@
+---
+"workspaces-effect": minor
+---
+
+## Performance
+
+### Defer I/O in `LockfileReaderLive` and `WorkspaceDiscoveryLive`
+
+Moves all filesystem I/O out of the `Layer.effect` constructors and into the
+service methods, memoized per layer instance via `Effect.cached`. Layer
+construction is now O(1); the workspace root walk, package-manager detection,
+lockfile read, and lockfile parse are paid on the first method call rather
+than every time a fresh layer is composed.
+
+Consumers that build a layer per call site — Vitest reporters with multiple
+projects, CLIs that compose layers per subcommand, tests that swap layers
+between cases — no longer pay the eager initialization cost N times.
+Downstream `vitest-agent-reporter` measured a 10× wall-clock improvement
+(44s → 4.3s) on a five-project monorepo by switching to the lighter slice
+that was the workaround for this issue.
+
+Closes #60.
+
+## Breaking Changes
+
+### `LockfileReader` service errors surface from method calls
+
+Errors that previously failed `Layer.provide(LockfileReaderLive)` now surface
+from the first invocation of `readLockfile`, `resolvedVersion`,
+`workspaceDependencies`, or `checkIntegrity`. The error union exposed by these
+methods has been widened to a new exported `LockfileInitError` alias:
+
+```ts
+type LockfileInitError =
+  | WorkspaceRootNotFoundError
+  | PackageManagerDetectionError
+  | LockfileReadError
+  | LockfileParseError;
+```
+
+Programs that previously relied on construction-time failure should move their
+error handling to the call site. Programs that already wrapped a method call
+in `Effect.runPromise` will continue to see failures, just routed through the
+program's error channel rather than the layer's.

--- a/.claude/design/architecture.md
+++ b/.claude/design/architecture.md
@@ -5,8 +5,8 @@ category: architecture
 status: current
 completeness: 100
 created: 2026-03-12
-updated: 2026-04-28
-last-synced: 2026-04-28
+updated: 2026-05-02
+last-synced: 2026-05-02
 related:
   - phase2-dependency-graph.md
   - phase3-change-detection.md
@@ -100,6 +100,22 @@ services.
   ensuring platform-correct path separators. This is a breaking change for
   any code that relied on the getter; the field is now required at
   construction.
+- **Lazy layer initialization (Issue #60, 2026-05-02)**: `LockfileReaderLive`
+  and `WorkspaceDiscoveryLive` no longer perform I/O during `Layer.effect`
+  construction. The workspace-root walk, package-manager detection, lockfile
+  read, and lockfile parse are wrapped in `Effect.cached` and paid on the
+  first method call instead. Layer construction is now O(1); consumers that
+  build a layer per call site (Vitest reporters, per-subcommand CLIs, tests
+  that swap layers between cases) no longer pay the eager initialization
+  cost N times. New exported `LockfileInitError` type alias
+  (`WorkspaceRootNotFoundError | PackageManagerDetectionError | LockfileReadError | LockfileParseError`)
+  describes the deferred failure modes. **Breaking change**: errors that
+  previously failed `Layer.provide(LockfileReaderLive)` now surface from the
+  first invocation of `readLockfile`, `resolvedVersion`,
+  `workspaceDependencies`, or `checkIntegrity`; `WorkspaceDiscoveryLive`
+  similarly defers `WorkspaceDiscoveryError` from the default-root walk to
+  the first method call that omits an explicit `cwd` argument. The Layer E
+  channels for both layers narrow to `never`.
 
 ## Design Goals
 
@@ -426,7 +442,11 @@ All major design decisions have been resolved. See phase-specific docs for
 details. Key decisions:
 
 - **Context.Tag** over GenericTag (deprecated) and Effect.Service (not used)
-- **Eager graph/index construction** in `Layer.effect` for all data services
+- **Eager graph/index construction** in `Layer.effect` for `DependencyGraphLive`
+  and `TopologicalSorterLive` (in-memory data services with no I/O dependency).
+  `LockfileReaderLive` and `WorkspaceDiscoveryLive` defer I/O via `Effect.cached`
+  for O(1) layer construction (Issue #60, 2026-05-02) -- the heavy work runs
+  once on first method call and is memoized for the layer's lifetime.
 - **Native Map/Set** for internal data structures (better perf for string keys)
 - **Request/RequestResolver** for `dependenciesOf`, `dependentsOf`, `resolvedVersion`
 - **Per-layer Request.makeCache** for deduplication without global cache contamination

--- a/.claude/design/architecture.md
+++ b/.claude/design/architecture.md
@@ -145,14 +145,19 @@ The library provides 9 services organized into four groups:
 
 WorkspaceDiscovery methods:
 
-- `listPackages()` -- returns all workspace packages **including the root
+- `listPackages(cwd?)` -- returns all workspace packages **including the root
   workspace package** as the first entry (breaking change from Issue #12).
   The root package has `relativePath: "."`. Consumers can filter using
   `isRootWorkspace` getter if they need only non-root packages.
-- `getPackage(name)` -- resolves any package by name (including root).
-- `importerMap()` -- returns `ReadonlyMap<string, WorkspacePackage>` keyed by
-  `relativePath`. Built from `listPackages()` and inherits its caching.
-  Supports lockfile importer-to-package mapping use cases.
+  When `cwd` is provided, the workspace root is resolved fresh from that
+  directory (results cached per resolved root); when omitted, uses the root
+  eagerly resolved from `process.cwd()` at layer construction time.
+- `getPackage(name, cwd?)` -- resolves any package by name (including root).
+  `cwd` semantics match `listPackages`.
+- `importerMap(cwd?)` -- returns `ReadonlyMap<string, WorkspacePackage>` keyed
+  by `relativePath`. Built from `listPackages()` and inherits its caching.
+  Supports lockfile importer-to-package mapping use cases. `cwd` semantics
+  match `listPackages`.
 
 ### Group 2: Package Analysis
 
@@ -293,7 +298,7 @@ Compares all 4 dep types combined. Located in `src/schemas/core.ts`.
 
 ## Error Hierarchy
 
-11 error types using `Data.TaggedError` with exported `*Base` constants for
+12 error types using `Data.TaggedError` with exported `*Base` constants for
 api-extractor DTS bundling. All have computed `message` getters.
 
 | Error | Phase | When Raised |

--- a/.claude/design/code-review-findings.md
+++ b/.claude/design/code-review-findings.md
@@ -157,9 +157,10 @@ non-workspace repos. No guard that the path is actually a workspace root.
   `peerDependencies` and `optionalDependencies` fields. Phase 2 graph
   can now optionally include peer deps.
 
-**Should fix soon**:
+**Tracked in GitHub issues**:
 
-- Issue 3 (`/**` glob) — affects Yarn Berry users
+- Issue 3 (`/**` glob) — affects Yarn Berry users; tracked in
+  [#62](https://github.com/spencerbeggs/workspaces-effect/issues/62)
 
 **Nice to have**:
 

--- a/.claude/design/effect-patterns-core.md
+++ b/.claude/design/effect-patterns-core.md
@@ -5,8 +5,8 @@ category: patterns
 status: current
 completeness: 95
 created: 2026-03-12
-updated: 2026-03-14
-last-synced: 2026-04-15
+updated: 2026-05-02
+last-synced: 2026-05-02
 authors:
   - C. Spencer Beggs
 tags:
@@ -212,6 +212,71 @@ const WorkspaceRootLive = Layer.effect(
   })
 );
 ```
+
+### Defer I/O with Effect.cached for O(1) layer construction
+
+When a layer needs to perform expensive I/O (filesystem walks, lockfile
+reads, network calls) that would otherwise run during `Layer.effect`, wrap
+the work in `Effect.cached` and consume the cached effect from each method.
+This keeps layer construction O(1), pays the I/O at most once per layer
+instance, and keeps all callers sharing the same cached result (success and
+failure are both memoized for the layer's lifetime):
+
+```typescript
+export const LockfileReaderLive: Layer.Layer<
+  LockfileReader,
+  never,
+  WorkspaceRoot | PackageManagerDetector | FileSystem.FileSystem | Path.Path
+> = Layer.effect(
+  LockfileReader,
+  Effect.gen(function* () {
+    const rootService = yield* WorkspaceRoot;
+    const detector = yield* PackageManagerDetector;
+    const fs = yield* FileSystem.FileSystem;
+    const path = yield* Path.Path;
+
+    // Effect.cached memoizes both success AND failure for the lifetime of
+    // the returned effect. Consumers that build the layer but never invoke
+    // a method pay nothing.
+    const initLockfile: Effect.Effect<LockfileState, LockfileInitError> =
+      yield* Effect.cached(
+        Effect.gen(function* () {
+          const root = yield* rootService.find(process.cwd());
+          const { type: pm } = yield* detector.detect(root);
+          // ... read + parse + index build ...
+          return { root, lockfileData, packageIndex } satisfies LockfileState;
+        }).pipe(Effect.withSpan("LockfileReader.init")),
+      );
+
+    return {
+      readLockfile: () =>
+        initLockfile.pipe(Effect.map(({ lockfileData }) => lockfileData)),
+      // ... other methods all consume initLockfile ...
+    };
+  }),
+);
+```
+
+**Trade-off:** Errors that would have failed `Layer.provide(...)` now surface
+from each method's E channel instead. Export a union type alias for the
+deferred error variants so consumers can `catchTag` against them
+ergonomically:
+
+```typescript
+export type LockfileInitError =
+  | WorkspaceRootNotFoundError
+  | PackageManagerDetectionError
+  | LockfileReadError
+  | LockfileParseError;
+```
+
+**When to use:** Choose `Effect.cached` over eager construction when the
+layer is composed per call site (Vitest reporters, per-subcommand CLIs,
+test suites that swap layers between cases) and the I/O cost would otherwise
+multiply with N layer constructions. Used in `LockfileReaderLive` and
+`WorkspaceDiscoveryLive` (Issue #60). For pure in-memory data services with
+no I/O dependency (e.g., `DependencyGraphLive` building a graph from
+already-discovered packages), keep the eager pattern.
 
 ### Layer.succeed for static implementations
 

--- a/.claude/design/lockfile-reader-service.md
+++ b/.claude/design/lockfile-reader-service.md
@@ -5,8 +5,8 @@ category: architecture
 status: current
 completeness: 95
 created: 2026-03-12
-updated: 2026-04-15
-last-synced: 2026-04-15
+updated: 2026-05-02
+last-synced: 2026-05-02
 authors:
   - C. Spencer Beggs
 tags:
@@ -73,16 +73,32 @@ integrity valid?". A unified interface with PM-specific parsing behind the
 scenes follows the same pattern as `PackageManagerDetector` -- one service
 tag, multiple internal strategies.
 
-### Why eager parsing at layer construction
+### Why lazy parsing memoized via `Effect.cached`
 
-Consistent with `DependencyGraphLive` and `TopologicalSorterLive`, the
-lockfile is read and parsed once when the layer is constructed. All service
-methods query the precomputed `LockfileData`. This is appropriate because:
+**Updated 2026-05-02 (Issue #60).** The lockfile is read and parsed lazily on
+the first service method call rather than during `Layer.effect` construction.
+The `Effect.cached`-wrapped initialization runs once per layer instance --
+both success and failure are memoized for the layer's lifetime, so all
+subsequent method calls reuse the cached `LockfileData`.
 
-- Lockfile content is immutable for the duration of a program run
-- Full parsing cost is low (single file read + YAML/JSON parse)
-- Avoids repeated I/O on every method call
-- Errors surface early (at layer construction, not at query time)
+Properties this preserves from the original eager design:
+
+- Lockfile content is read only once per layer instance
+- Full parse cost is paid at most once
+- Repeated `resolvedVersion`/`workspaceDependencies` calls hit the index, not
+  the filesystem
+
+Properties that changed:
+
+- Layer construction is O(1) (allocates the service record only). Consumers
+  that build the layer per call site (Vitest reporters, per-subcommand CLIs,
+  test suites that swap layers between cases) no longer pay N initialization
+  walks for N layer constructions.
+- Errors that previously failed `Layer.provide(LockfileReaderLive)` --
+  workspace-root-not-found, PM-detect failure, lockfile-read failure,
+  lockfile-parse failure -- now surface from the **first method call**
+  through a `LockfileInitError` union exposed in each method's E channel.
+- Programs that compose the layer but never call a method pay nothing.
 
 ### Why separate PublishabilityDetector
 
@@ -180,15 +196,30 @@ export class PackageNotInLockfileError extends PackageNotInLockfileErrorBase<{
 
 ### Error hierarchy rationale
 
+**Updated 2026-05-02 (Issue #60).** All initialization errors now surface from
+the **first method call** rather than from layer construction. The Layer E
+channel for `LockfileReaderLive` is `never`; method E channels include the
+exported `LockfileInitError` union.
+
 | Error | When raised | Where raised |
 | --- | --- | --- |
-| `LockfileNotFoundError` | Lockfile missing from workspace root | Layer construction |
-| `LockfileParseError` | YAML/JSON/JSONC syntax error or Schema validation failure | Layer construction |
-| `LockfileVersionError` | Lockfile version too old or unrecognized | Layer construction |
-| `PackageNotInLockfileError` | Package name not in parsed lockfile data | `resolvedVersion`, `checkIntegrity` |
+| `WorkspaceRootNotFoundError` | Cannot find a workspace root from `process.cwd()` | First method call (deferred init) |
+| `PackageManagerDetectionError` | Cannot determine PM type at the resolved root | First method call (deferred init) |
+| `LockfileReadError` | Lockfile missing or unreadable at the expected path | First method call (deferred init) |
+| `LockfileParseError` | YAML/JSON/JSONC syntax error or Schema validation failure | First method call (deferred init) |
+| `LockfileIntegrityError` | Critical integrity violation between `package.json` and lockfile | `checkIntegrity` |
+| `PackageNotInLockfileError` (spec only) | Package name not in parsed lockfile data | `resolvedVersion`, `checkIntegrity` (current code returns `Option.none` instead) |
 
-The first three are **construction-time** errors (in the Layer's E channel).
-Only `PackageNotInLockfileError` is a **query-time** error (in method return types).
+The four init-time errors are exported as the `LockfileInitError` type
+alias from the package barrel:
+
+```typescript
+export type LockfileInitError =
+  | WorkspaceRootNotFoundError
+  | PackageManagerDetectionError
+  | LockfileReadError
+  | LockfileParseError;
+```
 
 ## LockfileReader Service Interface
 
@@ -207,9 +238,11 @@ import type { PackageNotInLockfileError } from "../errors/index.js"
 /**
  * Service for reading and querying lockfile data.
  *
- * Parses the lockfile for the detected package manager at layer
- * construction time and provides a unified query API. All methods
- * operate on the precomputed data (no additional I/O).
+ * Parses the lockfile for the detected package manager on the first
+ * method call (memoized via `Effect.cached` for the layer's lifetime)
+ * and provides a unified query API. After the first call all methods
+ * operate on the cached data with no additional I/O. Init errors
+ * surface in each method's E channel as a `LockfileInitError` variant.
  */
 export class LockfileReader extends Context.Tag(
   "workspaces-effect/LockfileReader",
@@ -221,7 +254,12 @@ export class LockfileReader extends Context.Tag(
      *
      * Returns the unified LockfileData model containing all resolved
      * packages, workspace dependencies, and PM-specific extensions.
-     * No additional I/O -- data was parsed at layer construction.
+     *
+     * **Implementation note (2026-05-02, Issue #60):** First call performs
+     * the lockfile read + parse (memoized via `Effect.cached`); subsequent
+     * calls return the cached `LockfileData` with no additional I/O. The
+     * actual signature is `readLockfile()` and its E channel includes
+     * `LockfileInitError`.
      */
     readonly lockfileData: () => Effect.Effect<LockfileData>
 
@@ -455,20 +493,29 @@ const lockfileNameFor = (pm: PackageManagerType): string => {
 /**
  * Live layer for LockfileReader.
  *
- * Construction flow:
+ * **Implementation note (2026-05-02, Issue #60):** The implementation now
+ * wraps steps 1-6 in `Effect.cached` so they run on the **first method call**
+ * rather than at layer construction. The Layer E channel narrowed to `never`;
+ * init errors moved into each method's E channel as a `LockfileInitError`
+ * variant. The numbered steps below describe the work done; the difference
+ * is *when* it runs, not *what* it does.
+ *
+ * Initialization flow (lazy, memoized per layer instance):
  * 1. Detect package manager (via PackageManagerDetector)
  * 2. Resolve lockfile path (workspace root + lockfile name)
  * 3. Read lockfile content (via FileSystem)
  * 4. Parse raw content (YAML/JSON/JSONC depending on PM)
  * 5. Validate against PM-specific raw schema (Schema.decode)
  * 6. Transform to unified LockfileData model
- * 7. Store parsed data; service methods query it
+ * 7. Store parsed data in the cached `LockfileState`; service methods read it
  *
- * Errors at any step propagate in the Layer's E channel.
+ * Errors at any step propagate in the **method's** E channel as a
+ * `LockfileInitError` variant on first invocation.
  */
 export const LockfileReaderLive: Layer.Layer<
   LockfileReader,
-  LockfileNotFoundError | LockfileParseError | LockfileVersionError,
+  // Updated 2026-05-02 (Issue #60): init errors moved off Layer E channel.
+  never,
   WorkspaceRoot | PackageManagerDetector | FileSystem.FileSystem | Path.Path
 > = Layer.effect(
   LockfileReader,

--- a/.claude/design/phase3-change-detection.md
+++ b/.claude/design/phase3-change-detection.md
@@ -355,16 +355,21 @@ const ChangeDetectorLive: Layer.Layer<
   Effect.gen(function* () {
     const resolver = yield* PackageResolver
     const graph = yield* DependencyGraph
-    // CommandExecutor is accessed implicitly via Command.string/Command.lines
+    const executor = yield* CommandExecutor.CommandExecutor
+    // git helpers close over `executor`, so service methods have R = never
     return { changedFiles, changedPackages, affectedPackages }
   }),
 )
 ```
 
-**Important**: The `Command.string` and `Command.lines` functions
-require `CommandExecutor` in the R channel. The ChangeDetectorLive layer
-does NOT resolve CommandExecutor — it passes through as a requirement,
-letting consumers provide `NodeContext.layer` or `BunContext.layer`.
+**Important**: `CommandExecutor` is resolved at layer construction time
+(yielded inside `Layer.effect`) so that all service methods have
+`R = never`, matching the project convention documented in `CLAUDE.md`
+and in `architecture.md`. The git helpers (`runGit`, `runGitLines`,
+`checkGit` in `src/layers/ChangeDetectorLive.ts`) close over the
+resolved `executor`. `CommandExecutor` still appears in the layer's
+requirements, so consumers must provide it via `NodeContext.layer` or
+`BunContext.layer`.
 
 ### Composite layer
 

--- a/.claude/design/phase4-configuration-lockfiles.md
+++ b/.claude/design/phase4-configuration-lockfiles.md
@@ -497,20 +497,46 @@ concern, not a per-query concern.
 
 ### Composite layer
 
-```typescript
-// All Phase 4 services (includes Discovery for WorkspaceRoot)
-const WorkspacesLive: Layer.Layer<
-  LockfileReader,
-  LockfileReadError | LockfileParseError,
-  WorkspaceRoot | PackageManagerDetector | FileSystem | Path
-> = LockfileReaderLive
+`LockfileReaderLive` ships as part of the top-level `WorkspacesLive` composite
+in `src/layers/WorkspacesLive.ts`, alongside the other six core services:
 
-// Full stack: Discovery + Configuration
-const WorkspacesFullLive = WorkspacesLive.pipe(
-  Layer.provide(WorkspacesLive),
+```typescript
+// All services except git-dependent ones
+// Requires: FileSystem + Path
+export const WorkspacesLive = Layer.mergeAll(
+  WorkspaceRootLive,
+  PackageManagerDetectorLive,
+  WorkspaceDiscoveryLive.pipe(Layer.provide(WorkspaceRootLive)),
+  DependencyGraphLive.pipe(
+    Layer.provide(WorkspaceDiscoveryLive),
+    Layer.provide(WorkspaceRootLive),
+  ),
+  TopologicalSorterLive.pipe(
+    Layer.provide(DependencyGraphLive),
+    Layer.provide(WorkspaceDiscoveryLive),
+    Layer.provide(WorkspaceRootLive),
+  ),
+  LockfileReaderLive.pipe(
+    Layer.provide(WorkspaceRootLive),
+    Layer.provide(PackageManagerDetectorLive),
+  ),
+  PublishabilityDetectorLive, // pure layer, no dependencies
 )
-// Type: Layer.Layer<LockfileReader, LockfileReadError | LockfileParseError, FileSystem | Path>
+
+// Full stack: adds git-dependent services
+// Requires: FileSystem + Path + CommandExecutor
+export const WorkspacesFullLive = Layer.mergeAll(
+  WorkspacesLive,
+  PackageResolverLive.pipe(Layer.provide(WorkspacesLive)),
+  ChangeDetectorLive.pipe(
+    Layer.provide(PackageResolverLive),
+    Layer.provide(WorkspacesLive),
+  ),
+)
 ```
+
+See `architecture.md` (Layer Composition) for the canonical description of
+the composite layer shapes.
 
 ## Testing Strategy
 

--- a/.claude/design/research-notes.md
+++ b/.claude/design/research-notes.md
@@ -2,11 +2,11 @@
 title: "Research Notes: Sibling Repos & Effect Patterns"
 module: core
 category: reference
-status: draft
-completeness: 60
+status: current
+completeness: 100
 created: 2026-03-12
-updated: 2026-03-14
-last-synced: 2026-04-15
+updated: 2026-05-02
+last-synced: 2026-05-02
 related:
   - architecture.md
   - effect-patterns-core.md
@@ -19,6 +19,15 @@ tags:
 ---
 
 ## Research Notes: Sibling Repos & Effect Patterns
+
+> **Status**: Reference material, not prescriptive. This document captures the
+> sibling-repo and Effect-docs research that informed the initial design of
+> `workspaces-effect`. The patterns selected from this research were absorbed
+> into `architecture.md` and the `effect-patterns-*.md` documents — those are
+> the authoritative sources for current architecture. This file is preserved
+> as historical context for *why* particular patterns were chosen (and others
+> rejected). Do not treat the catalog below as the current state of the
+> implementation; consult the architecture docs or the source for that.
 
 <!-- TOC -->
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,7 +55,7 @@ Load these when working on the corresponding area:
 - `.claude/design/lockfile-reader-service.md` — LockfileReader service interface
 - `.claude/design/lockfile-schemas.md` — all 4 lockfile format schemas
 - `.claude/design/bun-lockfile.md` — bun.lock JSONC format reference
-- `.claude/design/code-review-findings.md` — known issues (5/10 fixed)
+- `.claude/design/code-review-findings.md` — known issues (6/10 fixed)
 - `.claude/design/research-notes.md` — patterns from sibling repos
 
 ## Key Conventions
@@ -100,21 +100,23 @@ pnpm run build:prod        # Build production/npm output only
 ### Running a Single Test
 
 ```bash
-# Run tests for a specific package (replace with actual package name)
-pnpm run test -- --filter=@spencerbeggs/<package-name>
-
 # Run a specific test file
-pnpm vitest run pkgs/<package-name>/__test__/index.test.ts
+pnpm vitest run __test__/layers/DependencyGraphLive.test.ts
+
+# Filter tests by name pattern
+pnpm vitest run -t "lockfile integrity"
 ```
 
 ## Architecture
 
-### Monorepo Structure
+### Repository Structure
 
-- **Package Manager**: pnpm with workspaces
+- **Package Manager**: pnpm (single-package workspace; `pnpm-workspace.yaml`
+  declares `packages: [.]`)
 - **Build Orchestration**: Turbo for caching and task dependencies
-- **Packages**: Located in `pkgs/` directory
-- **Shared Configs**: Located in `lib/configs/`
+- **Source**: `src/` (services, layers, errors, schemas, utils)
+- **Tests**: `__test__/` (unit, integration, fixtures, shared utilities)
+- **Shared Configs**: `lib/configs/`
 
 ### Package Build Pipeline
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,6 +33,13 @@ child packages). PublishTarget schema and shared parser utilities fully tested.
 Sync API (`src/sync.ts`): `findWorkspaceRootSync` and
 `getWorkspacePackagesSync` exported for non-Effect contexts (e.g., lint-staged
 handlers); uses `node:fs`/`node:path` directly.
+Lazy layer init (Issue #60): `LockfileReaderLive` and `WorkspaceDiscoveryLive`
+defer all I/O via `Effect.cached`; layer construction is O(1), the
+root-find/PM-detect/lockfile-read/parse/index-build runs once on first method
+call. New exported `LockfileInitError` =
+`WorkspaceRootNotFoundError | PackageManagerDetectionError | LockfileReadError | LockfileParseError`;
+LockfileReader method signatures include `LockfileInitError` in their E
+channels (breaking: previously construction-time failures only).
 
 ## Design Documents
 
@@ -57,7 +64,7 @@ Load these when working on the corresponding area:
 - `@effect/platform` for FileSystem, Path, Command (no `node:` imports)
 - `Data.TaggedError` with exported Base constants
 - CommandExecutor resolved at layer construction for R=never methods
-- Eager data construction in `Layer.effect`
+- Eager data construction in `Layer.effect` for pure in-memory services (`DependencyGraphLive`, `TopologicalSorterLive`); lazy `Effect.cached` initialization for I/O-bound layers (`LockfileReaderLive`, `WorkspaceDiscoveryLive`) so layer construction stays O(1) and init errors surface from the first method call via `LockfileInitError`
 - Internal service events use `Effect.logDebug` (not `logInfo`); library stays silent under the default logger
 - Request/RequestResolver with per-layer `Request.makeCache` for deduplication
 - `Schema.transformOrFail` + `Schema.compose` for parsing pipelines

--- a/README.md
+++ b/README.md
@@ -192,6 +192,57 @@ Errors are still raised through the typed error channel
 (`WorkspaceRootNotFoundError`, `LockfileReadError`, etc.) -- the
 logger only carries informational events.
 
+## Lazy lockfile and discovery initialization
+
+`LockfileReaderLive` and `WorkspaceDiscoveryLive` defer all I/O (workspace
+root discovery, package-manager detection, lockfile read, and lockfile parse)
+to the first call to a service method. The work is memoized for the lifetime
+of the layer instance via `Effect.cached`, so layer construction itself is
+O(1). This benefits consumers that build the layer per call site -- Vitest
+reporters with multiple projects, CLIs that compose layers per subcommand,
+and tests that swap layers between cases (issue #60).
+
+The trade-off is that errors which used to fail
+`Effect.provide(LockfileReaderLive)` now surface from each method's E
+channel instead. The four init-time errors are exported as a single union
+type alias for convenient handling:
+
+```typescript
+import type { LockfileInitError } from "workspaces-effect";
+
+// LockfileInitError =
+//   | WorkspaceRootNotFoundError
+//   | PackageManagerDetectionError
+//   | LockfileReadError
+//   | LockfileParseError
+```
+
+Every `LockfileReader` method (`readLockfile`, `resolvedVersion`,
+`workspaceDependencies`, `checkIntegrity`) lists `LockfileInitError` in its E
+channel; `checkIntegrity` additionally lists `LockfileIntegrityError`. Code
+that previously relied on layer-construction failure should move its handler
+to the call site:
+
+```typescript
+import { Effect } from "effect";
+import { LockfileReader, WorkspacesLive } from "workspaces-effect";
+
+const program = Effect.gen(function* () {
+  const reader = yield* LockfileReader;
+  return yield* reader.readLockfile();
+}).pipe(
+  Effect.catchTag("LockfileReadError", (e) =>
+    Effect.logWarning(`No lockfile at ${e.lockfilePath}: ${e.reason}`),
+  ),
+  Effect.catchTag("LockfileParseError", (e) =>
+    Effect.logError(`Cannot parse ${e.format} lockfile at ${e.lockfilePath}`),
+  ),
+);
+```
+
+See the [Lazy Initialization](./docs/guides/lockfile-parsing.md#lazy-initialization)
+section of the lockfile guide for the full discussion.
+
 ## Documentation
 
 For architecture details, API reference, and advanced usage, see

--- a/__test__/layers/LockfileReaderLive.test.ts
+++ b/__test__/layers/LockfileReaderLive.test.ts
@@ -261,4 +261,102 @@ describe("LockfileReaderLive", () => {
 			}
 		});
 	});
+
+	describe("laziness", () => {
+		it("does no I/O at layer construction", async () => {
+			let findRuns = 0;
+			let detectRuns = 0;
+			let readRuns = 0;
+
+			const layer = LockfileReaderLive.pipe(
+				Layer.provide(
+					Layer.mergeAll(
+						Layer.succeed(WorkspaceRoot, {
+							find: () =>
+								Effect.sync(() => {
+									findRuns++;
+									return "/project";
+								}),
+						}),
+						Layer.succeed(PackageManagerDetector, {
+							detect: () =>
+								Effect.sync(() => {
+									detectRuns++;
+									return { type: "pnpm" as const, version: undefined };
+								}),
+						}),
+						FileSystem.layerNoop({
+							readFileString: (filePath: string) =>
+								Effect.suspend(() => {
+									readRuns++;
+									if (filePath.endsWith("pnpm-lock.yaml")) return Effect.succeed(PNPM_FIXTURE);
+									return Effect.fail(notFound(filePath));
+								}),
+						}),
+						Path.layer,
+						Logger.replace(Logger.defaultLogger, Logger.none),
+					),
+				),
+			);
+
+			// Acquire the service from the layer without invoking any of its methods.
+			await Effect.runPromise(
+				Effect.gen(function* () {
+					yield* LockfileReader;
+				}).pipe(Effect.provide(layer)),
+			);
+
+			expect(findRuns).toBe(0);
+			expect(detectRuns).toBe(0);
+			expect(readRuns).toBe(0);
+		});
+
+		it("memoizes initialization across multiple method calls", async () => {
+			let findRuns = 0;
+			let detectRuns = 0;
+
+			const layer = LockfileReaderLive.pipe(
+				Layer.provide(
+					Layer.mergeAll(
+						Layer.succeed(WorkspaceRoot, {
+							find: () =>
+								Effect.sync(() => {
+									findRuns++;
+									return "/project";
+								}),
+						}),
+						Layer.succeed(PackageManagerDetector, {
+							detect: () =>
+								Effect.sync(() => {
+									detectRuns++;
+									return { type: "pnpm" as const, version: undefined };
+								}),
+						}),
+						FileSystem.layerNoop({
+							readFileString: (filePath: string) => {
+								if (filePath.endsWith("pnpm-lock.yaml")) return Effect.succeed(PNPM_FIXTURE);
+								return Effect.fail(notFound(filePath));
+							},
+						}),
+						Path.layer,
+						Logger.replace(Logger.defaultLogger, Logger.none),
+					),
+				),
+			);
+
+			await Effect.runPromise(
+				Effect.gen(function* () {
+					const reader = yield* LockfileReader;
+					yield* reader.readLockfile();
+					yield* reader.readLockfile();
+					yield* reader.workspaceDependencies();
+					yield* reader.resolvedVersion("lodash");
+				}).pipe(Effect.provide(layer)),
+			);
+
+			// Initialization runs exactly once; subsequent method calls hit the cache.
+			expect(findRuns).toBe(1);
+			expect(detectRuns).toBe(1);
+		});
+	});
 });

--- a/__test__/layers/WorkspaceDiscoveryLive.test.ts
+++ b/__test__/layers/WorkspaceDiscoveryLive.test.ts
@@ -748,6 +748,76 @@ describe("WorkspaceDiscoveryLive", () => {
 		});
 	});
 
+	describe("laziness", () => {
+		it("does not run WorkspaceRoot.find at layer construction", async () => {
+			let findRuns = 0;
+			const layer = WorkspaceDiscoveryLive.pipe(
+				Layer.provide(
+					Layer.mergeAll(
+						Layer.succeed(WorkspaceRoot, {
+							find: () =>
+								Effect.sync(() => {
+									findRuns++;
+									return "/projects/monorepo";
+								}),
+						}),
+						mockFs({}),
+						Path.layer,
+						Logger.replace(Logger.defaultLogger, Logger.none),
+					),
+				),
+			);
+
+			// Acquire the service without invoking any of its methods.
+			await Effect.runPromise(
+				Effect.gen(function* () {
+					yield* WorkspaceDiscovery;
+				}).pipe(Effect.provide(layer)),
+			);
+
+			expect(findRuns).toBe(0);
+		});
+
+		it("memoizes the default-root lookup across method calls", async () => {
+			let findRuns = 0;
+			const root = "/projects/monorepo";
+			const layer = WorkspaceDiscoveryLive.pipe(
+				Layer.provide(
+					Layer.mergeAll(
+						Layer.succeed(WorkspaceRoot, {
+							find: () =>
+								Effect.sync(() => {
+									findRuns++;
+									return root;
+								}),
+						}),
+						mockFs({
+							[`${root}/package.json`]: JSON.stringify({
+								name: "my-mono",
+								version: "1.0.0",
+							}),
+						}),
+						Path.layer,
+						Logger.replace(Logger.defaultLogger, Logger.none),
+					),
+				),
+			);
+
+			await Effect.runPromise(
+				Effect.gen(function* () {
+					const discovery = yield* WorkspaceDiscovery;
+					yield* discovery.listPackages();
+					yield* discovery.listPackages();
+					yield* discovery.importerMap();
+				}).pipe(Effect.provide(layer)),
+			);
+
+			// Default root resolved once, then reused for every subsequent
+			// method invocation.
+			expect(findRuns).toBe(1);
+		});
+	});
+
 	describe("pnpm-workspace.yaml parsing edge cases", () => {
 		it("handles comments in packages list", async () => {
 			const root = "/projects/monorepo";

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -2,9 +2,12 @@
 
 workspaces-effect provides 9 composable Effect services organized into four
 groups. Each service is an Effect `Context.Tag` with a live layer
-implementation. All service methods have `R = never` -- dependencies are
-resolved at layer construction time, so consuming code never needs to provide
-transitive services manually.
+implementation. All service methods have `R = never` -- inter-service and
+platform dependencies are resolved when the layer is built, so consuming
+code never needs to provide transitive services manually. Where I/O is
+deferred for performance (`LockfileReader`, `WorkspaceDiscovery`), the work
+runs on the first method call and its errors surface in each method's E
+channel; see [Error Model](#error-model).
 
 ## Table of Contents
 
@@ -211,6 +214,30 @@ const program = Effect.gen(function* () {
   ),
 );
 ```
+
+### LockfileInitError union
+
+`LockfileReader` defers all initialization (workspace-root discovery,
+package-manager detection, lockfile read, and lockfile parse) to the first
+method call. The four errors that can fail that initialization are exposed as
+a single exported type alias for ergonomic handling:
+
+```typescript
+import type { LockfileInitError } from "workspaces-effect";
+
+// LockfileInitError =
+//   | WorkspaceRootNotFoundError
+//   | PackageManagerDetectionError
+//   | LockfileReadError
+//   | LockfileParseError
+```
+
+Every `LockfileReader` method (`readLockfile`, `resolvedVersion`,
+`workspaceDependencies`, `checkIntegrity`) lists `LockfileInitError` in its E
+channel. `checkIntegrity` additionally lists `LockfileIntegrityError`. The
+`LockfileReaderLive` and `WorkspaceDiscoveryLive` Layer E channels are
+`never` -- errors no longer surface from `Effect.provide`. See
+[Lockfile Parsing -> Lazy Initialization](../guides/lockfile-parsing.md#lazy-initialization).
 
 For a complete list of error fields and solutions, see
 [Troubleshooting](../troubleshooting.md).

--- a/docs/architecture/services.md
+++ b/docs/architecture/services.md
@@ -101,7 +101,7 @@ package as a standalone single-package workspace.
 **Layer:** `WorkspaceDiscoveryLive` (E channel: `never`; default-root
 discovery is deferred to the first method call that omits an explicit `cwd`
 and memoized via `Effect.cached`)
-**Service deps:** `WorkspaceRoot`, `PackageManagerDetector`
+**Service deps:** `WorkspaceRoot`
 **Composite layers:** `WorkspacesLive`, `WorkspacesFullLive`
 
 ### Methods

--- a/docs/architecture/services.md
+++ b/docs/architecture/services.md
@@ -98,11 +98,16 @@ entry. If no workspace configuration is found (no `pnpm-workspace.yaml` and no
 `workspaces` field in `package.json`), discovery falls back to treating the root
 package as a standalone single-package workspace.
 
-**Layer:** `WorkspaceDiscoveryLive`
+**Layer:** `WorkspaceDiscoveryLive` (E channel: `never`; default-root
+discovery is deferred to the first method call that omits an explicit `cwd`
+and memoized via `Effect.cached`)
 **Service deps:** `WorkspaceRoot`, `PackageManagerDetector`
 **Composite layers:** `WorkspacesLive`, `WorkspacesFullLive`
 
 ### Methods
+
+All methods optionally accept a `cwd` argument. When omitted, the workspace
+root resolved from `process.cwd()` (lazily, on first use) is used.
 
 #### `listPackages()`
 
@@ -344,10 +349,17 @@ const affected = yield* detector.affectedPackages(options);
 Parses lockfiles from all four package managers into a unified schema. The
 correct parser is selected automatically based on the detected package manager.
 
-**Layer:** `LockfileReaderLive`
+**Layer:** `LockfileReaderLive` (E channel: `never`; root discovery, PM
+detection, lockfile read, and lockfile parse are deferred to the first method
+call and memoized for the layer's lifetime via `Effect.cached`)
 **Service deps:** `WorkspaceRoot`, `PackageManagerDetector`
 **Platform deps:** `FileSystem`, `Path`
 **Composite layers:** `WorkspacesLive`, `WorkspacesFullLive`
+
+All four methods below carry the exported [`LockfileInitError`](#lockfileiniterror-union)
+union in their E channels because their first invocation drives the lazy
+init. See [Lockfile Parsing -> Lazy Initialization](../guides/lockfile-parsing.md#lazy-initialization)
+for the full discussion.
 
 ### Methods
 
@@ -356,28 +368,29 @@ correct parser is selected automatically based on the detected package manager.
 Read and parse the workspace lockfile into a normalized `LockfileData`
 structure.
 
-- **Returns:** `Effect<LockfileData>`
+- **Returns:** `Effect<LockfileData, LockfileInitError>`
 
 #### `resolvedVersion(packageName: string)`
 
 Look up the resolved version of a package in the lockfile.
 
-- **Returns:** `Effect<Option<ResolvedPackage>>`
+- **Returns:** `Effect<Option<ResolvedPackage>, LockfileInitError>`
 
 #### `workspaceDependencies()`
 
 Get all workspace-to-workspace dependency links from the lockfile.
 
-- **Returns:** `Effect<ReadonlyArray<WorkspaceDependency>>`
+- **Returns:** `Effect<ReadonlyArray<WorkspaceDependency>, LockfileInitError>`
 
 #### `checkIntegrity()`
 
 Verify lockfile integrity against current `package.json` files. Returns a
 `LockfileIntegrity` report on success. Fails with `LockfileIntegrityError` if
 the check itself cannot complete (integrity mismatches are reported in the
-returned data, not as errors).
+returned data, not as errors). May also fail with any `LockfileInitError`
+variant on first invocation.
 
-- **Returns:** `Effect<LockfileIntegrity, LockfileIntegrityError>`
+- **Returns:** `Effect<LockfileIntegrity, LockfileIntegrityError | LockfileInitError>`
 
 ```typescript
 const reader = yield* LockfileReader;
@@ -385,6 +398,21 @@ const lockfile = yield* reader.readLockfile();
 const react = yield* reader.resolvedVersion("react");
 const integrity = yield* reader.checkIntegrity();
 ```
+
+### LockfileInitError union
+
+```typescript
+import type { LockfileInitError } from "workspaces-effect";
+
+// LockfileInitError =
+//   | WorkspaceRootNotFoundError
+//   | PackageManagerDetectionError
+//   | LockfileReadError
+//   | LockfileParseError
+```
+
+Catch the variants individually with `Effect.catchTag` (each carries its own
+`_tag`) or catch all four together by their union with `Effect.catchTags`.
 
 ---
 

--- a/docs/guides/lockfile-parsing.md
+++ b/docs/guides/lockfile-parsing.md
@@ -13,6 +13,7 @@ dependencies, and integrity checks.
 - [Integrity Checking](#integrity-checking)
 - [PM-Specific Extensions](#pm-specific-extensions)
 - [Error Handling](#error-handling)
+- [Lazy Initialization](#lazy-initialization)
 
 ## Supported Formats
 
@@ -234,13 +235,28 @@ if (lockfile.pmSpecific?._tag === "bun") {
 
 ## Error Handling
 
-Lockfile operations can fail with three error types:
+Lockfile operations can fail with several error types. Initialization
+failures (root discovery, package-manager detection, lockfile read, lockfile
+parse) surface from the **first** call to any `LockfileReader` method as a
+member of the exported `LockfileInitError` union:
 
-| Error | Cause |
-| --- | --- |
-| `LockfileReadError` | Lockfile does not exist or cannot be read from disk |
-| `LockfileParseError` | Lockfile exists but contains invalid or unparseable content |
-| `LockfileIntegrityError` | Integrity check itself cannot complete |
+```typescript
+import type { LockfileInitError } from "workspaces-effect";
+
+// LockfileInitError =
+//   | WorkspaceRootNotFoundError
+//   | PackageManagerDetectionError
+//   | LockfileReadError
+//   | LockfileParseError
+```
+
+| Error | Cause | Where it surfaces |
+| --- | --- | --- |
+| `WorkspaceRootNotFoundError` | No workspace root found from `process.cwd()` | First method call (member of `LockfileInitError`) |
+| `PackageManagerDetectionError` | Cannot determine PM type at the resolved root | First method call (member of `LockfileInitError`) |
+| `LockfileReadError` | Lockfile does not exist or cannot be read from disk | First method call (member of `LockfileInitError`) |
+| `LockfileParseError` | Lockfile exists but contains invalid or unparseable content | First method call (member of `LockfileInitError`) |
+| `LockfileIntegrityError` | Integrity check itself cannot complete | `checkIntegrity()` only |
 
 `LockfileReadError` has `lockfilePath` and `reason` fields.
 `LockfileParseError` has `lockfilePath`, `format`, and `cause` fields.
@@ -251,6 +267,12 @@ const program = Effect.gen(function* () {
   const reader = yield* LockfileReader;
   return yield* reader.readLockfile();
 }).pipe(
+  Effect.catchTag("WorkspaceRootNotFoundError", (e) =>
+    Effect.logWarning(`No workspace root: ${e.reason}`),
+  ),
+  Effect.catchTag("PackageManagerDetectionError", (e) =>
+    Effect.logWarning(`PM detection failed: ${e.reason}`),
+  ),
   Effect.catchTag("LockfileReadError", (e) =>
     Effect.logWarning(`No lockfile at ${e.lockfilePath}: ${e.reason}`),
   ),
@@ -260,4 +282,39 @@ const program = Effect.gen(function* () {
 );
 ```
 
+`checkIntegrity()` widens the error channel further:
+`LockfileInitError | LockfileIntegrityError`.
+
 See [Troubleshooting](../troubleshooting.md) for detailed solutions.
+
+## Lazy Initialization
+
+`LockfileReaderLive` defers all I/O (workspace-root discovery, package-manager
+detection, lockfile read, and lockfile parse) until the first call to
+`readLockfile`, `resolvedVersion`, `workspaceDependencies`, or
+`checkIntegrity`. The result is memoized for the lifetime of the layer
+instance via `Effect.cached`, so subsequent calls reuse the cached parse.
+
+The practical implications:
+
+- **Layer construction is O(1).** Building the layer (e.g., via
+  `Effect.provide(WorkspacesLive)`) performs no filesystem work. Programs that
+  compose the layer but never invoke a `LockfileReader` method pay nothing.
+- **Errors surface from the first method call**, not from
+  `Effect.provide(LockfileReaderLive)`. Code that previously relied on
+  construction-time failure (for example, by handling errors in a wrapper
+  around `Layer.provide`) must move its handling to the call site.
+- **Both success and failure are memoized.** If the first call fails because
+  the lockfile cannot be parsed, every subsequent call on the same layer
+  instance fails with the same error. Build a fresh layer instance to retry.
+- **The Layer E channel is `never`.** The error variants previously listed on
+  `LockfileReaderLive` (`LockfileReadError`, `LockfileParseError`, and the
+  others above) now appear on each method's E channel as `LockfileInitError`
+  variants. `WorkspaceDiscoveryLive` similarly defers its default-root walk
+  and now has an E channel of `never`.
+
+This change exists primarily to benefit consumers that build the layer per
+call site (Vitest reporters with multiple projects, CLIs that compose layers
+per subcommand, tests that swap layers between cases) -- the previous eager
+construction paid the read/parse cost N times for N layer instances. See
+GitHub issue #60 for context.

--- a/src/index.ts
+++ b/src/index.ts
@@ -126,6 +126,7 @@ export {
 export { PublishTarget } from "./schemas/publish.js";
 export { ChangeDetectionOptions, ChangeDetector } from "./services/ChangeDetector.js";
 export { DependencyGraph } from "./services/DependencyGraph.js";
+export type { LockfileInitError } from "./services/LockfileReader.js";
 export { LockfileReader } from "./services/LockfileReader.js";
 export type { DetectedPackageManager } from "./services/PackageManagerDetector.js";
 export { PackageManagerDetector } from "./services/PackageManagerDetector.js";

--- a/src/layers/LockfileReaderLive.ts
+++ b/src/layers/LockfileReaderLive.ts
@@ -10,10 +10,10 @@
 
 import { FileSystem, Path } from "@effect/platform";
 import { Effect, Exit, Layer, Option, Request, RequestResolver } from "effect";
-import type { LockfileParseError } from "../errors/LockfileParseError.js";
 import { LockfileReadError } from "../errors/LockfileReadError.js";
 import type { PackageManagerType } from "../schemas/core.js";
 import { LockfileData, ResolvedPackage, WorkspaceDependency } from "../schemas/lockfile.js";
+import type { LockfileInitError } from "../services/LockfileReader.js";
 import { LockfileReader } from "../services/LockfileReader.js";
 import { PackageManagerDetector } from "../services/PackageManagerDetector.js";
 import { WorkspaceRoot } from "../services/WorkspaceRoot.js";
@@ -59,44 +59,57 @@ const parseLockfile = (content: string, lockfilePath: string, pm: PackageManager
 	}
 };
 
+/** @internal Snapshot of parsed lockfile state held in the layer's cache. */
+interface LockfileState {
+	readonly root: string;
+	readonly lockfileData: LockfileData;
+	readonly packageIndex: ReadonlyMap<string, ReadonlyArray<ResolvedPackage>>;
+}
+
 /** @internal Request for resolvedVersion lookups. */
 class ResolvedVersionRequest extends Request.TaggedClass("ResolvedVersionRequest")<
 	Option.Option<ResolvedPackage>,
-	never,
+	LockfileInitError,
 	{ readonly packageName: string }
 > {}
 
 /**
  * Convenience type alias for the {@link LockfileReaderLive} layer signature.
  *
- * Useful for consumers who want to annotate layer types explicitly. The
- * error union includes `LockfileReadError` and `LockfileParseError` because
- * the lockfile is read and parsed eagerly at construction time.
+ * Useful for consumers who want to annotate layer types explicitly. Layer
+ * construction is now O(1); read and parse errors surface from service
+ * methods on first use.
  *
  * @public
  */
 export type LockfileReaderLiveLayer = Layer.Layer<
 	LockfileReader,
-	LockfileReadError | LockfileParseError,
+	never,
 	WorkspaceRoot | PackageManagerDetector | FileSystem.FileSystem | Path.Path
 >;
 
 /**
  * Live layer for the {@link LockfileReader} service.
  *
- * Reads, parses, and indexes the lockfile for the detected package manager
- * at construction time. Provides cached version lookups, workspace dependency
- * extraction, and lockfile integrity checking.
+ * Provides a unified view of the workspace lockfile (npm, pnpm, yarn Berry,
+ * or bun) with cached version lookups, workspace dependency extraction, and
+ * integrity checking.
  *
  * @remarks
  * Requires {@link WorkspaceRoot}, {@link PackageManagerDetector}, `FileSystem`,
- * and `Path` from `@effect/platform`. The lockfile is read and parsed eagerly
- * at construction time; the parsed data is cached for the lifetime of the layer.
+ * and `Path` from `@effect/platform`. Layer construction allocates the service
+ * record but performs no I/O. The first invocation of any method resolves the
+ * workspace root, detects the package manager, and reads/parses the lockfile;
+ * subsequent calls reuse the cached result for the lifetime of the layer
+ * (success or failure are both memoized via `Effect.cached`).
  *
  * @privateRemarks
- * Delegates to format-specific parsers in `./parsers/`. Uses an Effect
- * `Request.Cache` for deduplicating `resolvedVersion` lookups (same pattern
- * as `DependencyGraphLive`). Integrity checking delegates to
+ * Wraps the eager initialization (root find, PM detect, lockfile read,
+ * format-specific parse, pnpm name resolution, multi-version index) in
+ * `Effect.cached` so the cost is paid once per service instance rather than
+ * once per layer construction. Format-specific parsers live in `./parsers/`.
+ * Uses an Effect `Request.Cache` for deduplicating `resolvedVersion` lookups
+ * (same pattern as `DependencyGraphLive`). Integrity checking delegates to
  * {@link checkLockfileIntegrity}.
  *
  * @example
@@ -121,7 +134,7 @@ export type LockfileReaderLiveLayer = Layer.Layer<
  *
  * @public
  */
-export const LockfileReaderLive = Layer.effect(
+export const LockfileReaderLive: LockfileReaderLiveLayer = Layer.effect(
 	LockfileReader,
 	Effect.gen(function* () {
 		const rootService = yield* WorkspaceRoot;
@@ -129,102 +142,112 @@ export const LockfileReaderLive = Layer.effect(
 		const fs = yield* FileSystem.FileSystem;
 		const path = yield* Path.Path;
 
-		const root = yield* rootService.find(process.cwd());
-		const { type: pm } = yield* detector.detect(root);
+		// Memoize the heavy I/O on first read so layer construction stays O(1).
+		// `Effect.cached` caches both success and failure for the lifetime of the
+		// returned effect; consumers that build the layer but never invoke a
+		// method pay nothing.
+		const initLockfile: Effect.Effect<LockfileState, LockfileInitError> = yield* Effect.cached(
+			Effect.gen(function* () {
+				const root = yield* rootService.find(process.cwd());
+				const { type: pm } = yield* detector.detect(root);
 
-		const lockfilePath = path.join(root, lockfileNameFor(pm));
+				const lockfilePath = path.join(root, lockfileNameFor(pm));
 
-		const content = yield* fs.readFileString(lockfilePath).pipe(
-			Effect.mapError(
-				() =>
-					new LockfileReadError({
-						lockfilePath,
-						reason: "file not found or unreadable",
-					}),
-			),
-		);
+				const content = yield* fs.readFileString(lockfilePath).pipe(
+					Effect.mapError(
+						() =>
+							new LockfileReadError({
+								lockfilePath,
+								reason: "file not found or unreadable",
+							}),
+					),
+				);
 
-		let lockfileData = yield* parseLockfile(content, lockfilePath, pm);
+				let lockfileData = yield* parseLockfile(content, lockfilePath, pm);
 
-		// For pnpm, resolve importer paths to actual package names from package.json
-		if (pm === "pnpm") {
-			const pathToName = new Map<string, string>();
-			for (const pkg of lockfileData.packages) {
-				if (pkg.isWorkspace && pkg.relativePath) {
-					const pkgJsonPath = path.join(root, pkg.relativePath, "package.json");
-					const exit = yield* Effect.exit(
-						fs
-							.readFileString(pkgJsonPath)
-							.pipe(Effect.flatMap((content) => Effect.try(() => JSON.parse(content) as { name?: string }))),
-					);
-					if (Exit.isSuccess(exit) && exit.value.name) {
-						pathToName.set(pkg.relativePath, exit.value.name);
+				// For pnpm, resolve importer paths to actual package names from package.json
+				if (pm === "pnpm") {
+					const pathToName = new Map<string, string>();
+					for (const pkg of lockfileData.packages) {
+						if (pkg.isWorkspace && pkg.relativePath) {
+							const pkgJsonPath = path.join(root, pkg.relativePath, "package.json");
+							const exit = yield* Effect.exit(
+								fs
+									.readFileString(pkgJsonPath)
+									.pipe(Effect.flatMap((content) => Effect.try(() => JSON.parse(content) as { name?: string }))),
+							);
+							if (Exit.isSuccess(exit) && exit.value.name) {
+								pathToName.set(pkg.relativePath, exit.value.name);
+							}
+						}
+					}
+
+					if (pathToName.size > 0) {
+						// Rebuild packages with resolved names
+						const resolvedPackages = lockfileData.packages.map((pkg) => {
+							if (!pkg.isWorkspace || !pkg.relativePath) return pkg;
+							const realName = pathToName.get(pkg.relativePath);
+							if (!realName) return pkg;
+							return new ResolvedPackage({
+								name: realName,
+								version: pkg.version,
+								integrity: pkg.integrity,
+								isWorkspace: pkg.isWorkspace,
+								relativePath: pkg.relativePath,
+								dependencies: pkg.dependencies,
+							});
+						});
+
+						// Rebuild workspace dependencies with resolved names
+						const resolvedWsDeps = lockfileData.workspaceDependencies.map((dep) => {
+							const fromName = pathToName.get(dep.from) ?? dep.from;
+							const toName = pathToName.get(dep.to) ?? dep.to;
+							return new WorkspaceDependency({
+								from: fromName,
+								to: toName,
+								depType: dep.depType,
+								constraint: dep.constraint,
+							});
+						});
+
+						lockfileData = new LockfileData({
+							packageManager: lockfileData.packageManager,
+							lockfileVersion: lockfileData.lockfileVersion,
+							packages: resolvedPackages,
+							workspaceDependencies: resolvedWsDeps,
+							pmSpecific: lockfileData.pmSpecific,
+						});
 					}
 				}
-			}
 
-			if (pathToName.size > 0) {
-				// Rebuild packages with resolved names
-				const resolvedPackages = lockfileData.packages.map((pkg) => {
-					if (!pkg.isWorkspace || !pkg.relativePath) return pkg;
-					const realName = pathToName.get(pkg.relativePath);
-					if (!realName) return pkg;
-					return new ResolvedPackage({
-						name: realName,
-						version: pkg.version,
-						integrity: pkg.integrity,
-						isWorkspace: pkg.isWorkspace,
-						relativePath: pkg.relativePath,
-						dependencies: pkg.dependencies,
-					});
-				});
+				// Build multi-version lookup index
+				const packageIndex = new Map<string, Array<ResolvedPackage>>();
+				for (const pkg of lockfileData.packages) {
+					const existing = packageIndex.get(pkg.name) ?? [];
+					existing.push(pkg);
+					packageIndex.set(pkg.name, existing);
+				}
 
-				// Rebuild workspace dependencies with resolved names
-				const resolvedWsDeps = lockfileData.workspaceDependencies.map((dep) => {
-					const fromName = pathToName.get(dep.from) ?? dep.from;
-					const toName = pathToName.get(dep.to) ?? dep.to;
-					return new WorkspaceDependency({
-						from: fromName,
-						to: toName,
-						depType: dep.depType,
-						constraint: dep.constraint,
-					});
-				});
+				yield* Effect.logDebug("Lockfile reader initialized").pipe(
+					Effect.annotateLogs({
+						"workspace.pm": pm,
+						"workspace.packages.count": lockfileData.packages.length,
+					}),
+				);
 
-				lockfileData = new LockfileData({
-					packageManager: lockfileData.packageManager,
-					lockfileVersion: lockfileData.lockfileVersion,
-					packages: resolvedPackages,
-					workspaceDependencies: resolvedWsDeps,
-					pmSpecific: lockfileData.pmSpecific,
-				});
-			}
-		}
-
-		// Build multi-version lookup index
-		const packageIndex = new Map<string, Array<ResolvedPackage>>();
-		for (const pkg of lockfileData.packages) {
-			const existing = packageIndex.get(pkg.name) ?? [];
-			existing.push(pkg);
-			packageIndex.set(pkg.name, existing);
-		}
-
-		yield* Effect.logDebug("Lockfile reader initialized").pipe(
-			Effect.annotateLogs({
-				"workspace.pm": pm,
-				"workspace.packages.count": lockfileData.packages.length,
-			}),
+				return { root, lockfileData, packageIndex } satisfies LockfileState;
+			}).pipe(Effect.withSpan("LockfileReader.init")),
 		);
 
 		// Per-layer cache for request deduplication (same pattern as DependencyGraphLive).
 		const cache = yield* Request.makeCache({ capacity: 1024, timeToLive: "1 minute" });
 
 		const ResolvedVersionResolver = RequestResolver.fromEffect((req: ResolvedVersionRequest) =>
-			Effect.succeed(Option.fromNullable(packageIndex.get(req.packageName)?.[0])),
+			initLockfile.pipe(Effect.map(({ packageIndex }) => Option.fromNullable(packageIndex.get(req.packageName)?.[0]))),
 		);
 
 		return {
-			readLockfile: () => Effect.succeed(lockfileData),
+			readLockfile: () => initLockfile.pipe(Effect.map(({ lockfileData }) => lockfileData)),
 
 			resolvedVersion: (packageName: string) =>
 				Effect.request(new ResolvedVersionRequest({ packageName }), ResolvedVersionResolver).pipe(
@@ -243,10 +266,12 @@ export const LockfileReaderLive = Layer.effect(
 					}),
 				),
 
-			workspaceDependencies: () => Effect.succeed(lockfileData.workspaceDependencies),
+			workspaceDependencies: () =>
+				initLockfile.pipe(Effect.map(({ lockfileData }) => lockfileData.workspaceDependencies)),
 
 			checkIntegrity: () =>
 				Effect.gen(function* () {
+					const { root, lockfileData } = yield* initLockfile;
 					const result = yield* checkLockfileIntegrity(lockfileData, root, fs, path);
 					yield* Effect.logDebug("Lockfile integrity check complete").pipe(
 						Effect.annotateLogs({

--- a/src/layers/WorkspaceDiscoveryLive.ts
+++ b/src/layers/WorkspaceDiscoveryLive.ts
@@ -339,9 +339,12 @@ export const WorkspaceDiscoveryLive: Layer.Layer<
 		// Lazily resolve the default root on first use. `Effect.cached` memoizes
 		// success and failure for the lifetime of the layer, so consumers that
 		// only invoke methods with an explicit `cwd` never pay the default-root
-		// fs walk, and those that omit `cwd` pay it exactly once.
+		// fs walk, and those that omit `cwd` pay it exactly once. `process.cwd()`
+		// is wrapped in `Effect.suspend` so it is read at first-call time, not at
+		// layer construction (matters for consumers that `process.chdir(...)`
+		// between provide and the first method invocation).
 		const resolveDefaultRoot = yield* Effect.cached(
-			rootService.find(process.cwd()).pipe(
+			Effect.suspend(() => rootService.find(process.cwd())).pipe(
 				Effect.mapError(
 					(e) =>
 						new WorkspaceDiscoveryError({

--- a/src/layers/WorkspaceDiscoveryLive.ts
+++ b/src/layers/WorkspaceDiscoveryLive.ts
@@ -289,15 +289,17 @@ const readWorkspacePackage = (
  * resolving glob patterns to directories, and parsing each `package.json`.
  *
  * @remarks
- * Requires {@link WorkspaceRoot}, `FileSystem`, and `Path`. The workspace
- * root is eagerly resolved at layer construction time using `process.cwd()`
- * as the starting directory. Discovery method calls accept an optional
- * `cwd` parameter to resolve a different root for that single call;
- * results are cached per resolved root path for the lifetime of the layer.
+ * Requires {@link WorkspaceRoot}, `FileSystem`, and `Path`. Layer construction
+ * is O(1); the default workspace root (resolved from `process.cwd()`) is looked
+ * up lazily on the first method call and cached for the lifetime of the layer.
+ * Discovery method calls accept an optional `cwd` parameter to resolve a
+ * different root for that single call; results are cached per resolved root
+ * path for the lifetime of the layer.
  *
  * @privateRemarks
- * Eagerly resolves the default root from `process.cwd()` at layer
- * construction. Per-call `cwd` arguments are resolved on demand via
+ * The default-root lookup is wrapped in `Effect.cached` so layer construction
+ * is free and consumers that build the layer but never call a method pay
+ * nothing. Per-call `cwd` arguments are resolved on demand via
  * `WorkspaceRoot.find` and memoized in a `Map` keyed by the absolute
  * resolved root path.
  *
@@ -325,7 +327,7 @@ const readWorkspacePackage = (
  */
 export const WorkspaceDiscoveryLive: Layer.Layer<
 	WorkspaceDiscovery,
-	WorkspaceDiscoveryError,
+	never,
 	WorkspaceRoot | FileSystem.FileSystem | Path.Path
 > = Layer.effect(
 	WorkspaceDiscovery,
@@ -334,16 +336,19 @@ export const WorkspaceDiscoveryLive: Layer.Layer<
 		const fs = yield* FileSystem.FileSystem;
 		const path = yield* Path.Path;
 
-		// Eagerly resolve the default root at layer construction time.
-		// Uses process.cwd() as the search starting point. Per-call `cwd`
-		// arguments are resolved on demand by `resolveRoot` below.
-		const defaultRoot = yield* rootService.find(process.cwd()).pipe(
-			Effect.mapError(
-				(e) =>
-					new WorkspaceDiscoveryError({
-						root: e.searchPath,
-						reason: `workspace root not found: ${e.reason}`,
-					}),
+		// Lazily resolve the default root on first use. `Effect.cached` memoizes
+		// success and failure for the lifetime of the layer, so consumers that
+		// only invoke methods with an explicit `cwd` never pay the default-root
+		// fs walk, and those that omit `cwd` pay it exactly once.
+		const resolveDefaultRoot = yield* Effect.cached(
+			rootService.find(process.cwd()).pipe(
+				Effect.mapError(
+					(e) =>
+						new WorkspaceDiscoveryError({
+							root: e.searchPath,
+							reason: `workspace root not found: ${e.reason}`,
+						}),
+				),
 			),
 		);
 
@@ -352,7 +357,7 @@ export const WorkspaceDiscoveryLive: Layer.Layer<
 
 		const resolveRoot = (cwd: string | undefined): Effect.Effect<string, WorkspaceDiscoveryError> =>
 			cwd === undefined
-				? Effect.succeed(defaultRoot)
+				? resolveDefaultRoot
 				: rootService.find(cwd).pipe(
 						Effect.mapError(
 							(e) =>

--- a/src/services/LockfileReader.ts
+++ b/src/services/LockfileReader.ts
@@ -7,7 +7,24 @@
 import type { Effect, Option } from "effect";
 import { Context } from "effect";
 import type { LockfileIntegrityError } from "../errors/LockfileIntegrityError.js";
+import type { LockfileParseError } from "../errors/LockfileParseError.js";
+import type { LockfileReadError } from "../errors/LockfileReadError.js";
+import type { PackageManagerDetectionError } from "../errors/PackageManagerDetectionError.js";
+import type { WorkspaceRootNotFoundError } from "../errors/WorkspaceRootNotFoundError.js";
 import type { LockfileData, LockfileIntegrity, ResolvedPackage, WorkspaceDependency } from "../schemas/lockfile.js";
+
+/**
+ * Union of errors that may surface from {@link LockfileReader} method calls
+ * because the live layer defers workspace-root discovery, package-manager
+ * detection, and lockfile read/parse to the first invocation.
+ *
+ * @public
+ */
+export type LockfileInitError =
+	| WorkspaceRootNotFoundError
+	| PackageManagerDetectionError
+	| LockfileReadError
+	| LockfileParseError;
 
 /**
  * Service for reading and querying package manager lockfile data.
@@ -65,11 +82,15 @@ export class LockfileReader extends Context.Tag("@spencerbeggs/workspaces-effect
 		 * Read and parse the workspace lockfile.
 		 *
 		 * Detects the lockfile format from the package manager type and parses it
-		 * into a normalized {@link LockfileData} structure.
+		 * into a normalized {@link LockfileData} structure. The first call resolves
+		 * the workspace root, detects the package manager, and reads/parses the
+		 * lockfile; subsequent calls return the cached result.
 		 *
-		 * @returns An Effect that succeeds with the parsed {@link LockfileData}.
+		 * @returns An Effect that succeeds with the parsed {@link LockfileData}, or
+		 *   fails with a {@link LockfileInitError} variant if any step of the
+		 *   first-call initialization (root find, PM detect, read, parse) fails.
 		 */
-		readonly readLockfile: () => Effect.Effect<LockfileData>;
+		readonly readLockfile: () => Effect.Effect<LockfileData, LockfileInitError>;
 
 		/**
 		 * Look up the resolved version of a package in the lockfile.
@@ -77,17 +98,21 @@ export class LockfileReader extends Context.Tag("@spencerbeggs/workspaces-effect
 		 * @param packageName - The npm package name to look up (e.g., `"react"`).
 		 * @returns An Effect that succeeds with `Option.some(resolvedPackage)` if the
 		 *   package is found in the lockfile, or `Option.none()` if it is not present.
+		 *   Fails with a {@link LockfileInitError} variant on first invocation if
+		 *   initialization fails.
 		 */
-		readonly resolvedVersion: (packageName: string) => Effect.Effect<Option.Option<ResolvedPackage>>;
+		readonly resolvedVersion: (packageName: string) => Effect.Effect<Option.Option<ResolvedPackage>, LockfileInitError>;
 
 		/**
 		 * Get all workspace-to-workspace dependency links from the lockfile.
 		 *
 		 * @returns An Effect that succeeds with a readonly array of
 		 *   {@link WorkspaceDependency} records representing inter-workspace
-		 *   dependency relationships as declared in the lockfile.
+		 *   dependency relationships as declared in the lockfile. Fails with a
+		 *   {@link LockfileInitError} variant on first invocation if initialization
+		 *   fails.
 		 */
-		readonly workspaceDependencies: () => Effect.Effect<ReadonlyArray<WorkspaceDependency>>;
+		readonly workspaceDependencies: () => Effect.Effect<ReadonlyArray<WorkspaceDependency>, LockfileInitError>;
 
 		/**
 		 * Verify lockfile integrity against the current `package.json` files.
@@ -97,8 +122,9 @@ export class LockfileReader extends Context.Tag("@spencerbeggs/workspaces-effect
 		 *
 		 * @returns An Effect that succeeds with a {@link LockfileIntegrity} report, or
 		 *   fails with {@link LockfileIntegrityError} if critical integrity violations
-		 *   are detected.
+		 *   are detected. May also fail with a {@link LockfileInitError} variant on
+		 *   first invocation if initialization fails.
 		 */
-		readonly checkIntegrity: () => Effect.Effect<LockfileIntegrity, LockfileIntegrityError>;
+		readonly checkIntegrity: () => Effect.Effect<LockfileIntegrity, LockfileIntegrityError | LockfileInitError>;
 	}
 >() {}


### PR DESCRIPTION
## Summary

- Wraps the eager initialization in `LockfileReaderLive` and `WorkspaceDiscoveryLive` (root walk, PM detect, lockfile read, parse, pnpm-name resolution, default-root lookup) in `Effect.cached` so layer construction is O(1) and the I/O cost is paid once on first method call.
- Exports a new `LockfileInitError` alias = `WorkspaceRootNotFoundError | PackageManagerDetectionError | LockfileReadError | LockfileParseError`. Errors that previously failed `Layer.provide` now surface from the first invocation of `readLockfile`, `resolvedVersion`, `workspaceDependencies`, or `checkIntegrity`.
- Adds laziness regression tests for both layers (asserting no I/O at construction, init runs exactly once across multiple method calls).
- Closes #60.

## Why

Consumers that build a layer per call site — Vitest reporters with multiple projects, CLIs that compose layers per subcommand, tests that swap layers between cases — were paying the eager initialization cost N times. Downstream `vitest-agent-reporter` measured a 10× wall-clock improvement (44s → 4.3s) on a five-project monorepo with the equivalent workaround.

## Breaking Changes

`LockfileReader` service method signatures now expose `LockfileInitError` in their error channels. Programs that relied on construction-time failure should move error handling to the call site. Programs that already wrap a method in `Effect.runPromise` will continue to see failures, just routed through the program's error channel rather than the layer's.

## Test plan

- [x] `pnpm run typecheck` clean
- [x] `pnpm run lint` clean (only pre-existing unrelated warnings)
- [x] `pnpm vitest run` — 283 unit + 142 integration tests pass (4 new laziness tests)
- [x] Changeset validates (`pnpm exec savvy-changesets check .changeset`)
- [ ] Verify CI passes
- [ ] Verify downstream `vitest-agent-reporter` can drop its workaround once published

Signed-off-by: C. Spencer Beggs <spencer@beggs.codes>