### PR TITLE
docs: daily routine improvements 2026-05-22

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,7 +82,7 @@ pnpm run test:watch
 pnpm run test:coverage
 
 # Run a specific test file
-pnpm vitest run src/layers/DependencyGraphLive.test.ts
+pnpm vitest run __test__/layers/DependencyGraphLive.test.ts
 ```
 
 ## TypeScript

--- a/docs/03-dependency-analysis.md
+++ b/docs/03-dependency-analysis.md
@@ -16,7 +16,7 @@ workspaces-effect builds a directed graph of inter-workspace dependencies. You c
 
 The `DependencyGraph` service reads every workspace `package.json` and builds a graph of edges between workspace packages. External npm dependencies are skipped.
 
-Edges come from `dependencies`, `devDependencies` and `peerDependencies`. If package A lists package B in any of those maps and package B is itself a workspace package, the graph holds an edge from A to B.
+Edges come from `dependencies` and `devDependencies`. If package A lists package B in either of those maps and package B is itself a workspace package, the graph holds an edge from A to B. `peerDependencies` and `optionalDependencies` are not included.
 
 ```typescript
 import { Effect } from "effect";

--- a/docs/09-troubleshooting.md
+++ b/docs/09-troubleshooting.md
@@ -359,7 +359,7 @@ program.pipe(
 );
 ```
 
-1. For change detection, switch to `WorkspacesFullLive`:
+2. For change detection, switch to `WorkspacesFullLive`:
 
 ```typescript
 program.pipe(


### PR DESCRIPTION
## Summary

Three small, high-confidence fixes to user-facing documentation found during today's automated audit:

- **`CONTRIBUTING.md`** — Fix stale test path in the "Run a specific test file" example. Tests were moved from `src/layers/` to `__test__/layers/` in the test-reorganization commit; the example still pointed to the old location (`src/layers/DependencyGraphLive.test.ts` → `__test__/layers/DependencyGraphLive.test.ts`).

- **`docs/09-troubleshooting.md`** — Fix duplicate step `1.` in the "Platform layer missing" section. The second solution was numbered `1.` instead of `2.`, breaking the ordered list.

- **`docs/03-dependency-analysis.md`** — Correct the description of which dependency types produce graph edges. The doc said "Edges come from `dependencies`, `devDependencies` and `peerDependencies`" but `DependencyGraphLive.ts` only spreads `pkg.dependencies` and `pkg.devDependencies` — `peerDependencies` and `optionalDependencies` are not included.

## Test plan

- [ ] Verify the corrected test path (`__test__/layers/DependencyGraphLive.test.ts`) exists in the repo
- [ ] Read the "Platform layer missing" section to confirm `1.` / `2.` ordering is now correct
- [ ] Confirm `DependencyGraphLive.ts` only uses `dependencies` and `devDependencies` (not `peerDependencies`)

Filed automatically by daily Routine. Close if not wanted — no follow-up needed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WyhBwV4tFNT5D4BQR7VdBi)_