### PR TITLE
docs: daily routine improvements 2026-05-15

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,7 +82,7 @@ pnpm run test:watch
 pnpm run test:coverage
 
 # Run a specific test file
-pnpm vitest run src/layers/DependencyGraphLive.test.ts
+pnpm vitest run __test__/layers/DependencyGraphLive.test.ts
 ```
 
 ## TypeScript

--- a/docs/01-getting-started.md
+++ b/docs/01-getting-started.md
@@ -234,7 +234,7 @@ export default {
 | | Effect API | Sync API |
 | --- | --- | --- |
 | **Import** | services + layers | standalone functions |
-| **Error handling** | typed `TaggedError` values | returns `null` on failure |
+| **Error handling** | typed `TaggedError` values | returns `null` or throws, depending on the failure |
 | **Root package** | `listPackages()` includes root | `getWorkspacePackagesSync` excludes root |
 | **Caching** | per-layer request caching | no caching (re-reads on each call) |
 | **Platform** | `@effect/platform` (Node, Bun) | `node:fs` and `node:path` directly |

--- a/docs/05-lockfile-parsing.md
+++ b/docs/05-lockfile-parsing.md
@@ -174,7 +174,7 @@ if (lockfile.pmSpecific?._tag === "pnpm") {
     for (const [catalogName, entries] of Object.entries(catalogs)) {
       for (const [pkgName, value] of Object.entries(entries)) {
         // value is either a string (version) or { specifier, version }
-        // pnpm v9+ uses the { specifier, version } format
+        // pnpm v10+ uses the { specifier, version } format; v9 uses plain strings
         if (typeof value === "string") {
           console.log(`${catalogName}/${pkgName}: ${value}`);
         } else {
@@ -196,7 +196,7 @@ if (lockfile.pmSpecific?._tag === "pnpm") {
 }
 ```
 
-The `PnpmExtension.catalogs` value type is `string | { specifier: string; version: string }`. Older pnpm versions store catalog entries as plain version strings. pnpm v9+ stores them as objects holding both the declared specifier and the resolved version.
+The `PnpmExtension.catalogs` value type is `string | { specifier: string; version: string }`. pnpm v9 stores catalog entries as plain version strings. pnpm v10+ stores them as objects holding both the declared specifier and the resolved version.
 
 ### bun extensions
 


### PR DESCRIPTION
## Summary

- **`CONTRIBUTING.md`**: Fix stale test path example — `src/layers/DependencyGraphLive.test.ts` → `__test__/layers/DependencyGraphLive.test.ts`. Tests moved to `__test__/` when the test suite was restructured; the example was never updated.
- **`docs/01-getting-started.md`**: Clarify sync API error-handling row in the comparison table. `findWorkspaceRootSync` can throw (when the git-root boundary has no `package.json`) or return `null` (when not inside any git project) — the old text "returns `null` on failure" was incomplete. The behavior matrix table above in the same file already documented both outcomes correctly.
- **`docs/05-lockfile-parsing.md`**: Correct the pnpm version references for catalog value formats. The inline comment and prose paragraph both said "pnpm v9+" for the `{ specifier, version }` object format, but the design doc (`lockfile-schemas.md`) and CLAUDE.md both state that v9 uses plain version strings and v10+ introduced the object format.

## Test plan

- [ ] Verify `__test__/layers/DependencyGraphLive.test.ts` exists (it does — confirmed by `ls __test__/layers/`)
- [ ] Verify pnpm version reference matches `lockfile-schemas.md` design doc comment (confirmed)
- [ ] Verify `findWorkspaceRootSync` behavior matrix table in the same file already shows `throws` as a possible outcome (confirmed at lines 182–189)

Filed automatically by daily Routine. Close if not wanted — no follow-up needed.

---
_Generated by [Claude Code](https://claude.ai/code/session_011x3hSpHDAvFqx8abDFtZ7x)_