### PR TITLE
docs: daily routine improvements 2026-05-09

### DIFF
--- a/docs/01-getting-started.md
+++ b/docs/01-getting-started.md
@@ -183,7 +183,7 @@ if (root) {
 
 Reads workspace patterns from `pnpm-workspace.yaml` or `package.json`, resolves each pattern to a directory, and returns `{ name, path }` for every match. Returns `null` if the root directory does not exist.
 
-The Effect-based `listPackages()` includes the root workspace; this function does **not**. It returns only packages matched by workspace patterns.
+Like the Effect-based `listPackages()`, this function includes the root workspace as the first entry. Child packages matched by workspace patterns follow in sorted order.
 
 ```typescript
 const root = findWorkspaceRootSync();
@@ -226,7 +226,7 @@ export default {
 | --- | --- | --- |
 | **Import** | services + layers | standalone functions |
 | **Error handling** | typed `TaggedError` values | returns `null` on failure |
-| **Root package** | `listPackages()` includes root | `getWorkspacePackagesSync` excludes root |
+| **Root package** | `listPackages()` includes root | `getWorkspacePackagesSync` includes root as first entry |
 | **Caching** | per-layer request caching | no caching (re-reads on each call) |
 | **Platform** | `@effect/platform` (Node, Bun) | `node:fs` and `node:path` directly |
 | **Observability** | spans + structured logging | none |


### PR DESCRIPTION
## Summary

- **`docs/01-getting-started.md`**: Fix incorrect statement that `getWorkspacePackagesSync` excludes the root workspace. The actual implementation in `src/sync.ts` always includes the root package as the first entry, matching the behavior of the Effect-based `listPackages()`. Two places were wrong:
  - The description under `### getWorkspacePackagesSync` said "this function does **not**" include root
  - The "Differences" comparison table had `getWorkspacePackagesSync` listed as "excludes root"

The JSDoc on `getWorkspacePackagesSync` in `sync.ts` is correct ("The root package is always the first entry, matching the behavior of the Effect-based `WorkspaceDiscovery.listPackages()`") — only the user-facing doc was wrong.

## Related

- Companion design-doc issue filed for `architecture.md` root-package claim: #67

## Notes

Filed automatically by daily Routine. Close if not wanted — no follow-up needed.


---
_Generated by [Claude Code](https://claude.ai/code/session_01EpCMoR2wTiZvzgmfnvgUyB)_