### PR TITLE
docs: daily routine improvements 2026-05-14

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,7 +82,7 @@ pnpm run test:watch
 pnpm run test:coverage
 
 # Run a specific test file
-pnpm vitest run src/layers/DependencyGraphLive.test.ts
+pnpm vitest run __test__/layers/DependencyGraphLive.test.ts
 ```
 
 ## TypeScript

--- a/docs/01-getting-started.md
+++ b/docs/01-getting-started.md
@@ -190,7 +190,7 @@ Behavior matrix:
 
 ### getWorkspacePackagesSync
 
-Reads workspace patterns from `pnpm-workspace.yaml` or `package.json`, resolves each pattern to a directory, and returns `{ name, path }` for every match. Returns `null` if the root directory does not exist.
+Reads workspace patterns from `pnpm-workspace.yaml` or `package.json`, resolves each pattern to a directory, and returns `{ name, path }` for every match. Throws if the root directory does not exist or the root `package.json` is missing a `name` or `version` field.
 
 The Effect-based `listPackages()` includes the root workspace; this function does **not**. It returns only packages matched by workspace patterns.
 


### PR DESCRIPTION
## Summary

- **CONTRIBUTING.md**: Fix stale test example path — `src/layers/DependencyGraphLive.test.ts` → `__test__/layers/DependencyGraphLive.test.ts`. Tests were moved from `src/layers/` when the test suite was restructured (see commit `7841a2a`); the contributing guide still showed the old path.

- **docs/01-getting-started.md**: Correct the `getWorkspacePackagesSync` description from "Returns `null` if the root directory does not exist" to accurately state that the function **throws** (an `Error`) when the root directory is missing or the root `package.json` lacks `name`/`version`. The function signature is `(root: string): ReadonlyArray<WorkspacePackage>` — it never returns null. Related: design-doc issue #100 tracks the same factual error in `architecture.md`.

## Test plan

- [ ] Read CONTRIBUTING.md — example command now references `__test__/layers/DependencyGraphLive.test.ts`
- [ ] Read docs/01-getting-started.md `getWorkspacePackagesSync` section — description now matches `src/sync.ts:264-266`

Filed automatically by daily Routine. Close if not wanted — no follow-up needed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01415fyg1pMhvFMVcLGyYZyb)_