### PR TITLE
docs: daily routine improvements 2026-05-19

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,7 +82,7 @@ pnpm run test:watch
 pnpm run test:coverage
 
 # Run a specific test file
-pnpm vitest run src/layers/DependencyGraphLive.test.ts
+pnpm vitest run __test__/layers/DependencyGraphLive.test.ts
 ```
 
 ## TypeScript


### PR DESCRIPTION
## Summary

- Fix stale test path in `CONTRIBUTING.md`: example command referenced `src/layers/DependencyGraphLive.test.ts` but tests live under `__test__/layers/` (as documented in CLAUDE.md and verified against the actual repository layout). The path `src/layers/DependencyGraphLive.test.ts` does not exist.

## Test plan

- [ ] Confirm `__test__/layers/DependencyGraphLive.test.ts` exists in the repo (it does)
- [ ] Run `pnpm vitest run __test__/layers/DependencyGraphLive.test.ts` to verify the corrected command works

Filed automatically by daily Routine. Close if not wanted — no follow-up needed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01W8PgVRsP6PeVfLX7rxo3Au)_