### PR TITLE
docs: daily routine improvements 2026-05-04

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,7 +82,7 @@ pnpm run test:watch
 pnpm run test:coverage
 
 # Run a specific test file
-pnpm vitest run src/layers/DependencyGraphLive.test.ts
+pnpm vitest run __test__/layers/DependencyGraphLive.test.ts
 ```
 
 ## TypeScript

--- a/docs/01-getting-started.md
+++ b/docs/01-getting-started.md
@@ -181,19 +181,17 @@ if (root) {
 
 ### getWorkspacePackagesSync
 
-Reads workspace patterns from `pnpm-workspace.yaml` or `package.json`, resolves each pattern to a directory, and returns `{ name, path }` for every match. Returns `null` if the root directory does not exist.
+Reads workspace patterns from `pnpm-workspace.yaml` or `package.json`, resolves each pattern to a directory, and returns a `ReadonlyArray<WorkspacePackage>` with the root workspace first. Throws if the root directory does not exist or if the root `package.json` is missing a required `name` or `version` field.
 
-The Effect-based `listPackages()` includes the root workspace; this function does **not**. It returns only packages matched by workspace patterns.
+The root workspace is always the first entry in the result, matching `listPackages()` behavior. Use the `isRootWorkspace` getter to filter it out when you only need child packages.
 
 ```typescript
 const root = findWorkspaceRootSync();
 if (root) {
   const packages = getWorkspacePackagesSync(root);
-  if (packages) {
-    for (const pkg of packages) {
-      console.log(`${pkg.name} at ${pkg.path}`);
-      // example output (varies by repo): "@myorg/utils at /workspace/packages/utils"
-    }
+  for (const pkg of packages) {
+    console.log(`${pkg.name} at ${pkg.path}`);
+    // example output (varies by repo): "@myorg/utils at /workspace/packages/utils"
   }
 }
 ```
@@ -225,8 +223,8 @@ export default {
 | | Effect API | Sync API |
 | --- | --- | --- |
 | **Import** | services + layers | standalone functions |
-| **Error handling** | typed `TaggedError` values | returns `null` on failure |
-| **Root package** | `listPackages()` includes root | `getWorkspacePackagesSync` excludes root |
+| **Error handling** | typed `TaggedError` values | throws on missing root or invalid package.json |
+| **Root package** | `listPackages()` includes root | `getWorkspacePackagesSync` includes root (as first entry) |
 | **Caching** | per-layer request caching | no caching (re-reads on each call) |
 | **Platform** | `@effect/platform` (Node, Bun) | `node:fs` and `node:path` directly |
 | **Observability** | spans + structured logging | none |


### PR DESCRIPTION
## Summary

- **CONTRIBUTING.md**: Fix stale test file path `src/layers/DependencyGraphLive.test.ts` → `__test__/layers/DependencyGraphLive.test.ts`. Tests have always lived in `__test__/` per the `@savvy-web/vitest` discovery convention; the path in the contributing guide pointed at a file that does not exist.

- **docs/01-getting-started.md** (`getWorkspacePackagesSync` section): Correct three factual errors in the sync API description:
  1. The function returns `ReadonlyArray<WorkspacePackage>`, not `{ name, path }[]`
  2. The root workspace **is** the first entry (not excluded); matches `listPackages()` behavior per the breaking change in Issue #12
  3. The function **throws** on a missing root or invalid package.json (not returns `null`) — updated the Differences table accordingly and removed the incorrect `if (packages)` null-guard from the code example

These errors were introduced in the `docs: standardize` commit (`610797d`) and contradict both the actual `src/sync.ts` implementation and the JSDoc on `getWorkspacePackagesSync`.

Related: #67 (architecture.md has the same root-package claim in the design docs — that is a separate fix)

## Test plan

- [ ] Verify `__test__/layers/DependencyGraphLive.test.ts` exists on disk
- [ ] Verify `src/sync.ts` → `getWorkspacePackagesSync` JSDoc says root is first entry
- [ ] Spot-check the updated code example runs correctly against the library

Filed automatically by daily Routine. Close if not wanted — no follow-up needed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AHMrLip2KLAoTsnQzxrn8p)_