### PR TITLE
docs: daily routine improvements 2026-05-05

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,7 +82,7 @@ pnpm run test:watch
 pnpm run test:coverage
 
 # Run a specific test file
-pnpm vitest run src/layers/DependencyGraphLive.test.ts
+pnpm vitest run __test__/layers/DependencyGraphLive.test.ts
 ```
 
 ## TypeScript

--- a/docs/01-getting-started.md
+++ b/docs/01-getting-started.md
@@ -183,7 +183,7 @@ if (root) {
 
 Reads workspace patterns from `pnpm-workspace.yaml` or `package.json`, resolves each pattern to a directory, and returns `{ name, path }` for every match. Returns `null` if the root directory does not exist.
 
-The Effect-based `listPackages()` includes the root workspace; this function does **not**. It returns only packages matched by workspace patterns.
+Like the Effect-based `listPackages()`, this function includes the root workspace as the first entry in the returned array.
 
 ```typescript
 const root = findWorkspaceRootSync();
@@ -226,7 +226,7 @@ export default {
 | --- | --- | --- |
 | **Import** | services + layers | standalone functions |
 | **Error handling** | typed `TaggedError` values | returns `null` on failure |
-| **Root package** | `listPackages()` includes root | `getWorkspacePackagesSync` excludes root |
+| **Root package** | `listPackages()` includes root | `getWorkspacePackagesSync` includes root |
 | **Caching** | per-layer request caching | no caching (re-reads on each call) |
 | **Platform** | `@effect/platform` (Node, Bun) | `node:fs` and `node:path` directly |
 | **Observability** | spans + structured logging | none |


### PR DESCRIPTION
## Summary

- **CONTRIBUTING.md** — Fix stale test file path in the "Run a specific test file" example: `src/layers/DependencyGraphLive.test.ts` → `__test__/layers/DependencyGraphLive.test.ts`. Test files live under `__test__/`, not `src/`; the source implementation is at `src/layers/DependencyGraphLive.ts`.

- **docs/01-getting-started.md** (lines 186 and 229) — Correct two claims that `getWorkspacePackagesSync` excludes the root package. The implementation (`src/sync.ts:279`) always places the root package as the first entry in the returned array, matching the `listPackages()` behaviour. The table row and the prose description both said "excludes root", which is the opposite of what the code does.

## Related issues

The root-inclusion claim is the user-docs counterpart of the design-doc error reported in #67 (architecture.md has the same incorrect claim).

## Notes

Filed automatically by daily Routine. Close if not wanted — no follow-up needed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WJzJBw9rkN6Ex1QVLfRj47)_