### PR TITLE
docs: sweep stale design-doc references and counts

### DIFF
--- a/.changeset/doc-debt-sweep.md
+++ b/.changeset/doc-debt-sweep.md
@@ -1,0 +1,28 @@
+---
+"workspaces-effect": patch
+---
+
+## Documentation
+
+Address eight stale design-doc audit issues (#47, #48, #49, #50, #51, #54,
+#55, #57). No code changes.
+
+- `architecture.md`: corrected error-type count from 11 to 12 (missing
+  `LockfileIntegrityError`); added the optional `cwd` parameter to the
+  documented `WorkspaceDiscovery` method signatures.
+- `CLAUDE.md`: removed two stale references to a non-existent `pkgs/`
+  directory and replaced the example test command with a single-package
+  equivalent; updated the code-review summary from "5/10 fixed" to
+  "6/10 fixed".
+- `code-review-findings.md`: replaced the open-ended "Should fix soon"
+  marker on Issue 3 (`/**` glob) with a reference to the new GitHub issue
+  #62 that tracks the fix.
+- `phase4-configuration-lockfiles.md`: replaced the stale, self-referential
+  composite layer example with the real `Layer.mergeAll` shape from
+  `src/layers/WorkspacesLive.ts`.
+- `phase3-change-detection.md`: corrected the false claim that
+  `ChangeDetectorLive` does not resolve `CommandExecutor`; the layer does
+  yield it inside `Layer.effect` so service methods have `R = never`.
+- `research-notes.md`: promoted from `draft`/60 % to `current`/100 % and
+  added a header marking the document as historical reference material that
+  informed the architecture rather than a prescriptive spec.

--- a/.claude/design/architecture.md
+++ b/.claude/design/architecture.md
@@ -145,14 +145,19 @@ The library provides 9 services organized into four groups:
 
 WorkspaceDiscovery methods:
 
-- `listPackages()` -- returns all workspace packages **including the root
+- `listPackages(cwd?)` -- returns all workspace packages **including the root
   workspace package** as the first entry (breaking change from Issue #12).
   The root package has `relativePath: "."`. Consumers can filter using
   `isRootWorkspace` getter if they need only non-root packages.
-- `getPackage(name)` -- resolves any package by name (including root).
-- `importerMap()` -- returns `ReadonlyMap<string, WorkspacePackage>` keyed by
-  `relativePath`. Built from `listPackages()` and inherits its caching.
-  Supports lockfile importer-to-package mapping use cases.
+  When `cwd` is provided, the workspace root is resolved fresh from that
+  directory (results cached per resolved root); when omitted, uses the root
+  eagerly resolved from `process.cwd()` at layer construction time.
+- `getPackage(name, cwd?)` -- resolves any package by name (including root).
+  `cwd` semantics match `listPackages`.
+- `importerMap(cwd?)` -- returns `ReadonlyMap<string, WorkspacePackage>` keyed
+  by `relativePath`. Built from `listPackages()` and inherits its caching.
+  Supports lockfile importer-to-package mapping use cases. `cwd` semantics
+  match `listPackages`.
 
 ### Group 2: Package Analysis
 
@@ -293,7 +298,7 @@ Compares all 4 dep types combined. Located in `src/schemas/core.ts`.
 
 ## Error Hierarchy
 
-11 error types using `Data.TaggedError` with exported `*Base` constants for
+12 error types using `Data.TaggedError` with exported `*Base` constants for
 api-extractor DTS bundling. All have computed `message` getters.
 
 | Error | Phase | When Raised |

--- a/.claude/design/code-review-findings.md
+++ b/.claude/design/code-review-findings.md
@@ -157,9 +157,10 @@ non-workspace repos. No guard that the path is actually a workspace root.
   `peerDependencies` and `optionalDependencies` fields. Phase 2 graph
   can now optionally include peer deps.
 
-**Should fix soon**:
+**Tracked in GitHub issues**:
 
-- Issue 3 (`/**` glob) — affects Yarn Berry users
+- Issue 3 (`/**` glob) — affects Yarn Berry users; tracked in
+  [#62](https://github.com/spencerbeggs/workspaces-effect/issues/62)
 
 **Nice to have**:
 

--- a/.claude/design/phase3-change-detection.md
+++ b/.claude/design/phase3-change-detection.md
@@ -355,16 +355,21 @@ const ChangeDetectorLive: Layer.Layer<
   Effect.gen(function* () {
     const resolver = yield* PackageResolver
     const graph = yield* DependencyGraph
-    // CommandExecutor is accessed implicitly via Command.string/Command.lines
+    const executor = yield* CommandExecutor.CommandExecutor
+    // git helpers close over `executor`, so service methods have R = never
     return { changedFiles, changedPackages, affectedPackages }
   }),
 )
 ```
 
-**Important**: The `Command.string` and `Command.lines` functions
-require `CommandExecutor` in the R channel. The ChangeDetectorLive layer
-does NOT resolve CommandExecutor — it passes through as a requirement,
-letting consumers provide `NodeContext.layer` or `BunContext.layer`.
+**Important**: `CommandExecutor` is resolved at layer construction time
+(yielded inside `Layer.effect`) so that all service methods have
+`R = never`, matching the project convention documented in `CLAUDE.md`
+and in `architecture.md`. The git helpers (`runGit`, `runGitLines`,
+`checkGit` in `src/layers/ChangeDetectorLive.ts`) close over the
+resolved `executor`. `CommandExecutor` still appears in the layer's
+requirements, so consumers must provide it via `NodeContext.layer` or
+`BunContext.layer`.
 
 ### Composite layer
 

--- a/.claude/design/phase4-configuration-lockfiles.md
+++ b/.claude/design/phase4-configuration-lockfiles.md
@@ -497,20 +497,46 @@ concern, not a per-query concern.
 
 ### Composite layer
 
-```typescript
-// All Phase 4 services (includes Discovery for WorkspaceRoot)
-const WorkspacesLive: Layer.Layer<
-  LockfileReader,
-  LockfileReadError | LockfileParseError,
-  WorkspaceRoot | PackageManagerDetector | FileSystem | Path
-> = LockfileReaderLive
+`LockfileReaderLive` ships as part of the top-level `WorkspacesLive` composite
+in `src/layers/WorkspacesLive.ts`, alongside the other six core services:
 
-// Full stack: Discovery + Configuration
-const WorkspacesFullLive = WorkspacesLive.pipe(
-  Layer.provide(WorkspacesLive),
+```typescript
+// All services except git-dependent ones
+// Requires: FileSystem + Path
+export const WorkspacesLive = Layer.mergeAll(
+  WorkspaceRootLive,
+  PackageManagerDetectorLive,
+  WorkspaceDiscoveryLive.pipe(Layer.provide(WorkspaceRootLive)),
+  DependencyGraphLive.pipe(
+    Layer.provide(WorkspaceDiscoveryLive),
+    Layer.provide(WorkspaceRootLive),
+  ),
+  TopologicalSorterLive.pipe(
+    Layer.provide(DependencyGraphLive),
+    Layer.provide(WorkspaceDiscoveryLive),
+    Layer.provide(WorkspaceRootLive),
+  ),
+  LockfileReaderLive.pipe(
+    Layer.provide(WorkspaceRootLive),
+    Layer.provide(PackageManagerDetectorLive),
+  ),
+  PublishabilityDetectorLive, // pure layer, no dependencies
 )
-// Type: Layer.Layer<LockfileReader, LockfileReadError | LockfileParseError, FileSystem | Path>
+
+// Full stack: adds git-dependent services
+// Requires: FileSystem + Path + CommandExecutor
+export const WorkspacesFullLive = Layer.mergeAll(
+  WorkspacesLive,
+  PackageResolverLive.pipe(Layer.provide(WorkspacesLive)),
+  ChangeDetectorLive.pipe(
+    Layer.provide(PackageResolverLive),
+    Layer.provide(WorkspacesLive),
+  ),
+)
 ```
+
+See `architecture.md` (Layer Composition) for the canonical description of
+the composite layer shapes.
 
 ## Testing Strategy
 

--- a/.claude/design/research-notes.md
+++ b/.claude/design/research-notes.md
@@ -2,11 +2,11 @@
 title: "Research Notes: Sibling Repos & Effect Patterns"
 module: core
 category: reference
-status: draft
-completeness: 60
+status: current
+completeness: 100
 created: 2026-03-12
-updated: 2026-03-14
-last-synced: 2026-04-15
+updated: 2026-05-02
+last-synced: 2026-05-02
 related:
   - architecture.md
   - effect-patterns-core.md
@@ -19,6 +19,15 @@ tags:
 ---
 
 ## Research Notes: Sibling Repos & Effect Patterns
+
+> **Status**: Reference material, not prescriptive. This document captures the
+> sibling-repo and Effect-docs research that informed the initial design of
+> `workspaces-effect`. The patterns selected from this research were absorbed
+> into `architecture.md` and the `effect-patterns-*.md` documents — those are
+> the authoritative sources for current architecture. This file is preserved
+> as historical context for *why* particular patterns were chosen (and others
+> rejected). Do not treat the catalog below as the current state of the
+> implementation; consult the architecture docs or the source for that.
 
 <!-- TOC -->
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,7 +55,7 @@ Load these when working on the corresponding area:
 - `.claude/design/lockfile-reader-service.md` — LockfileReader service interface
 - `.claude/design/lockfile-schemas.md` — all 4 lockfile format schemas
 - `.claude/design/bun-lockfile.md` — bun.lock JSONC format reference
-- `.claude/design/code-review-findings.md` — known issues (5/10 fixed)
+- `.claude/design/code-review-findings.md` — known issues (6/10 fixed)
 - `.claude/design/research-notes.md` — patterns from sibling repos
 
 ## Key Conventions
@@ -100,21 +100,23 @@ pnpm run build:prod        # Build production/npm output only
 ### Running a Single Test
 
 ```bash
-# Run tests for a specific package (replace with actual package name)
-pnpm run test -- --filter=@spencerbeggs/<package-name>
-
 # Run a specific test file
-pnpm vitest run pkgs/<package-name>/__test__/index.test.ts
+pnpm vitest run __test__/layers/DependencyGraphLive.test.ts
+
+# Filter tests by name pattern
+pnpm vitest run -t "lockfile integrity"
 ```
 
 ## Architecture
 
-### Monorepo Structure
+### Repository Structure
 
-- **Package Manager**: pnpm with workspaces
+- **Package Manager**: pnpm (single-package workspace; `pnpm-workspace.yaml`
+  declares `packages: [.]`)
 - **Build Orchestration**: Turbo for caching and task dependencies
-- **Packages**: Located in `pkgs/` directory
-- **Shared Configs**: Located in `lib/configs/`
+- **Source**: `src/` (services, layers, errors, schemas, utils)
+- **Tests**: `__test__/` (unit, integration, fixtures, shared utilities)
+- **Shared Configs**: `lib/configs/`
 
 ### Package Build Pipeline
 


### PR DESCRIPTION
## Summary

Stacks on top of #61. Addresses 8 open design-docs issues uncovered by an audit while the lazy-layers PR is in review. All edits are pure documentation; no code changes.

| Issue | File | Fix |
| --- | --- | --- |
| #47 | architecture.md | 11 -> 12 error types |
| #48 | architecture.md | WorkspaceDiscovery method bullets gain optional cwd parameter |
| #49 | CLAUDE.md | Drop nonexistent pkgs/ references; rewrite Repository Structure for single-package layout |
| #50 | research-notes.md | Promoted draft 60% -> current 100% with reference-material header |
| #51 | code-review-findings.md | Single-level glob bug now linked to new tracking issue #62 |
| #54 | phase4-configuration-lockfiles.md | Composite layer section rewritten to match Layer.mergeAll shape |
| #55 | phase3-change-detection.md | Corrected: CommandExecutor IS resolved at construction |
| #57 | CLAUDE.md | 5/10 fixed -> 6/10 fixed for code-review-findings count |

A new GitHub issue (#62) was opened to track the remaining single-level glob bug.

## Decisions of note

- **#50** — Marked research-notes.md as historical reference rather than archiving. The doc captures lineage of design decisions (e.g., why class-based Context.Tag) that current architecture docs assume rather than re-explain. Promoted to current/100% with a header pointing readers to architecture.md / effect-patterns-*.md for current truth.
- **#51** — Filed #62 with reproduction, root cause, affected users, and suggested fix. Replaced the Should fix soon note in code-review-findings.md with a Tracked in GitHub issues link.

## Test plan

- [x] pnpm exec savvy-changesets check .changeset
- [x] pnpm run typecheck
- [x] pnpm vitest run (283 unit + 142 integration = 425 tests)
- [ ] CI passes
- [ ] Verify each Closes #N in the commit auto-closes its issue on merge

## Stacking

Branched from perf/lazy-layers-issue-60 to avoid touching files PR #61 already modifies (architecture.md, CLAUDE.md). Should rebase to main automatically once #61 lands; alternatively merge #61 first then merge this.

Signed-off-by: C. Spencer Beggs <spencer@beggs.codes>