### PR TITLE
feat(discovery): add WorkspaceDiscovery.refresh to clear the package cache

### DIFF
--- a/.changeset/workspace-discovery-refresh.md
+++ b/.changeset/workspace-discovery-refresh.md
@@ -1,0 +1,7 @@
+---
+"workspaces-effect": minor
+---
+
+## Features 
+
+Add `WorkspaceDiscovery.refresh()` to discard the per-root package cache so the next `listPackages` (and `getPackage` / `importerMap`) re-reads each `package.json` from disk. Use it after mutating package files mid-process — e.g. running `changeset version` and then reading the bumped versions back — which previously returned the pre-mutation snapshot from the layer-lifetime cache.

--- a/.claude/design/architecture.md
+++ b/.claude/design/architecture.md
@@ -5,8 +5,8 @@ category: architecture
 status: current
 completeness: 100
 created: 2026-03-12
-updated: 2026-05-02
-last-synced: 2026-05-02
+updated: 2026-05-23
+last-synced: 2026-05-23
 related:
   - phase2-dependency-graph.md
   - phase3-change-detection.md
@@ -42,7 +42,7 @@ platform layers (Node.js or Bun) at the edge.
 
 ## Current State
 
-All phases complete. 386 tests passing (250 unit + 136 integration), all
+All phases complete. 432 tests passing (290 unit + 142 integration), all
 typechecking. Full observability (spans + structured logging) across all
 services.
 
@@ -116,6 +116,13 @@ services.
   similarly defers `WorkspaceDiscoveryError` from the default-root walk to
   the first method call that omits an explicit `cwd` argument. The Layer E
   channels for both layers narrow to `never`.
+- **Cache invalidation API (2026-05-23)**: `WorkspaceDiscovery.refresh()`
+  added -- `Effect.Effect<void>` that clears the per-resolved-root package
+  cache in `WorkspaceDiscoveryLive` so the next `listPackages` / `getPackage` /
+  `importerMap` call re-reads each `package.json` from disk. The resolved-root
+  memo (the `Effect.cached` default-root lookup) is left intact. Use after a
+  mid-process mutation of package files (e.g. `changeset version` followed by
+  reading bumped versions), which the layer-lifetime cache would otherwise mask.
 
 ## Design Goals
 
@@ -158,6 +165,14 @@ WorkspaceDiscovery methods:
   by `relativePath`. Built from `listPackages()` and inherits its caching.
   Supports lockfile importer-to-package mapping use cases. `cwd` semantics
   match `listPackages`.
+- `refresh()` -- `Effect.Effect<void>`. Discards the per-root package cache so
+  the next `listPackages` / `getPackage` / `importerMap` call re-reads every
+  `package.json` from disk. The resolved-root memo is intentionally left intact
+  (the root does not move when package contents change), so the next call pays
+  only the package re-scan, not the root walk. Use after mutating package files
+  mid-process -- e.g. running `changeset version` then reading the bumped
+  versions back, which would otherwise return the pre-mutation snapshot from the
+  layer-lifetime cache.
 
 ### Group 2: Package Analysis
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,8 +5,9 @@ tooling. Supports npm, pnpm, yarn Berry, and Bun workspaces.
 
 ## Status
 
-All phases complete plus WorkspacePackage enrichment (Issue #12). 386 tests
-passing (250 unit + 136 integration). Full observability (spans + structured
+All phases complete plus WorkspacePackage enrichment (Issue #12). 432 tests
+passing (290 unit + 142 integration). Full
+observability (spans + structured
 logging at Debug level) across all services -- library is silent under
 Effect's default logger; consumers opt in via
 `Logger.withMinimumLogLevel(LogLevel.Debug)`. See README "Observability"
@@ -20,7 +21,12 @@ computed getters (isRootWorkspace, isPublic, scope, unscopedName,
 allDependencies), instance methods + static
 dual-API functions, DependencyDiff, readPackageJson utility.
 ResolvedPackage has optional relativePath field for workspace-aware resolution.
-WorkspaceDiscovery.importerMap() added. listPackages() now includes root
+WorkspaceDiscovery.importerMap() added. WorkspaceDiscovery.refresh() added
+(branch feat/refresh-api): clears the per-resolved-root package cache so the
+next listPackages/getPackage/importerMap re-reads each package.json from disk;
+the resolved-root memo is preserved. See
+`.claude/design/architecture.md` "Cache invalidation API (2026-05-23)".
+listPackages() now includes root
 workspace (breaking change). PnpmExtension.catalogs accepts union type for
 pnpm v9+ format (catalogs defined in pnpm-workspace.yaml in v10).
 PublishConfig is a Schema.Class with `tag` and `linkDirectory` fields

--- a/__test__/layers/WorkspaceDiscoveryLive.test.ts
+++ b/__test__/layers/WorkspaceDiscoveryLive.test.ts
@@ -965,4 +965,49 @@ describe("WorkspaceDiscoveryLive", () => {
 			expect(result).toHaveLength(2);
 		});
 	});
+
+	describe("refresh", () => {
+		it("re-reads package.json versions after the cache is invalidated", async () => {
+			const root = "/projects/monorepo";
+			const pkgJsonPath = `${root}/packages/pkg-a/package.json`;
+			// Mutable so the test can rewrite a package.json mid-run, the way
+			// `changeset version` rewrites versions between two discovery reads.
+			const files: Record<string, string | true> = {
+				[`${root}/pnpm-workspace.yaml`]: "packages:\n  - 'packages/*'",
+				[`${root}/package.json`]: JSON.stringify({ name: "my-monorepo", version: "0.0.0", private: true }),
+				[pkgJsonPath]: JSON.stringify({ name: "@scope/pkg-a", version: "1.0.0" }),
+			};
+			const layer = testLayer(root, files, { [`${root}/packages`]: ["pkg-a"] });
+
+			const versionOf = (pkgs: ReadonlyArray<{ name: string; version: string }>) =>
+				pkgs.find((p) => p.name === "@scope/pkg-a")?.version;
+
+			const result = await Effect.runPromise(
+				Effect.gen(function* () {
+					const discovery = yield* WorkspaceDiscovery;
+
+					const first = versionOf(yield* discovery.listPackages());
+
+					// Bump the version on disk after the first read populated the cache.
+					yield* Effect.sync(() => {
+						files[pkgJsonPath] = JSON.stringify({ name: "@scope/pkg-a", version: "1.0.1" });
+					});
+
+					// Without invalidation, the cached pre-bump snapshot is returned.
+					const cached = versionOf(yield* discovery.listPackages());
+
+					yield* discovery.refresh();
+
+					// After refresh, the next read picks up the on-disk bump.
+					const refreshed = versionOf(yield* discovery.listPackages());
+
+					return { first, cached, refreshed };
+				}).pipe(Effect.provide(layer)),
+			);
+
+			expect(result.first).toBe("1.0.0");
+			expect(result.cached).toBe("1.0.0");
+			expect(result.refreshed).toBe("1.0.1");
+		});
+	});
 });

--- a/docs/02-workspace-package.md
+++ b/docs/02-workspace-package.md
@@ -13,6 +13,7 @@
 - [Reading package.json](#reading-packagejson)
 - [Importer map](#importer-map)
 - [Root package in listPackages](#root-package-in-listpackages)
+- [Refreshing after mutation](#refreshing-after-mutation)
 
 ## Fields
 
@@ -307,3 +308,28 @@ const program = Effect.gen(function* () {
   const childPackages = all.filter((pkg) => !pkg.isRootWorkspace);
 });
 ```
+
+## Refreshing after mutation
+
+`listPackages()` memoizes its result per resolved workspace root for the lifetime of the layer. That cache is correct for a static tree, but a process that mutates `package.json` files mid-run will keep seeing the pre-mutation snapshot. A common case is running `changeset version` to bump versions, then reading the new versions back from the same layer.
+
+`WorkspaceDiscovery.refresh()` discards the cached package list. The next `listPackages()` — and `getPackage()` / `importerMap()`, which build on it — re-reads every `package.json` from disk. The resolved workspace root is preserved, since the root does not move when package contents change, so the next call pays only for the package re-scan, not the root walk:
+
+```typescript
+const program = Effect.gen(function* () {
+  const discovery = yield* WorkspaceDiscovery;
+
+  // Snapshot taken and cached on first call
+  const before = yield* discovery.getPackage("@myorg/app");
+
+  // ...something mutates packages/app/package.json on disk
+  // (for example, `changeset version` bumps it)
+
+  yield* discovery.refresh();
+
+  // Re-read from disk; reflects the new version
+  const after = yield* discovery.getPackage("@myorg/app");
+});
+```
+
+`refresh()` returns `Effect<void>` and never fails; the re-scan itself runs on the next discovery call and surfaces its errors there.

--- a/docs/08-services-reference.md
+++ b/docs/08-services-reference.md
@@ -111,11 +111,21 @@ Returns a map keyed by workspace-relative directory path. Useful for cross-refer
 
 - **Returns:** `Effect<ReadonlyMap<string, WorkspacePackage>, WorkspaceDiscoveryError>`
 
+#### `refresh()`
+
+Discards the cached package list so the next `listPackages()` (and `getPackage()` / `importerMap()`, which build on it) re-reads every `package.json` from disk. The resolved workspace root is kept — the root does not move when package contents change — so the next call pays only for the package re-scan, not the root walk. Use it after a process mutates `package.json` files mid-run, such as running `changeset version` and then reading the bumped versions back.
+
+- **Returns:** `Effect<void>`
+
 ```typescript
 const discovery = yield* WorkspaceDiscovery;
 const packages = yield* discovery.listPackages();
 const core = yield* discovery.getPackage("@myorg/core");
 const importers = yield* discovery.importerMap();
+
+// After mutating package.json files on disk:
+yield* discovery.refresh();
+const updated = yield* discovery.listPackages(); // re-read from disk
 ```
 
 ---

--- a/src/layers/WorkspaceDiscoveryLive.ts
+++ b/src/layers/WorkspaceDiscoveryLive.ts
@@ -493,6 +493,14 @@ export const WorkspaceDiscoveryLive: Layer.Layer<
 						attributes: { "workspace.package": name },
 					}),
 				),
+
+			refresh: () =>
+				Effect.sync(() => {
+					// Drop every cached root so the next discovery re-reads each
+					// package.json. The resolved-root memo is intentionally left
+					// intact — the root does not move when package contents change.
+					cache.clear();
+				}).pipe(Effect.withSpan("WorkspaceDiscovery.refresh")),
 		};
 	}),
 );

--- a/src/services/WorkspaceDiscovery.ts
+++ b/src/services/WorkspaceDiscovery.ts
@@ -101,5 +101,27 @@ export class WorkspaceDiscovery extends Context.Tag("@spencerbeggs/workspaces-ef
 		readonly importerMap: (
 			cwd?: string,
 		) => Effect.Effect<ReadonlyMap<string, WorkspacePackage>, WorkspaceDiscoveryError>;
+
+		/**
+		 * Discard cached discovery results so the next {@link listPackages}
+		 * (and {@link getPackage} / {@link importerMap}, which build on it)
+		 * re-reads every `package.json` from disk.
+		 *
+		 * @remarks
+		 * `listPackages` memoizes its result per resolved workspace root for the
+		 * lifetime of the layer. That cache is correct for a static tree, but a
+		 * process that mutates `package.json` mid-run — for example running
+		 * `changeset version` to bump versions and then reading the new versions
+		 * back — would otherwise observe the pre-mutation snapshot. Call
+		 * `refresh` after such a mutation to force a re-scan.
+		 *
+		 * The resolved workspace root itself is not discarded (the root does not
+		 * move when package contents change), so the next call pays only the
+		 * package re-scan, not the root walk. `refresh` clears the cache for
+		 * every resolved root.
+		 *
+		 * @returns An Effect that clears the cache and succeeds with `void`.
+		 */
+		readonly refresh: () => Effect.Effect<void>;
 	}
 >() {}


### PR DESCRIPTION
## Summary

Adds `WorkspaceDiscovery.refresh(): Effect<void>` — a new public method that discards the per-resolved-root package cache so the next `listPackages` / `getPackage` / `importerMap` re-reads each `package.json` from disk. The resolved-root memo is intentionally preserved.

**Use case:** after mutating package files mid-process — e.g. running `changeset version` and then reading the bumped versions back — which previously returned the pre-mutation snapshot from the layer-lifetime cache.

## Changes

- `src/services/WorkspaceDiscovery.ts` — `refresh()` added to the service interface
- `src/layers/WorkspaceDiscoveryLive.ts` — implementation (`cache.clear()`, spanned `WorkspaceDiscovery.refresh`)
- `__test__/layers/WorkspaceDiscoveryLive.test.ts` — coverage for the refresh behavior
- Docs: `docs/08-services-reference.md`, `docs/02-workspace-package.md`, `.claude/design/architecture.md`, `CLAUDE.md` (test-count metric refreshed to 432)

## Release

Changeset: **`minor`** for `workspaces-effect` — additive, non-breaking new API on a 1.x package.

## Verification

- `pnpm run test` → **432 passing** (290 unit + 142 integration)

Signed-off-by: C. Spencer Beggs <spencer@beggs.codes>
