### PR TITLE
docs: daily routine improvements 2026-05-11

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,7 +82,7 @@ pnpm run test:watch
 pnpm run test:coverage
 
 # Run a specific test file
-pnpm vitest run src/layers/DependencyGraphLive.test.ts
+pnpm vitest run __test__/layers/DependencyGraphLive.test.ts
 ```
 
 ## TypeScript

--- a/docs/09-troubleshooting.md
+++ b/docs/09-troubleshooting.md
@@ -16,6 +16,7 @@ Reference for every error type in workspaces-effect. All errors extend `Data.Tag
 - [LockfileReadError](#lockfilereaderror)
 - [LockfileParseError](#lockfileparseerror)
 - [LockfileIntegrityError](#lockfileintegrityerror)
+- [LockfileInitError union](#lockfileiniterror-union)
 - [Platform layer missing](#platform-layer-missing)
 
 ---
@@ -337,6 +338,33 @@ Effect.catchTag("LockfileIntegrityError", (e) =>
 
 ---
 
+## LockfileInitError union
+
+`LockfileInitError` is a type alias, not a concrete error class. It groups the four errors that can surface from `LockfileReader` methods when lazy initialization runs for the first time:
+
+```typescript
+import type { LockfileInitError } from "workspaces-effect";
+
+// LockfileInitError =
+//   | WorkspaceRootNotFoundError
+//   | PackageManagerDetectionError
+//   | LockfileReadError
+//   | LockfileParseError
+```
+
+All four `LockfileReader` methods — `readLockfile`, `resolvedVersion`, `workspaceDependencies`, `checkIntegrity` — include `LockfileInitError` in their E channel because the workspace-root walk, package-manager detection, lockfile read, and lockfile parse are deferred to the first call. Handle the individual errors at the call site using `Effect.catchTag`:
+
+```typescript
+Effect.catchTag("WorkspaceRootNotFoundError", (e) => ...)
+Effect.catchTag("PackageManagerDetectionError", (e) => ...)
+Effect.catchTag("LockfileReadError", (e) => ...)
+Effect.catchTag("LockfileParseError", (e) => ...)
+```
+
+Each constituent error is documented in its own section above. See [Lazy lockfile and discovery initialization](../README.md#lazy-lockfile-and-discovery-initialization) for the full explanation.
+
+---
+
 ## Platform layer missing
 
 **Symptom:** Type error about a missing `FileSystem`, `Path` or `CommandExecutor` in the Effect context.
@@ -359,7 +387,7 @@ program.pipe(
 );
 ```
 
-1. For change detection, switch to `WorkspacesFullLive`:
+2. For change detection, switch to `WorkspacesFullLive`:
 
 ```typescript
 program.pipe(


### PR DESCRIPTION
## Summary

- **`CONTRIBUTING.md`**: Fix stale test path in the "Run a specific test file" example. Tests moved from `src/layers/` to `__test__/layers/` in commit `7841a2a` (feat: fix lockfile parsing and restructure tests #19); the example still pointed at the old location.
- **`docs/09-troubleshooting.md`**: Add a `LockfileInitError union` section documenting the exported `LockfileInitError` type alias. It groups the four init-phase errors that appear in all `LockfileReader` method E channels after the lazy-init refactor (Issue #60). The type is already documented in the README and `docs/08-services-reference.md` but was absent from the error-reference guide.
- **`docs/09-troubleshooting.md`**: Fix duplicate `1.` numbering in the "Platform layer missing" solutions list — both items were numbered `1.`; the second is now `2.`.

## Related issues

- Lazy init (Issue #60) introduced `LockfileInitError` — the troubleshooting guide lagged behind.

Filed automatically by daily Routine. Close if not wanted — no follow-up needed.

---
_Generated by [Claude Code](https://claude.ai/code/session_013xinZDMHiCyGYGLYdur3iT)_