### PR TITLE
docs: daily routine improvements 2026-05-18

### DIFF
--- a/docs/01-getting-started.md
+++ b/docs/01-getting-started.md
@@ -190,9 +190,7 @@ Behavior matrix:
 
 ### getWorkspacePackagesSync
 
-Reads workspace patterns from `pnpm-workspace.yaml` or `package.json`, resolves each pattern to a directory, and returns `{ name, path }` for every match. Returns `null` if the root directory does not exist.
-
-The Effect-based `listPackages()` includes the root workspace; this function does **not**. It returns only packages matched by workspace patterns.
+Reads workspace patterns from `pnpm-workspace.yaml` or `package.json`, resolves each pattern to a directory, and returns a `ReadonlyArray<WorkspacePackage>` for every match. The root package is always the first entry. Throws if the root directory does not exist or if the root `package.json` is missing `name` or `version`.
 
 ```typescript
 const root = findWorkspaceRootSync();
@@ -235,7 +233,7 @@ export default {
 | --- | --- | --- |
 | **Import** | services + layers | standalone functions |
 | **Error handling** | typed `TaggedError` values | returns `null` on failure |
-| **Root package** | `listPackages()` includes root | `getWorkspacePackagesSync` excludes root |
+| **Root package** | `listPackages()` includes root | `getWorkspacePackagesSync` includes root (first entry) |
 | **Caching** | per-layer request caching | no caching (re-reads on each call) |
 | **Platform** | `@effect/platform` (Node, Bun) | `node:fs` and `node:path` directly |
 | **Observability** | spans + structured logging | none |

--- a/docs/07-architecture-overview.md
+++ b/docs/07-architecture-overview.md
@@ -146,7 +146,7 @@ Both context layers provide `FileSystem`, `Path` and `CommandExecutor`, so eithe
 Some callers cannot run an Effect — lint-staged handlers and synchronous config files are the usual culprits. Two plain functions are exported for those cases:
 
 - `findWorkspaceRootSync(cwd?)` walks up from `cwd` (default `process.cwd()`). At each level it checks for `pnpm-workspace.yaml`, then `package.json` with a `workspaces` field. Ascent stops at the first `.git` it encounters — if that directory also has a `package.json`, it returns the directory (single-package repo); if not, it throws. The walk returns `null` only when no `.git` is found before the filesystem root, i.e. `cwd` is not inside any git project.
-- `getWorkspacePackagesSync(root)` returns `ReadonlyArray<{ name: string; path: string }>` or `null`.
+- `getWorkspacePackagesSync(root)` returns `ReadonlyArray<WorkspacePackage>` with the root package as the first entry. Throws if the root directory does not exist or its `package.json` is missing required fields.
 
 These use `node:fs` and `node:path` directly, so they are Node-only and bypass the platform abstraction. There is no caching and no logging. See the [Getting started](./01-getting-started.md#synchronous-utilities) guide for examples.
 


### PR DESCRIPTION
## Summary

Three corrections to the sync API documentation — all verified against `src/sync.ts`:

- **`docs/01-getting-started.md`** — Update `getWorkspacePackagesSync` description: the function returns `ReadonlyArray<WorkspacePackage>` (not `{ name, path }` objects), includes the root package as the first entry, and throws when the root directory is missing or its `package.json` lacks required fields (it does not return `null`).
- **`docs/01-getting-started.md`** — Fix comparison table row: "Root package | `getWorkspacePackagesSync` excludes root" → "includes root (first entry)", matching actual `src/sync.ts` behaviour where `const packages: WorkspacePackage[] = [rootPkg]` always prepends the root.
- **`docs/07-architecture-overview.md`** — Fix one-liner signature from `ReadonlyArray<{ name: string; path: string }> or null` to `ReadonlyArray<WorkspacePackage>` with throw semantics.

These errors stem from the WorkspacePackage enrichment changes (Issue #12) that changed the sync API's return type and root-inclusion behaviour. Related design-doc tracking: #67 (architecture.md has the same root-exclusion claim), #100 (architecture.md wrong return type).

## Test plan

- [ ] Read `src/sync.ts` — confirms `getWorkspacePackagesSync` returns `ReadonlyArray<WorkspacePackage>`, includes `rootPkg` as first entry, and throws (not returns null) on missing root
- [ ] Verify prose in `docs/01-getting-started.md` matches the source
- [ ] Verify one-liner in `docs/07-architecture-overview.md` matches the source

Filed automatically by daily Routine. Close if not wanted — no follow-up needed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01924MSshAwjmVqmPEU2iNBH)_