### PR TITLE
docs: daily routine improvements 2026-05-16

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,7 +82,7 @@ pnpm run test:watch
 pnpm run test:coverage
 
 # Run a specific test file
-pnpm vitest run src/layers/DependencyGraphLive.test.ts
+pnpm vitest run __test__/layers/DependencyGraphLive.test.ts
 ```
 
 ## TypeScript

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,8 +6,7 @@
 | --- | --- |
 | Latest | Yes |
 
-This package is pre-release (`< 1.0.0`). Only the latest published version
-receives security fixes.
+Only the latest published version receives security fixes.
 
 ## Reporting a Vulnerability
 

--- a/docs/08-services-reference.md
+++ b/docs/08-services-reference.md
@@ -20,7 +20,7 @@ All services are imported from `"workspaces-effect"`. Service methods have `R = 
 
 ## WorkspaceRoot
 
-Walks up from a given path to find the monorepo root. Markers checked at each level: `pnpm-workspace.yaml`, a `package.json` with a `workspaces` field, or a lockfile.
+Walks up from a given path to find the monorepo root. Markers checked at each level: `pnpm-workspace.yaml`, or a `package.json` with a `workspaces` field.
 
 **Layer:** `WorkspaceRootLive`
 **Platform deps:** `FileSystem`, `Path`


### PR DESCRIPTION
## Summary

Three small, verified fixes to user-facing docs — each confirmed against source code or git history before editing:

- **`CONTRIBUTING.md`**: Fix stale test file path in the "Run a specific test file" example. Tests moved from `src/layers/` to `__test__/layers/` in #19 but the example was never updated. (`src/layers/DependencyGraphLive.test.ts` → `__test__/layers/DependencyGraphLive.test.ts`)

- **`SECURITY.md`**: Remove the pre-release qualifier ("This package is pre-release (`< 1.0.0`)"). Version 1.0.0 shipped in #105.

- **`docs/08-services-reference.md`**: Remove "or a lockfile" from the `WorkspaceRoot` marker description. The actual `WorkspaceRootLive` implementation only checks for `pnpm-workspace.yaml` and `package.json` with a `workspaces` field — no lockfile check exists in the source (`src/layers/WorkspaceRootLive.ts`).

## Related issues

None directly — these are self-contained corrections.

---

Filed automatically by daily Routine. Close if not wanted — no follow-up needed.

---
_Generated by [Claude Code](https://claude.ai/code/session_014nS8TuXk9TQiqwRFvSsLzu)_