### PR TITLE
docs: daily routine improvements 2026-05-03

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,7 +82,7 @@ pnpm run test:watch
 pnpm run test:coverage
 
 # Run a specific test file
-pnpm vitest run src/layers/DependencyGraphLive.test.ts
+pnpm vitest run __test__/layers/DependencyGraphLive.test.ts
 ```
 
 ## TypeScript

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![npm version](https://img.shields.io/npm/v/workspaces-effect)](https://www.npmjs.com/package/workspaces-effect)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
-[![TypeScript](https://img.shields.io/badge/TypeScript-5.9-blue.svg)](https://www.typescriptlang.org/)
+[![TypeScript](https://img.shields.io/badge/TypeScript-6.0-blue.svg)](https://www.typescriptlang.org/)
 
 An [Effect](https://effect.website) library for monorepo workspace tooling. Discover workspaces, analyze dependency graphs, detect changes, parse lockfiles, and check publishability across npm, pnpm, yarn Berry and Bun through composable Effect services with typed errors and platform independence.
 

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -33,7 +33,7 @@ You choose the Effect and platform versions. workspaces-effect requires
 ## Prerequisites
 
 - A monorepo using npm, pnpm, yarn Berry, or Bun workspaces
-- Node.js 22+ or Bun 1.0+
+- Node.js 24+ or Bun 1.0+
 - Effect 3.x
 
 Workspace configuration is recommended but not required:


### PR DESCRIPTION
## Changes

- `README.md`: Update TypeScript badge from `5.9` to `6.0` (matches actual installed `typescript@6.0.3`)
- `CONTRIBUTING.md`: Fix test file path in example — `src/layers/DependencyGraphLive.test.ts` → `__test__/layers/DependencyGraphLive.test.ts` (tests live in `__test__/`, not `src/`)
- `docs/guides/getting-started.md`: Update Node.js prerequisite from `22+` to `24+` (matches `devEngines.runtime[0].version: 24.11.0` in `package.json`)

## Verification

All three changes were verified against actual repo state:
- TypeScript version: confirmed via `pnpm-lock.yaml` (`typescript@6.0.3`)
- Test path: confirmed via `git ls-files __test__/layers/DependencyGraphLive.test.ts`
- Node.js version: confirmed via `package.json` `devEngines` field

Filed automatically by daily Routine. Close if not wanted — no follow-up needed.

---
_Generated by [Claude Code](https://claude.ai/code/session_0154LEpS7Uk5sTqFg3NHT2jD)_