### PR TITLE
docs: daily routine improvements 2026-05-23

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,7 +82,7 @@ pnpm run test:watch
 pnpm run test:coverage
 
 # Run a specific test file
-pnpm vitest run src/layers/DependencyGraphLive.test.ts
+pnpm vitest run __test__/layers/DependencyGraphLive.test.ts
 ```
 
 ## TypeScript

--- a/docs/01-getting-started.md
+++ b/docs/01-getting-started.md
@@ -190,19 +190,18 @@ Behavior matrix:
 
 ### getWorkspacePackagesSync
 
-Reads workspace patterns from `pnpm-workspace.yaml` or `package.json`, resolves each pattern to a directory, and returns `{ name, path }` for every match. Returns `null` if the root directory does not exist.
+Reads workspace patterns from `pnpm-workspace.yaml` or `package.json`, resolves each pattern to a directory, and returns a `WorkspacePackage` for each match. Throws if the root directory does not exist or if the root `package.json` is missing `name` or `version`.
 
-The Effect-based `listPackages()` includes the root workspace; this function does **not**. It returns only packages matched by workspace patterns.
+Like `listPackages()`, it includes the root workspace as the first entry.
 
 ```typescript
 const root = findWorkspaceRootSync();
 if (root) {
   const packages = getWorkspacePackagesSync(root);
-  if (packages) {
-    for (const pkg of packages) {
-      console.log(`${pkg.name} at ${pkg.path}`);
-      // example output (varies by repo): "@myorg/utils at /workspace/packages/utils"
-    }
+  for (const pkg of packages) {
+    if (pkg.isRootWorkspace) continue;
+    console.log(`${pkg.name} at ${pkg.path}`);
+    // example output (varies by repo): "@myorg/utils at /workspace/packages/utils"
   }
 }
 ```
@@ -234,8 +233,8 @@ export default {
 | | Effect API | Sync API |
 | --- | --- | --- |
 | **Import** | services + layers | standalone functions |
-| **Error handling** | typed `TaggedError` values | returns `null` on failure |
-| **Root package** | `listPackages()` includes root | `getWorkspacePackagesSync` excludes root |
+| **Error handling** | typed `TaggedError` values | throws `Error` on root failures; silently skips unreadable child packages |
+| **Root package** | `listPackages()` includes root | `getWorkspacePackagesSync` includes root as first entry |
 | **Caching** | per-layer request caching | no caching (re-reads on each call) |
 | **Platform** | `@effect/platform` (Node, Bun) | `node:fs` and `node:path` directly |
 | **Observability** | spans + structured logging | none |


### PR DESCRIPTION
## Summary

- **CONTRIBUTING.md**: Fix stale test file path — example used `src/layers/DependencyGraphLive.test.ts` but tests live in `__test__/layers/`
- **docs/01-getting-started.md**: Correct `getWorkspacePackagesSync` documentation — the function throws on a missing root directory (does not return `null`), includes the root workspace as its first entry (same as `listPackages()`), the example had a spurious `if (packages)` null-guard, and the comparison table had both the error-handling and root-package rows wrong

Related prior issues already tracking the same class of error in design docs: #67, #100

Filed automatically by daily Routine. Close if not wanted — no follow-up needed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qz66EmTf6jCzsycVMG55nW)_