### PR TITLE
docs: daily routine improvements 2026-05-12

### DIFF
--- a/docs/01-getting-started.md
+++ b/docs/01-getting-started.md
@@ -181,19 +181,16 @@ if (root) {
 
 ### getWorkspacePackagesSync
 
-Reads workspace patterns from `pnpm-workspace.yaml` or `package.json`, resolves each pattern to a directory, and returns `{ name, path }` for every match. Returns `null` if the root directory does not exist.
-
-The Effect-based `listPackages()` includes the root workspace; this function does **not**. It returns only packages matched by workspace patterns.
+Reads workspace patterns from `pnpm-workspace.yaml` or `package.json`, resolves each pattern to a directory, and returns a `WorkspacePackage` for every match. The root package is always the first entry, matching the behaviour of the Effect-based `listPackages()`. Throws if the root directory does not exist or if the root `package.json` is missing a `name` or `version` field.
 
 ```typescript
 const root = findWorkspaceRootSync();
 if (root) {
   const packages = getWorkspacePackagesSync(root);
-  if (packages) {
-    for (const pkg of packages) {
-      console.log(`${pkg.name} at ${pkg.path}`);
-      // example output (varies by repo): "@myorg/utils at /workspace/packages/utils"
-    }
+  for (const pkg of packages) {
+    console.log(`${pkg.name} at ${pkg.path}`);
+    // example output (varies by repo): "@myorg/root at /workspace"
+    // example output (varies by repo): "@myorg/utils at /workspace/packages/utils"
   }
 }
 ```
@@ -225,8 +222,8 @@ export default {
 | | Effect API | Sync API |
 | --- | --- | --- |
 | **Import** | services + layers | standalone functions |
-| **Error handling** | typed `TaggedError` values | returns `null` on failure |
-| **Root package** | `listPackages()` includes root | `getWorkspacePackagesSync` excludes root |
+| **Error handling** | typed `TaggedError` values | `findWorkspaceRootSync` returns `null`; `getWorkspacePackagesSync` throws |
+| **Root package** | `listPackages()` includes root | `getWorkspacePackagesSync` includes root (as first entry) |
 | **Caching** | per-layer request caching | no caching (re-reads on each call) |
 | **Platform** | `@effect/platform` (Node, Bun) | `node:fs` and `node:path` directly |
 | **Observability** | spans + structured logging | none |


### PR DESCRIPTION
## Summary

- **Fix false root-exclusion claim in `docs/01-getting-started.md`**: The `getWorkspacePackagesSync` description incorrectly stated "this function does **not** include the root workspace." The actual implementation (`src/sync.ts:279`) always prepends `rootPkg` as the first entry, matching `listPackages()` behaviour. The comparison table row for "Root package" has been corrected from "excludes root" to "includes root (as first entry)".
- **Fix false null-return claim**: The description also incorrectly stated "Returns `null` if the root directory does not exist." The function throws a `Error` rather than returning null (return type is `ReadonlyArray<WorkspacePackage>`). The misleading `if (packages)` guard in the code example (which was always truthy) has been removed.
- **Fix error-handling table row**: The "Error handling" comparison row previously said "returns `null` on failure" for the entire Sync API. This is only true for `findWorkspaceRootSync`. The row now distinguishes between the two functions.

## Related issues

Relates to #67 (which tracks the same incorrect root-exclusion claim in `.claude/design/architecture.md`).

## Test plan

- [ ] Verify `src/sync.ts` — `getWorkspacePackagesSync` return type is `ReadonlyArray<WorkspacePackage>` (never null) and `rootPkg` is the first entry (line 279)
- [ ] Verify the updated prose matches the JSDoc on `getWorkspacePackagesSync` (line 235: "The root package is always the first entry")

Filed automatically by daily Routine. Close if not wanted — no follow-up needed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SJgkXtHPmH5cKfxVFD6wZU)_