### PR TITLE
fix: make worktree snapshots re-read manifests changed after discovery cached them

### DIFF
--- a/.changeset/stale-worktree-snapshot.md
+++ b/.changeset/stale-worktree-snapshot.md
@@ -1,0 +1,7 @@
+---
+"workspaces-effect": patch
+---
+
+## Bug Fixes
+
+`PointInTimeWorkspace.worktree()` now discards the `WorkspaceDiscovery` cache before reading, so a snapshot taken after `package.json` files changed on disk reflects the live manifests instead of the ones cached at the first discovery call. Previously a long-lived layer (one shared discovery instance) served the pre-change manifests, making a worktree snapshot compare equal to its base ref and silently producing an empty dependency diff downstream.

--- a/__test__/layers/PointInTimeWorkspaceLive.test.ts
+++ b/__test__/layers/PointInTimeWorkspaceLive.test.ts
@@ -267,6 +267,58 @@ describe("relativePath producer parity", () => {
 	});
 });
 
+describe("worktree freshness", () => {
+	let freshRoot: string;
+
+	beforeAll(() => {
+		freshRoot = mkdtempSync(join(tmpdir(), "pit-fresh-"));
+		writeFileSync(join(freshRoot, "package.json"), JSON.stringify({ name: "fresh-root", version: "0.0.0" }));
+		writeFileSync(join(freshRoot, "pnpm-workspace.yaml"), `packages:\n  - packages/*\n`);
+		mkdirSync(join(freshRoot, "packages", "a"), { recursive: true });
+		writeFileSync(
+			join(freshRoot, "packages", "a", "package.json"),
+			JSON.stringify({ name: "@fresh/a", version: "1.0.0", dependencies: { "std-env": "^4.1.0" } }),
+		);
+		const g = (...args: string[]) => execFileSync("git", args, { cwd: freshRoot, encoding: "utf8" });
+		g("init", "-b", "main");
+		g("add", "-A");
+		g("-c", "user.email=t@t", "-c", "user.name=t", "commit", "-m", "fresh base");
+	});
+	afterAll(() => rmSync(freshRoot, { recursive: true, force: true }));
+
+	it("worktree() reflects manifest edits made after an earlier read of the same layer", async () => {
+		// Regression: WorkspaceDiscoveryLive caches listPackages per root for the
+		// layer lifetime, so a worktree() snapshot taken after files changed used
+		// to serve the manifests from BEFORE the change (the silk-update-action
+		// "DepsRegen: wrote 0 changeset(s)" bug). worktree() means "live state
+		// now" -- it must re-read the working tree on every call.
+		const RootStubF = Layer.succeed(WorkspaceRoot, { find: () => Effect.succeed(freshRoot) } as never);
+		const liveF = PointInTimeWorkspaceLive.pipe(
+			Layer.provide(Layer.mergeAll(RootStubF, WorkspaceDiscoveryLive.pipe(Layer.provide(RootStubF)))),
+			Layer.provide(NodeContext.layer),
+		);
+		const [before, after] = await Effect.runPromise(
+			Effect.gen(function* () {
+				const pit = yield* PointInTimeWorkspace;
+				const first = yield* pit.worktree();
+				// Mutate the manifest on disk between the two reads.
+				writeFileSync(
+					join(freshRoot, "packages", "a", "package.json"),
+					JSON.stringify({ name: "@fresh/a", version: "1.0.0", dependencies: { "std-env": "^4.2.0" } }),
+				);
+				const second = yield* pit.worktree();
+				return [first, second] as const;
+			}).pipe(Effect.provide(liveF)) as Effect.Effect<
+				readonly [WorkspaceStateSnapshot, WorkspaceStateSnapshot],
+				unknown,
+				never
+			>,
+		);
+		expect(Option.getOrNull(before.package("@fresh/a"))?.dependencies["std-env"]).toBe("^4.1.0");
+		expect(Option.getOrNull(after.package("@fresh/a"))?.dependencies["std-env"]).toBe("^4.2.0");
+	});
+});
+
 describe("root-level wildcard parity", () => {
 	let wildcardRoot: string;
 

--- a/src/layers/PointInTimeWorkspaceLive.ts
+++ b/src/layers/PointInTimeWorkspaceLive.ts
@@ -199,6 +199,11 @@ export const PointInTimeWorkspaceLive: PointInTimeWorkspaceLiveLayer = Layer.eff
 		const worktree = (options?: PointInTimeOptions) =>
 			Effect.gen(function* () {
 				const root = yield* resolveRoot(options?.cwd);
+				// A worktree snapshot means "the live state now". WorkspaceDiscovery
+				// caches listPackages per root for the layer lifetime, so a snapshot
+				// taken after manifests changed on disk would otherwise serve the
+				// pre-change manifests (and diff as a no-op against the base ref).
+				yield* discovery.refresh();
 				const pkgs = yield* discovery.listPackages(root);
 				const packages = pkgs.map(
 					(p) =>


### PR DESCRIPTION
## Summary

`PointInTimeWorkspace.worktree()` now calls `WorkspaceDiscovery.refresh()` before listing packages. The discovery layer caches `listPackages` per root for its lifetime, so a worktree snapshot taken after `package.json` edits in the same layer build served the pre-edit manifests and diffed as a no-op against the base ref.

This is the root cause of silk-update-action writing `DepsRegen: wrote 0 changeset(s)` on every consumer run: the action enumerates the workspace (RegularDeps, lockfile compare) before editing manifests, and Effect memoizes `WorkspaceDiscoveryLive` by reference across composition branches, so DepsRegen's internal discovery shared the primed stale cache. Verified end-to-end via a `@dev` dogfood run on silk-router-action (savvy-web/silk-router-action#117 now contains a changeset).

## Testing

- New regression test: `worktree()` reflects manifest edits made after an earlier read of the same layer (RED before the fix, GREEN after)
- Full suite: 517/517 passing

Signed-off-by: C. Spencer Beggs <spencer@beggs.codes>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refreshed workspace information when reading the live worktree, ensuring package manifests and dependency data reflect the latest on-disk changes.
* **Tests**
  * Added regression coverage verifying that successive worktree reads return updated package dependency versions after manifest edits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->