### PR TITLE
docs: daily routine improvements 2026-05-17

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,7 +82,7 @@ pnpm run test:watch
 pnpm run test:coverage
 
 # Run a specific test file
-pnpm vitest run src/layers/DependencyGraphLive.test.ts
+pnpm vitest run __test__/layers/DependencyGraphLive.test.ts
 ```
 
 ## TypeScript


### PR DESCRIPTION
## Summary

- Fix stale test file path in `CONTRIBUTING.md`: the single-file vitest example referenced `src/layers/DependencyGraphLive.test.ts`, which was the pre-reorganization location. Tests now live under `__test__/` following the `@savvy-web/vitest` discovery convention. Corrected to `__test__/layers/DependencyGraphLive.test.ts`.

## Test plan

- [ ] Confirm the corrected path (`__test__/layers/DependencyGraphLive.test.ts`) exists in the repo (`git ls-files __test__/layers/DependencyGraphLive.test.ts`)
- [ ] Verify `pnpm vitest run __test__/layers/DependencyGraphLive.test.ts` runs the intended test file

## Related issues

None directly. The test reorganization that caused the drift is reflected in `architecture.md` (Test organization entry) and `CLAUDE.md`.

---

Filed automatically by daily Routine. Close if not wanted — no follow-up needed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FBiMEmSF1SyUwk9QabMHNL)_