### PR TITLE
docs: daily routine improvements 2026-05-21

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,7 +82,7 @@ pnpm run test:watch
 pnpm run test:coverage
 
 # Run a specific test file
-pnpm vitest run src/layers/DependencyGraphLive.test.ts
+pnpm vitest run __test__/layers/DependencyGraphLive.test.ts
 ```
 
 ## TypeScript

--- a/docs/03-dependency-analysis.md
+++ b/docs/03-dependency-analysis.md
@@ -16,7 +16,7 @@ workspaces-effect builds a directed graph of inter-workspace dependencies. You c
 
 The `DependencyGraph` service reads every workspace `package.json` and builds a graph of edges between workspace packages. External npm dependencies are skipped.
 
-Edges come from `dependencies`, `devDependencies` and `peerDependencies`. If package A lists package B in any of those maps and package B is itself a workspace package, the graph holds an edge from A to B.
+Edges come from `dependencies` and `devDependencies`. If package A lists package B in either of those maps and package B is itself a workspace package, the graph holds an edge from A to B.
 
 ```typescript
 import { Effect } from "effect";

--- a/docs/08-services-reference.md
+++ b/docs/08-services-reference.md
@@ -122,7 +122,7 @@ const importers = yield* discovery.importerMap();
 
 ## DependencyGraph
 
-A directed graph of inter-workspace dependencies. Edges come from `dependencies`, `devDependencies` and `peerDependencies`; external npm packages are not vertices.
+A directed graph of inter-workspace dependencies. Edges come from `dependencies` and `devDependencies`; external npm packages are not vertices.
 
 The graph is built once at layer construction time from the workspace package list. Every query is an in-memory lookup.
 


### PR DESCRIPTION
## Summary

Three small, verifiable corrections to user-facing documentation found during the daily routine audit:

- **`CONTRIBUTING.md`**: Fix stale single-test example — path was `src/layers/DependencyGraphLive.test.ts` but tests were relocated to `__test__/layers/` during the test restructuring commit (`7841a2a`). The correct path is `__test__/layers/DependencyGraphLive.test.ts`.
- **`docs/03-dependency-analysis.md`**: Remove incorrect claim that `peerDependencies` are included in graph edges. `DependencyGraphLive` only reads `dependencies` and `devDependencies` when building edges (see `src/layers/DependencyGraphLive.ts` lines 62–64).
- **`docs/08-services-reference.md`**: Same correction in the `DependencyGraph` service entry — `peerDependencies` is not included in graph edges.

## Verification

```bash
# Confirm actual edge-building logic:
grep -n "peerDependencies\|devDependencies\|dependencies" src/layers/DependencyGraphLive.ts
# Lines 60-64: only dependencies + devDependencies

# Confirm correct test path:
ls __test__/layers/DependencyGraphLive.test.ts  # exists
ls src/layers/DependencyGraphLive.test.ts        # does not exist
```

Filed automatically by daily Routine. Close if not wanted — no follow-up needed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01H6JZtGwxXEHZiiioGAwfRk)_